### PR TITLE
0.0.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+rss.js
+rss2.js
+logs.log
+notas.md
+focus.js

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ logs.log
 notas.md
 focus.js
 /notas
+/AGENTS.md
+/gotchas.md
+/changelog.md
+/.cursor
+/.windsurf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ rss2.js
 logs.log
 notas.md
 focus.js
+/notas

--- a/README.es.md
+++ b/README.es.md
@@ -1,3 +1,5 @@
+[English version](README.md)
+
 # 🔴 YouTube Playback Plox
 
 Guarda y retoma automáticamente el progreso de videos en YouTube sin necesidad de iniciar sesión.
@@ -122,3 +124,16 @@ Toda la información se almacena localmente en tu navegador. **No se envía ning
 ## 📄 Licencia
 
 Este proyecto está bajo la licencia MIT. Consulta el archivo [LICENSE](./LICENSE) para más detalles.
+
+## Agradecimientos
+
+- [YouTube Helper API](https://greasyfork.org/es/scripts/549881-youtube-helper-api) - [MIT](https://spdx.org/licenses/MIT.html)
+
+## Nota
+
+Este proyecto no está afiliado con Google o YouTube.
+
+## Traducciones
+
+- [English](README.md)
+- [Spanish](README.es.md)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[Spanish version](README.es.md)
+
 # 🔴 YouTube Playback Plox
 
 Save and resume automatically video playback progress on YouTube without needing to log in.
@@ -123,3 +125,16 @@ All information is stored locally in your browser. **No data is sent to external
 ## 📄 License
 
 This project is under the MIT license. Consult the file [LICENSE](./LICENSE) for more details.
+
+## Shoutouts
+
+- [YouTube Helper API](https://greasyfork.org/es/scripts/549881-youtube-helper-api) - [MIT](https://spdx.org/licenses/MIT.html)
+
+## Notice
+
+This project is not affiliated with Google or YouTube.
+
+## Translations
+
+- [English](README.md)
+- [Spanish](README.es.md)

--- a/YouTube-Helper-API.js
+++ b/YouTube-Helper-API.js
@@ -2,15 +2,162 @@
 // @name            YouTube Helper API
 // @author          ElectroKnight22
 // @namespace       electroknight22_helper_api_namespace
-// @version         0.7.5
+// @version         0.9.4
 // @license         MIT
 // @description     A helper api for YouTube scripts that provides easy and consistent access for commonly needed functions, objects, and values.
 // ==/UserScript==
 
 /*jshint esversion: 11 */
 
-window.youtubeHelperApi = (function () {
-    'use strict';
+'use strict';
+
+// eslint-disable-next-line no-unused-vars
+const youtubeHelperApi = (function () {
+    // --- DEBUG SYSTEM ---
+    const debug = {
+        enabled: false,
+        _level: 1,
+        debugBadgeText: 'YT-Helper-API-Debug',
+
+        set level(val) {
+            const map = { minimal: 0, typical: 1, detailed: 2, all: 3, overkill: 4 };
+
+            let targetLevel = val;
+            if (typeof val === 'string' && val.toLowerCase() in map) {
+                targetLevel = map[val.toLowerCase()];
+            }
+
+            if (typeof targetLevel === 'number' && Object.values(map).includes(targetLevel)) {
+                this._level = targetLevel;
+            } else {
+                console.warn(
+                    `[${this.debugBadgeText}] Invalid level "${val}". Please use 0-4 or: minimal, typical, detailed, all, overkill.`,
+                );
+            }
+        },
+
+        get level() {
+            return this._level;
+        },
+
+        get logMinimal() {
+            return this.enabled && this._level >= 0
+                ? console.log.bind(window.console, `%c[${this.debugBadgeText}][Minimal]`, 'color: #28a745; font-weight: bold;')
+                : () => {};
+        },
+        get logTypical() {
+            return this.enabled && this._level >= 1
+                ? console.log.bind(window.console, `%c[${this.debugBadgeText}][Typical]`, 'color: #007bff; font-weight: bold;')
+                : () => {};
+        },
+        get logDetailed() {
+            return this.enabled && this._level >= 2
+                ? console.log.bind(window.console, `%c[${this.debugBadgeText}][Detailed]`, 'color: #17a2b8; font-weight: bold;')
+                : () => {};
+        },
+        get logAll() {
+            return this.enabled && this._level >= 3
+                ? console.log.bind(window.console, `%c[${this.debugBadgeText}][All]`, 'color: #6c757d; font-weight: bold;')
+                : () => {};
+        },
+        get logOverkill() {
+            return this.enabled && this._level >= 4
+                ? console.log.bind(window.console, `%c[${this.debugBadgeText}][All]`, 'color: #ce00a8ff; font-weight: bold;')
+                : () => {};
+        },
+    };
+    // --- END DEBUG SYSTEM ---
+
+    // --- GM API SHIM ---
+    const gmCapabilities = {
+        isModern: false,
+        isLegacy: false,
+        features: {},
+    };
+
+    (function performGmShim() {
+        const KNOWN_GM_GLOBALS = [
+            'setValue',
+            'getValue',
+            'deleteValue',
+            'listValues',
+            'getResourceText',
+            'getResourceURL',
+            'addStyle',
+            'addElement',
+            'registerMenuCommand',
+            'unregisterMenuCommand',
+            'openInTab',
+            'notification',
+            'setClipboard',
+            'contextMenu',
+            'xmlhttpRequest',
+            'download',
+            'webRequest',
+            'cookie',
+            'saveTab',
+            'getTab',
+            'getTabs',
+            'log',
+            'info',
+            'print',
+        ];
+
+        const realGM = typeof GM !== 'undefined' ? GM : {};
+        const isModernEnv = typeof GM !== 'undefined';
+
+        const checkFeature = (name) => {
+            const legacyName = `GM_${name}`;
+            const legacyExists = typeof window[legacyName] !== 'undefined';
+            const modernExists = isModernEnv && name in realGM;
+
+            return legacyExists || modernExists;
+        };
+
+        gmCapabilities.isModern = isModernEnv;
+
+        gmCapabilities.features = {
+            storage: checkFeature('setValue'),
+            menu: checkFeature('registerMenuCommand'),
+            network: checkFeature('xmlhttpRequest') || (isModernEnv && 'xmlHttpRequest' in realGM),
+            clipboard: checkFeature('setClipboard'),
+            tabs: checkFeature('openInTab'),
+            ui: checkFeature('addStyle'),
+        };
+
+        const GMFallbackAsync = async (...args) => {
+            debug.logAll('GM.* (Async) call shimmed:', args);
+            return undefined;
+        };
+        const GMFallbackSync = (...args) => {
+            debug.logAll('GM_* (Sync) call shimmed:', args);
+            return undefined;
+        };
+
+        const gmProxyHandler = {
+            get: (target, prop, receiver) => {
+                if (Reflect.has(target, prop)) return Reflect.get(target, prop, receiver);
+                if (prop === 'info') return { script: { version: '0.0.0' }, scriptHandler: 'Shim', version: '0.0.0' };
+                return GMFallbackAsync;
+            },
+        };
+
+        try {
+            window.GM = new Proxy(realGM, gmProxyHandler);
+        } catch (error) {
+            console.warn('[YouTube Helper API] Failed to patch window.GM', error);
+        }
+
+        KNOWN_GM_GLOBALS.forEach((name) => {
+            const key = `GM_${name}`;
+            if (typeof window[key] !== 'undefined') {
+                gmCapabilities.isLegacy = true;
+            } else {
+                window[key] = name === 'info' ? { script: { version: '0.0.0' }, scriptHandler: 'Shim' } : GMFallbackSync;
+            }
+        });
+    })();
+    // --- GM API SHIM END ---
 
     const privateEventTarget = new EventTarget();
 
@@ -37,7 +184,71 @@ window.youtubeHelperApi = (function () {
         tiny: { p: 144, label: '144p' },
     });
 
-    const apiProxy = new Proxy(
+
+/**
+ * A Proxy object that provides a safe interface to interact with the YouTube player API.
+ * It handles method calls, checks for API readiness, and provides warnings for undefined methods.
+ * 
+ * @example
+ * // Example usage:
+ * apiProxy.playVideo(); // Calls the underlying YouTube player's playVideo method
+ * apiProxy.pauseVideo(); // Calls pauseVideo if available
+ * 
+ * // Returns undefined and logs a warning if the API isn't ready
+ * const currentTime = apiProxy.getCurrentTime();
+ * 
+ * @type {Proxy<Object, {get: function(target: Object, property: string): function(...*): *}>}
+ * @property {function(): number} getCurrentTime - Returns the current playback time in seconds
+ * @property {function(number): void} seekTo - Seeks to a specified time in the video
+ * @property {function(): void} playVideo - Starts or resumes playback
+ * @property {function(): void} pauseVideo - Pauses the video
+ * @property {function(): Object} getPlayerResponse - Returns the player response object
+ * @property {function(): string} getVideoUrl - Returns the URL of the current video
+ * @property {function(): string} getVideoData - Returns video data including video ID and title
+ * @property {function(): boolean} isMuted - Returns true if the video is muted
+ * @property {function(boolean): void} mute - Mutes or unmutes the video
+ * @property {function(number): void} setVolume - Sets the volume (0-100)
+ * @property {function(): number} getVolume - Gets the current volume (0-100)
+ * @property {function(string, number, string): void} loadVideoById - Loads a video by its ID
+ * @property {function(): string} getPlaylistId - Returns the current playlist ID if any
+ * @property {function(): number} getVideoLoadedFraction - Returns the fraction of the video that has been buffered (0-1)
+ * @property {function(): string} getPlaybackQuality - Returns the current playback quality
+ * @property {function(string): void} setPlaybackQuality - Sets the playback quality
+ * @property {function(): string[]} getAvailableQualityLevels - Returns available quality levels
+ */
+const apiProxy = new Proxy(
+    {},
+    {
+        get(target, property) {
+            return (...args) => {
+                if (!appState.player.api) {
+                    console.warn(`YouTube player API not ready.`);
+                    return;
+                }
+                if (typeof appState.player.api[property] === 'function') {
+                    return appState.player.api[property](...args);
+                } else {
+                    console.warn(`Method "${property}" does not exist on the YouTube player API.`);
+                }
+            };
+        },
+    },
+);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+   /*  const apiProxy = new Proxy(
         {},
         {
             get(target, property) {
@@ -51,7 +262,7 @@ window.youtubeHelperApi = (function () {
                 };
             },
         },
-    );
+    ); */
 
     const _readOnlyHandler = {
         get(target, property) {
@@ -92,6 +303,7 @@ window.youtubeHelperApi = (function () {
             thumbnails: [],
             playingLanguage: null,
             originalLanguage: null,
+            isAutoDubbed: false,
             realCurrentProgress: 0,
             isTimeSpecified: false,
             isInPlaylist: false,
@@ -178,18 +390,21 @@ window.youtubeHelperApi = (function () {
                 listValues: async () => Object.keys(localStorage),
             },
         };
-        const gmType = (() => {
-            if (typeof GM !== 'undefined') {
+        const gmStorageType = (() => {
+            if (!gmCapabilities.features.storage) {
+                return 'none';
+            }
+            if (gmCapabilities.isModern) {
                 return 'modern';
             }
-            if (typeof GM_info !== 'undefined') {
+            if (gmCapabilities.isLegacy) {
                 return 'old';
             }
             return 'none';
         })();
         return {
-            ...STORAGE_IMPLEMENTATIONS[gmType],
-            gmType,
+            ...STORAGE_IMPLEMENTATIONS[gmStorageType],
+            gmType: gmStorageType,
         };
     })();
 
@@ -211,6 +426,7 @@ window.youtubeHelperApi = (function () {
     }
 
     async function saveToStorage(storageKey, data) {
+        debug.logDetailed(`Saving to storage: ${storageKey}`);
         const dataToStore = {
             data: data,
             metadata: {
@@ -226,6 +442,7 @@ window.youtubeHelperApi = (function () {
     }
 
     async function loadFromStorage(storageKey, defaultData) {
+        debug.logDetailed(`Loading from storage: ${storageKey}`);
         try {
             const syncedWrapper = await _getSyncedStorageData(storageKey);
             const storedData = syncedWrapper && !syncedWrapper.metadata ? syncedWrapper : syncedWrapper?.data ?? {};
@@ -237,6 +454,7 @@ window.youtubeHelperApi = (function () {
     }
 
     async function loadAndCleanFromStorage(storageKey, defaultData) {
+        debug.logDetailed(`Loading and cleaning storage: ${storageKey}`);
         try {
             const combinedData = await loadFromStorage(storageKey, defaultData);
             const cleanedData = Object.keys(defaultData).reduce((accumulator, currentKey) => {
@@ -251,6 +469,7 @@ window.youtubeHelperApi = (function () {
     }
 
     async function deleteFromStorage(storageKey) {
+        debug.logDetailed(`Deleting from storage: ${storageKey}`);
         try {
             if (storageApi.gmType !== 'none') await storageApi.deleteValue(storageKey);
             localStorage.removeItem(storageKey);
@@ -274,7 +493,7 @@ window.youtubeHelperApi = (function () {
     }
 
     function fallbackGetPlayerApi() {
-        console.log('Trying to get player api using fallback...');
+        debug.logAll('Fallback Player API Check');
         if (appState.page.isIframe || appState.page.isMobile) return document.querySelector(SELECTORS.watchPlayer);
         if (window.location.pathname.startsWith('/shorts')) return document.querySelector(SELECTORS.shortsPlayer);
         if (window.location.pathname.startsWith('/watch')) return document.querySelector(SELECTORS.watchPlayer);
@@ -287,7 +506,7 @@ window.youtubeHelperApi = (function () {
                 if (!appState?.player?.api) return resolve(null);
                 const playerResponse = apiProxy.getPlayerResponse();
                 if (playerResponse) return resolve(playerResponse);
-                console.warn('Player API exists, but playerResponse is missing. Waiting for metadata event...');
+                debug.logTypical('Player API ready, but missing playerResponse. Waiting for metadata...');
                 appState.player.videoElement.addEventListener('loadedmetadata', check, { once: true });
             }
             check();
@@ -321,18 +540,23 @@ window.youtubeHelperApi = (function () {
     }
 
     function setPlaybackResolution(targetResolution, ignoreAvailable = false, usePremium = true) {
+        debug.logTypical(`Attempting to set resolution: ${targetResolution} (Premium: ${usePremium}, Force: ${ignoreAvailable})`);
         try {
             if (!appState.player.api?.getAvailableQualityData) return;
             if (!usePremium && ignoreAvailable) {
                 apiProxy.setPlaybackQualityRange(targetResolution);
             } else {
                 const optimalQuality = getOptimalResolution(targetResolution, usePremium);
-                if (optimalQuality)
+                if (optimalQuality) {
+                    debug.logDetailed('Found optimal quality format:', optimalQuality);
                     apiProxy.setPlaybackQualityRange(
                         optimalQuality.quality,
                         optimalQuality.quality,
                         usePremium ? optimalQuality.formatId : null,
                     );
+                } else {
+                    debug.logTypical('Could not find a matching quality for:', targetResolution);
+                }
             }
         } catch (error) {
             console.error('Error when setting resolution:', error);
@@ -351,7 +575,10 @@ window.youtubeHelperApi = (function () {
 
         Object.assign(eventDetail, stateSnapshot);
 
-        if (!eventDetail.video.id) return;
+        if (!eventDetail.video.id) return console.warn('Video ID not found in state snapshot.');
+
+        debug.logMinimal(`Video Ready. Title: "${stateSnapshot.video.title}". Id: "${stateSnapshot.video.id}"`);
+        debug.logDetailed('Dispatching Ready Event with state:', stateSnapshot);
 
         const event = new CustomEvent('yt-helper-api-ready', {
             detail: Object.freeze(eventDetail),
@@ -361,12 +588,15 @@ window.youtubeHelperApi = (function () {
     }
 
     function _notifyAdDetected() {
-        if (appState.player.isPlayingAds)
+        debug.logDetailed(`Ad State Change: Is Playing Ad? ${appState.player.isPlayingAds}`);
+        if (appState.player.isPlayingAds) {
+            debug.logTypical('Ad detected!');
             privateEventTarget.dispatchEvent(
                 new CustomEvent('yt-helper-api-ad-detected', {
                     detail: Object.freeze({ isPlayingAds: appState.player.isPlayingAds }),
                 }),
             );
+        }
     }
 
     function checkIsIframe() {
@@ -378,15 +608,47 @@ window.youtubeHelperApi = (function () {
         appState.player.playerObject = event?.target?.playerContainer_?.children[0] ?? fallbackGetPlayerApi();
         appState.player.videoElement = appState.player.playerObject?.querySelector(SELECTORS.videoElement);
         appState.player.response = await getPlayerResponseWhenReady();
+        debug.logDetailed('Player state updated', appState.player);
     }
 
     function updateVideoLanguage() {
         if (!appState.player.api) return;
-        const availableTracks = apiProxy.getAvailableAudioTracks();
+
+        const availableTracks = apiProxy.getAvailableAudioTracks() ?? [];
         const playingAudioTrack = apiProxy.getAudioTrack();
-        const originalAudioTrack = availableTracks?.find((track) => track.S === true);
+
+        const getTrackDetails = (track) => Object.values(track ?? {});
+        const originalAudioTrack = availableTracks?.find((track) => {
+            if (!track || typeof track !== 'object') return false;
+            const values = getTrackDetails(track);
+            const hasMetadata = values.some((val) => val && typeof val === 'object' && 'isAutoDubbed' in val);
+            const hasTrueFlag = values.some((val) => val === true);
+            return hasMetadata && hasTrueFlag;
+        });
+
+        const isAutoDubbed = getTrackDetails(playingAudioTrack).some((val) => val?.isAutoDubbed === true);
+
+        if (appState.video.playingLanguage === playingAudioTrack) return;
+        const isInit =
+            (appState.video.playingLanguage === null && `${playingAudioTrack}` !== 'Default') ||
+            `${appState.video.playingLanguage}` === 'Default';
+
+        debug.logTypical(`Language updated: ${playingAudioTrack} (Auto-Dubbed: ${isAutoDubbed})`);
+
         appState.video.playingLanguage = playingAudioTrack;
         appState.video.originalLanguage = originalAudioTrack;
+        appState.video.isAutoDubbed = isAutoDubbed;
+
+        privateEventTarget.dispatchEvent(
+            new CustomEvent('yt-helper-api-playback-language-updated', {
+                detail: Object.freeze({
+                    isInit,
+                    playingLanguage: appState.video.playingLanguage,
+                    originalLanguage: appState.video.originalLanguage,
+                    isAutoDubbed: appState.video.isAutoDubbed,
+                }),
+            }),
+        );
     }
 
     function updateVideoState() {
@@ -409,24 +671,31 @@ window.youtubeHelperApi = (function () {
         appState.video.isLiveOrVodContent = playerResponseObject?.videoDetails?.isLiveContent;
         appState.video.wasStreamedOrPremiered = !!playerResponseObject?.microformat?.playerMicroformatRenderer?.liveBroadcastDetails;
         appState.video.isFamilySafe = playerResponseObject?.microformat?.playerMicroformatRenderer?.isFamilySafe;
-        appState.video.thumbnails = playerResponseObject?.microformat?.playerMicroformatRenderer?.thumbnail?.thumbnails;
+        appState.video.thumbnails =
+            playerResponseObject?.microformat?.playerMicroformatRenderer?.thumbnail?.thumbnails ??
+            playerResponseObject?.videoDetails?.thumbnail?.thumbnails;
         appState.video.realCurrentProgress = apiProxy.getCurrentTime();
         appState.video.isTimeSpecified = searchParams.has('t');
         appState.video.playlistId = apiProxy.getPlaylistId();
+
+        debug.logDetailed('Video state updated', appState.video);
     }
 
     function updateFullscreenState() {
         appState.player.isFullscreen = !!document.fullscreenElement;
+        debug.logDetailed(`Fullscreen: ${appState.player.isFullscreen}`);
     }
 
     function updateTheaterState(event) {
         appState.player.isTheater = !!event?.detail?.enabled;
+        debug.logDetailed(`Theater Mode: ${appState.player.isTheater}`);
     }
 
     function updateChatStateUpdated(event) {
         appState.chat.iFrame = event?.target ?? document.querySelector(SELECTORS.chatFrame);
         appState.chat.container = appState.chat.iFrame?.parentElement ?? document.querySelector(SELECTORS.chatContainer);
         appState.chat.isCollapsed = event?.detail ?? true;
+        debug.logDetailed('Chat state updated', appState.chat);
         privateEventTarget.dispatchEvent(
             new CustomEvent('yt-helper-api-chat-state-updated', { detail: Object.freeze({ ...appState.chat }) }),
         );
@@ -451,6 +720,7 @@ window.youtubeHelperApi = (function () {
     function fallbackUpdateAdState() {
         if (!appState.player.api) return;
         try {
+            debug.logAll('Fallback Ad State Check');
             const progressState = apiProxy.getProgressState();
             const reportedContentDuration = progressState.duration;
             const realContentDuration = apiProxy.getDuration() ?? -1;
@@ -466,12 +736,14 @@ window.youtubeHelperApi = (function () {
 
     function reloadVideo(targetTime) {
         if (!appState.player.api) return;
+        debug.logTypical(`Reloading video to ${targetTime}s`);
         apiProxy.loadVideoById(appState.video.id, targetTime);
         appState.player.videoElement = appState.player.playerObject?.querySelector(SELECTORS.videoElement);
         trackPlaybackProgress();
     }
 
     function reloadToCurrentProgress() {
+        debug.logDetailed(`Reloading video to current progress`);
         reloadVideo(appState.video.realCurrentProgress);
     }
 
@@ -480,9 +752,11 @@ window.youtubeHelperApi = (function () {
         if (timeUpdateTrackedElements.has(appState.player.videoElement)) return;
         if (!appState.player.videoElement) return;
         const updateProgress = () => {
+            debug.logOverkill(`TimeUpdate: ${appState.player.videoElement.currentTime}`);
             if (!appState.player.isPlayingAds && appState.player.videoElement.currentTime > 0) {
                 appState.video.realCurrentProgress = appState.player.videoElement.currentTime;
             }
+            updateVideoLanguage();
         };
         appState.player.videoElement.addEventListener('timeupdate', updateProgress);
         timeUpdateTrackedElements.set(appState.player.videoElement, true);
@@ -498,36 +772,49 @@ window.youtubeHelperApi = (function () {
     }
 
     let updateLocked = false;
-
     async function _handlePlayerUpdate(event = null) {
         if (updateLocked) return;
+        debug.logAll('Player update triggered. Unlocking...');
         updateLocked = true;
-        const customEvent = new CustomEvent('yt-helper-api-update-started');
-        privateEventTarget.dispatchEvent(customEvent);
-        await updatePlayerState(event);
-        updateAdState();
-        trackAdState();
-        updateVideoState();
-        updateVideoLanguage();
-        trackPlaybackProgress();
-        queueMicrotask(_dispatchHelperApiReadyEvent);
-        updateLocked = false;
+        debug.logDetailed('Player update triggered by:', event?.type || 'manual call');
+        try {
+            const customEvent = new CustomEvent('yt-helper-api-update-started');
+            privateEventTarget.dispatchEvent(customEvent);
+            await updatePlayerState(event);
+            updateAdState();
+            trackAdState();
+            updateVideoState();
+            updateVideoLanguage();
+            trackPlaybackProgress();
+            queueMicrotask(_dispatchHelperApiReadyEvent);
+        } catch (error) {
+            console.error('Error in _handlePlayerUpdate:', error);
+        } finally {
+            debug.logAll('Player update complete. Locking...');
+            updateLocked = false;
+        }
     }
 
     function _handlePageDataUpdate(event) {
         appState.page.type = event.detail?.pageType;
+        debug.logDetailed('Page data updated', appState.page);
     }
 
     function _handlePageTypeChange(event) {
         appState.page.type = event.detail?.newPageSubtype;
+        debug.logDetailed('Page type changed', appState.page);
     }
 
     function _handlePageshowEvent() {
+        debug.logDetailed('Pageshow event triggered');
         const shouldTryEarly =
             window.location.pathname.startsWith('/watch') ||
             window.location.pathname.startsWith('/embed') ||
             window.location.pathname.startsWith('/shorts');
-        if (shouldTryEarly) _handlePlayerUpdate();
+        if (shouldTryEarly) {
+            debug.logDetailed('Trying early player update...');
+            _handlePlayerUpdate();
+        }
     }
 
     function addPageStateListeners() {
@@ -547,6 +834,7 @@ window.youtubeHelperApi = (function () {
     }
 
     function initialize() {
+        debug.logMinimal('Library Initialized. Waiting for player...');
         window.addEventListener('pageshow', _handlePageshowEvent);
         checkIsIframe();
         if (!appState.page.isIframe) {
@@ -583,7 +871,9 @@ window.youtubeHelperApi = (function () {
         listFromStorage,
         reloadVideo,
         reloadToCurrentProgress,
+        gmCapabilities,
         apiProxy,
+        debug,
         eventTarget: privateEventTarget,
     };
 

--- a/YouTube-Helper-API.js
+++ b/YouTube-Helper-API.js
@@ -651,33 +651,80 @@ const apiProxy = new Proxy(
         );
     }
 
+    /**
+     * Actualiza el estado del video con la información más reciente del reproductor de YouTube.
+     * Extrae y formatea los metadatos del video desde el objeto de respuesta del reproductor.
+     * @returns {void}
+     */
     function updateVideoState() {
+        // Verificar si la API del reproductor está disponible
         if (!appState.player.api) return;
+        
+        // Obtener la respuesta actual del reproductor y parámetros de la URL
         const playerResponseObject = appState.player.response;
         const searchParams = new URL(window.location.href).searchParams;
+
+        // --- METADATOS BÁSICOS ---
+        // Información de identificación del video
         appState.video.id = playerResponseObject?.videoDetails?.videoId;
         appState.video.title = playerResponseObject?.videoDetails?.title;
+        
+        // Información del canal
         appState.video.channel = playerResponseObject?.videoDetails?.author;
         appState.video.channelId = playerResponseObject?.videoDetails?.channelId;
+        
+        // Descripción y metadatos de texto
         appState.video.rawDescription = playerResponseObject?.videoDetails?.shortDescription;
+        
+        // --- MANEJO DE FECHAS ---
+        // Fechas en formato crudo (strings)
         appState.video.rawUploadDate = playerResponseObject?.microformat?.playerMicroformatRenderer?.uploadDate;
         appState.video.rawPublishDate = playerResponseObject?.microformat?.playerMicroformatRenderer?.publishDate;
+        
+        // Convertir fechas a objetos Date
         appState.video.uploadDate = appState.video.rawUploadDate ? new Date(appState.video.rawUploadDate) : null;
         appState.video.publishDate = appState.video.rawPublishDate ? new Date(appState.video.rawPublishDate) : null;
+        
+        // --- ESTADÍSTICAS DEL VIDEO ---
+        // Duración en segundos (convertida a entero)
         appState.video.lengthSeconds = parseInt(playerResponseObject?.videoDetails?.lengthSeconds ?? '0', 10);
+        
+        // Contador de vistas (puede no estar disponible en Shorts)
         appState.video.viewCount = parseInt(playerResponseObject?.videoDetails?.viewCount ?? '0', 10);
+        
+        // Contador de me gusta (desde microformatos)
         appState.video.likeCount = parseInt(playerResponseObject?.microformat?.playerMicroformatRenderer?.likeCount ?? '0', 10);
+        
+        // --- ESTADO DE TRANSMISIÓN ---
+        // Verificar si es una transmisión en vivo actual
         appState.video.isCurrentlyLive = apiProxy.getVideoData().isLive;
+        
+        // Verificar si es contenido en vivo o VOD
         appState.video.isLiveOrVodContent = playerResponseObject?.videoDetails?.isLiveContent;
+        
+        // Verificar si fue transmitido en vivo o estrenado
         appState.video.wasStreamedOrPremiered = !!playerResponseObject?.microformat?.playerMicroformatRenderer?.liveBroadcastDetails;
+        
+        // Clasificación de contenido
         appState.video.isFamilySafe = playerResponseObject?.microformat?.playerMicroformatRenderer?.isFamilySafe;
+        
+        // --- MINIATURAS ---
+        // Obtener miniaturas de diferentes fuentes posibles
         appState.video.thumbnails =
             playerResponseObject?.microformat?.playerMicroformatRenderer?.thumbnail?.thumbnails ??
             playerResponseObject?.videoDetails?.thumbnail?.thumbnails;
+        
+        // --- ESTADO DE REPRODUCCIÓN ---
+        // Tiempo actual de reproducción
         appState.video.realCurrentProgress = apiProxy.getCurrentTime();
+        
+        // Verificar si se especificó un tiempo de inicio en la URL (parámetro 't')
         appState.video.isTimeSpecified = searchParams.has('t');
+        
+        // Obtener ID de la lista de reproducción actual
         appState.video.playlistId = apiProxy.getPlaylistId();
 
+        // Registrar cambios en el sistema de depuración
         debug.logDetailed('Video state updated', appState.video);
     }
 

--- a/translations.json
+++ b/translations.json
@@ -719,7 +719,7 @@
             "confirmRemoveFromPlaylist": "¿Estás seguro de que quieres quitar este video de la playlist?",
             "playlistAssociationRemoved": "Asociación de playlist eliminada",
             "loading": "Cargando",
-            "rendered": "renderizados"
+            "rendered": "Renderizados"
         },
         "ca": {
             "settings": "Configuració",

--- a/translations.json
+++ b/translations.json
@@ -386,7 +386,12 @@
             "confirmRemoveFromPlaylist": "Are you sure you want to remove this video from the playlist? It will remain as an individual video.",
             "playlistAssociationRemoved": "Playlist association removed",
             "loading": "Loading",
-            "rendered": "Rendered"
+            "rendered": "Rendered",
+            "previews": "Previews",
+            "migratingData": "Migrating saved data from previous version...",
+            "migratingDataProgress": "Migrating data... {count} entries processed",
+            "migrationComplete": "Migration completed: {migrated} videos successfully migrated",
+            "migrationNoData": "No data found to migrate"
         },
         "en-US": {
             "settings": "Settings",
@@ -497,7 +502,12 @@
             "confirmRemoveFromPlaylist": "Are you sure you want to remove this video from the playlist? It will remain as an individual video.",
             "playlistAssociationRemoved": "Playlist association removed",
             "loading": "Loading",
-            "rendered": "Rendered"
+            "rendered": "Rendered",
+            "previews": "Previews",
+            "migratingData": "Migrating saved data from previous version...",
+            "migratingDataProgress": "Migrating data... {count} entries processed",
+            "migrationComplete": "Migration completed: {migrated} videos successfully migrated",
+            "migrationNoData": "No data found to migrate"
         },
         "es-ES": {
             "settings": "Configuración",
@@ -608,7 +618,12 @@
             "confirmRemoveFromPlaylist": "¿Estás seguro de que quieres quitar este vídeo de la lista de reproducción? Se mantendrá como vídeo individual.",
             "playlistAssociationRemoved": "Asociación de la lista de reproducción eliminada",
             "loading": "Cargando",
-            "rendered": "Renderizados"
+            "rendered": "Renderizados",
+            "previews": "Previsualizaciones",
+            "migratingData": "Migrando datos guardados desde versión anterior...",
+            "migratingDataProgress": "Migrando datos... {count} entradas procesadas",
+            "migrationComplete": "Migración completada: {migrated} videos migrados correctamente",
+            "migrationNoData": "No se encontraron datos para migrar"
         },
         "es-419": {
             "settings": "Configuración",
@@ -719,7 +734,12 @@
             "confirmRemoveFromPlaylist": "¿Estás seguro de que quieres quitar este video de la playlist?",
             "playlistAssociationRemoved": "Asociación de playlist eliminada",
             "loading": "Cargando",
-            "rendered": "Renderizados"
+            "rendered": "Renderizados",
+            "previews": "Previsualizaciones",
+            "migratingData": "Migrando datos guardados desde versión anterior...",
+            "migratingDataProgress": "Migrando datos... {count} entradas procesadas",
+            "migrationComplete": "Migración completada: {migrated} videos migrados correctamente",
+            "migrationNoData": "No se encontraron datos para migrar"
         },
         "ca": {
             "settings": "Configuració",
@@ -830,7 +850,12 @@
             "confirmRemoveFromPlaylist": "Estàs segur que vols treure aquest vídeo de la llista de reproducció? Es mantindrà com a vídeo individual.",
             "playlistAssociationRemoved": "Associació de la llista de reproducció eliminada",
             "loading": "Carregant",
-            "rendered": "Renderitzats"
+            "rendered": "Renderitzats",
+            "previews": "Previsualitzacions",
+            "migratingData": "Migrant dades desades des de versió anterior...",
+            "migratingDataProgress": "Migrant dades... {count} entrades processades",
+            "migrationComplete": "Migració completada: {migrated} vídeos migrats correctament",
+            "migrationNoData": "No s'han trobat dades per migrar"
         },
         "fr": {
             "settings": "Paramètres",
@@ -941,7 +966,12 @@
             "confirmRemoveFromPlaylist": "Êtes-vous sûr de vouloir retirer cette vidéo de la playlist ? Elle restera comme vidéo individuelle.",
             "playlistAssociationRemoved": "Association à la playlist supprimée",
             "loading": "Chargement",
-            "rendered": "Rendus"
+            "rendered": "Rendus",
+            "previews": "Aperçus",
+            "migratingData": "Migration des données enregistrées depuis la version précédente...",
+            "migratingDataProgress": "Migration des données... {count} éléments traités",
+            "migrationComplete": "Migration terminée : {migrated} vidéos migrées avec succès",
+            "migrationNoData": "Aucune donnée trouvée à migrer"
         },
         "de": {
             "settings": "Einstellungen",
@@ -1052,7 +1082,12 @@
             "confirmRemoveFromPlaylist": "Möchten Sie dieses Video wirklich aus der Playlist entfernen? Es bleibt als einzelnes Video erhalten.",
             "playlistAssociationRemoved": "Playlist-Zuordnung entfernt",
             "loading": "Wird geladen",
-            "rendered": "Gerendert"
+            "rendered": "Gerendert",
+            "previews": "Vorschauen",
+            "migratingData": "Gespeicherte Daten aus der vorherigen Version werden migriert...",
+            "migratingDataProgress": "Daten werden migriert... {count} Einträge verarbeitet",
+            "migrationComplete": "Migration abgeschlossen: {migrated} Videos erfolgreich migriert",
+            "migrationNoData": "Keine Daten zum Migrieren gefunden"
         },
         "it": {
             "settings": "Impostazioni",
@@ -1163,7 +1198,12 @@
             "confirmRemoveFromPlaylist": "Sei sicuro di voler rimuovere questo video dalla playlist? Rimarrà come video singolo.",
             "playlistAssociationRemoved": "Associazione alla playlist rimossa",
             "loading": "Caricamento",
-            "rendered": "Renderizzati"
+            "rendered": "Renderizzati",
+            "previews": "Anteprime",
+            "migratingData": "Migrazione dei dati salvati dalla versione precedente...",
+            "migratingDataProgress": "Migrazione dei dati... {count} elementi elaborati",
+            "migrationComplete": "Migrazione completata: {migrated} video migrati con successo",
+            "migrationNoData": "Nessun dato trovato da migrare"
         },
         "pt": {
             "settings": "Configurações",
@@ -1274,7 +1314,12 @@
             "confirmRemoveFromPlaylist": "Tem certeza de que deseja remover este vídeo da playlist? Ele permanecerá como vídeo individual.",
             "playlistAssociationRemoved": "Associação à playlist removida",
             "loading": "Carregando",
-            "rendered": "Renderizados"
+            "rendered": "Renderizados",
+            "previews": "Pré-visualizações",
+            "migratingData": "Migrando dados salvos da versão anterior...",
+            "migratingDataProgress": "Migrando dados... {count} entradas processadas",
+            "migrationComplete": "Migração concluída: {migrated} vídeos migrados com sucesso",
+            "migrationNoData": "Nenhum dado encontrado para migrar"
         },
         "nl": {
             "settings": "Instellingen",
@@ -1385,7 +1430,12 @@
             "confirmRemoveFromPlaylist": "Weet je zeker dat je deze video uit de afspeellijst wilt verwijderen? Deze blijft als individuele video bestaan.",
             "playlistAssociationRemoved": "Koppeling met afspeellijst verwijderd",
             "loading": "Laden",
-            "rendered": "Gerenderd"
+            "rendered": "Gerenderd",
+            "previews": "Voorbeelden",
+            "migratingData": "Opgeslagen gegevens van vorige versie worden gemigreerd...",
+            "migratingDataProgress": "Gegevens worden gemigreerd... {count} items verwerkt",
+            "migrationComplete": "Migratie voltooid: {migrated} video's succesvol gemigreerd",
+            "migrationNoData": "Geen gegevens gevonden om te migreren"
         },
         "pl": {
             "settings": "Ustawienia",
@@ -1496,7 +1546,12 @@
             "confirmRemoveFromPlaylist": "Czy na pewno chcesz usunąć ten film z playlisty? Pozostanie jako osobny film.",
             "playlistAssociationRemoved": "Powiązanie z playlistą usunięte",
             "loading": "Ładowanie",
-            "rendered": "Wyrenderowane"
+            "rendered": "Wyrenderowane",
+            "previews": "Podglądy",
+            "migratingData": "Migracja zapisanych danych z poprzedniej wersji...",
+            "migratingDataProgress": "Migracja danych... {count} przetworzonych wpisów",
+            "migrationComplete": "Migracja zakończona: {migrated} filmów pomyślnie zmigrowano",
+            "migrationNoData": "Nie znaleziono danych do migracji"
         },
         "sv": {
             "settings": "Inställningar",
@@ -1607,7 +1662,12 @@
             "confirmRemoveFromPlaylist": "Är du säker på att du vill ta bort den här videon från spellistan? Den kommer att finnas kvar som en enskild video.",
             "playlistAssociationRemoved": "Spellistekoppling borttagen",
             "loading": "Laddar",
-            "rendered": "Renderade"
+            "rendered": "Renderade",
+            "previews": "Förhandsvisningar",
+            "migratingData": "Migrerar sparade data från tidigare version...",
+            "migratingDataProgress": "Migrerar data... {count} poster bearbetade",
+            "migrationComplete": "Migrering slutförd: {migrated} videor migrerade",
+            "migrationNoData": "Inga data hittades att migrera"
         },
         "da": {
             "settings": "Indstillinger",
@@ -1718,7 +1778,12 @@
             "confirmRemoveFromPlaylist": "Er du sikker på, at du vil fjerne denne video fra playlisten? Den forbliver som en individuel video.",
             "playlistAssociationRemoved": "Playliste-tilknytning fjernet",
             "loading": "Indlæser",
-            "rendered": "Renderede"
+            "rendered": "Renderede",
+            "previews": "Forhåndsvisninger",
+            "migratingData": "Migrerer gemte data fra tidligere version...",
+            "migratingDataProgress": "Migrerer data... {count} poster behandlet",
+            "migrationComplete": "Migrering fuldført: {migrated} videoer migreret",
+            "migrationNoData": "Ingen data fundet til migrering"
         },
         "no": {
             "settings": "Innstillinger",
@@ -1829,7 +1894,12 @@
             "confirmRemoveFromPlaylist": "Er du sikker på at du vil fjerne denne videoen fra spillelisten? Den vil forbli som en individuell video.",
             "playlistAssociationRemoved": "Spilleliste-tilknytning fjernet",
             "loading": "Laster",
-            "rendered": "Rendret"
+            "rendered": "Rendret",
+            "previews": "Forhåndsvisninger",
+            "migratingData": "Migrerer lagrede data fra tidligere versjon...",
+            "migratingDataProgress": "Migrerer data... {count} oppføringer behandlet",
+            "migrationComplete": "Migrering fullført: {migrated} videoer migrert",
+            "migrationNoData": "Ingen data funnet for migrering"
         },
         "fi": {
             "settings": "Asetukset",
@@ -1940,7 +2010,12 @@
             "confirmRemoveFromPlaylist": "Haluatko varmasti poistaa tämän videon soittolistalta? Se säilyy yksittäisenä videona.",
             "playlistAssociationRemoved": "Soittolistaliitos poistettu",
             "loading": "Ladataan",
-            "rendered": "Renderöidyt"
+            "rendered": "Renderöidyt",
+            "previews": "Esikatselut",
+            "migratingData": "Siirretään tallennettuja tietoja edellisestä versiosta...",
+            "migratingDataProgress": "Siirretään tietoja... {count} merkintää käsitelty",
+            "migrationComplete": "Siirto valmis: {migrated} videota siirretty onnistuneesti",
+            "migrationNoData": "Siirrettäviä tietoja ei löytynyt"
         },
         "cs": {
             "settings": "Nastavení",
@@ -2051,7 +2126,12 @@
             "confirmRemoveFromPlaylist": "Opravdu chcete odebrat toto video z playlistu? Zůstane jako samostatné video.",
             "playlistAssociationRemoved": "Přiřazení k playlistu bylo odstraněno",
             "loading": "Načítání",
-            "rendered": "Vykresleno"
+            "rendered": "Vykresleno",
+            "previews": "Náhledy",
+            "migratingData": "Migrace uložených dat z předchozí verze...",
+            "migratingDataProgress": "Migrace dat... {count} položek zpracováno",
+            "migrationComplete": "Migrace dokončena: {migrated} videí úspěšně migrováno",
+            "migrationNoData": "Nebyla nalezena žádná data k migraci"
         },
         "sk": {
             "settings": "Nastavenia",
@@ -2162,7 +2242,12 @@
             "confirmRemoveFromPlaylist": "Naozaj chcete odstrániť toto video z playlistu? Zostane ako samostatné video.",
             "playlistAssociationRemoved": "Prepojenie s playlistom bolo odstránené",
             "loading": "Načítava sa",
-            "rendered": "Vykreslené"
+            "rendered": "Vykreslené",
+            "previews": "Náhľady",
+            "migratingData": "Migrácia uložených údajov z predchádzajúcej verzie...",
+            "migratingDataProgress": "Migrácia údajov... {count} položiek spracovaných",
+            "migrationComplete": "Migrácia dokončená: {migrated} videí úspešne migrovaných",
+            "migrationNoData": "Nenašli sa žiadne údaje na migráciu"
         },
         "hu": {
             "settings": "Beállítások",
@@ -2273,7 +2358,12 @@
             "confirmRemoveFromPlaylist": "Biztosan el szeretnéd távolítani ezt a videót a lejátszási listáról? Önálló videóként megmarad.",
             "playlistAssociationRemoved": "Lejátszási lista-hozzárendelés eltávolítva",
             "loading": "Betöltés",
-            "rendered": "Renderelve"
+            "rendered": "Renderelve",
+            "previews": "Előnézetek",
+            "migratingData": "Mentett adatok migrálása az előző verzióból...",
+            "migratingDataProgress": "Adatok migrálása... {count} elem feldolgozva",
+            "migrationComplete": "Migráció befejezve: {migrated} videó sikeresen migrálva",
+            "migrationNoData": "Nem találhatók migrálandó adatok"
         },
         "ro": {
             "settings": "Setări",
@@ -2384,7 +2474,12 @@
             "confirmRemoveFromPlaylist": "Sigur doriți să eliminați acest videoclip din playlist? Va rămâne ca videoclip individual.",
             "playlistAssociationRemoved": "Asocierea cu playlistul a fost eliminată",
             "loading": "Se încarcă",
-            "rendered": "Randate"
+            "rendered": "Randate",
+            "previews": "Previzualizări",
+            "migratingData": "Se migrează datele salvate din versiunea anterioară...",
+            "migratingDataProgress": "Se migrează datele... {count} înregistrări procesate",
+            "migrationComplete": "Migrare finalizată: {migrated} videoclipuri migrate cu succes",
+            "migrationNoData": "Nu au fost găsite date pentru migrare"
         },
         "bg": {
             "settings": "Настройки",
@@ -2495,7 +2590,12 @@
             "confirmRemoveFromPlaylist": "Сигурни ли сте, че искате да премахнете това видео от плейлиста? То ще остане като отделно видео.",
             "playlistAssociationRemoved": "Асоциацията с плейлиста е премахната",
             "loading": "Зареждане",
-            "rendered": "Рендерирани"
+            "rendered": "Рендерирани",
+            "previews": "Прегледи",
+            "migratingData": "Мигриране на запазени данни от предишна версия...",
+            "migratingDataProgress": "Мигриране на данни... {count} записа обработени",
+            "migrationComplete": "Миграцията завърши: {migrated} видеоклипа успешно мигрирани",
+            "migrationNoData": "Няма намерени данни за мигриране"
         },
         "el": {
             "settings": "Ρυθμίσεις",
@@ -2606,7 +2706,12 @@
             "confirmRemoveFromPlaylist": "Είστε βέβαιοι ότι θέλετε να αφαιρέσετε αυτό το βίντεο από τη λίστα αναπαραγωγής; Θα παραμείνει ως μεμονωμένο βίντεο.",
             "playlistAssociationRemoved": "Η συσχέτιση με τη λίστα αναπαραγωγής αφαιρέθηκε",
             "loading": "Φόρτωση",
-            "rendered": "Αποδομένα"
+            "rendered": "Αποδομένα",
+            "previews": "Προεπισκοπήσεις",
+            "migratingData": "Μεταφορά αποθηκευμένων δεδομένων από προηγούμενη έκδοση...",
+            "migratingDataProgress": "Μεταφορά δεδομένων... {count} εγγραφές επεξεργάστηκαν",
+            "migrationComplete": "Η μεταφορά ολοκληρώθηκε: {migrated} βίντεο μεταφέρθηκαν με επιτυχία",
+            "migrationNoData": "Δεν βρέθηκαν δεδομένα για μεταφορά"
         },
         "sr": {
             "settings": "Подешавања",
@@ -2717,7 +2822,12 @@
             "confirmRemoveFromPlaylist": "Да ли сте сигурни да желите да уклоните овај видео са плејлисте? Остаће као појединачни видео.",
             "playlistAssociationRemoved": "Повезаност са плејлистом је уклоњена",
             "loading": "Учитавање",
-            "rendered": "Рендеровано"
+            "rendered": "Рендеровано",
+            "previews": "Прегледи",
+            "migratingData": "Миграција сачуваних података из претходне верзије...",
+            "migratingDataProgress": "Миграција података... {count} ставки обрађено",
+            "migrationComplete": "Миграција завршена: {migrated} видео записа успешно мигрирано",
+            "migrationNoData": "Нису пронађени подаци за миграцију"
         },
         "hr": {
             "settings": "Postavke",
@@ -2828,7 +2938,12 @@
             "confirmRemoveFromPlaylist": "Jeste li sigurni da želite ukloniti ovaj video s playliste? Ostat će kao pojedinačni video.",
             "playlistAssociationRemoved": "Povezanost s playlistom je uklonjena",
             "loading": "Učitavanje",
-            "rendered": "Renderirani"
+            "rendered": "Renderirani",
+            "previews": "Pregledi",
+            "migratingData": "Migracija spremljenih podataka iz prethodne verzije...",
+            "migratingDataProgress": "Migracija podataka... {count} stavki obrađeno",
+            "migrationComplete": "Migracija završena: {migrated} videozapisa uspješno migrirano",
+            "migrationNoData": "Nisu pronađeni podaci za migraciju"
         },
         "sl": {
             "settings": "Nastavitve",
@@ -2939,7 +3054,12 @@
             "confirmRemoveFromPlaylist": "Ali ste prepričani, da želite odstraniti ta video s seznama predvajanja? Ostal bo kot posamezen video.",
             "playlistAssociationRemoved": "Povezava s seznamom predvajanja je odstranjena",
             "loading": "Nalaganje",
-            "rendered": "Izrisani"
+            "rendered": "Izrisani",
+            "previews": "Predogledi",
+            "migratingData": "Migracija shranjenih podatkov iz prejšnje različice...",
+            "migratingDataProgress": "Migracija podatkov... {count} vnosov obdelanih",
+            "migrationComplete": "Migracija zaključena: {migrated} videov uspešno migriranih",
+            "migrationNoData": "Ni najdenih podatkov za migracijo"
         },
         "lt": {
             "settings": "Nustatymai",
@@ -3050,7 +3170,12 @@
             "confirmRemoveFromPlaylist": "Ar tikrai norite pašalinti šį vaizdo įrašą iš grojaraščio? Jis liks kaip atskiras vaizdo įrašas.",
             "playlistAssociationRemoved": "Grojaraščio susiejimas pašalintas",
             "loading": "Įkeliama",
-            "rendered": "Sugeneruoti"
+            "rendered": "Sugeneruoti",
+            "previews": "Peržiūros",
+            "migratingData": "Perkeliami išsaugoti duomenys iš ankstesnės versijos...",
+            "migratingDataProgress": "Perkeliami duomenys... {count} įrašų apdorota",
+            "migrationComplete": "Perkėlimas baigtas: {migrated} vaizdo įrašai sėkmingai perkelti",
+            "migrationNoData": "Nerasta duomenų perkėlimui"
         },
         "lv": {
             "settings": "Iestatījumi",
@@ -3161,7 +3286,12 @@
             "confirmRemoveFromPlaylist": "Vai tiešām vēlaties noņemt šo video no atskaņošanas saraksta? Tas paliks kā atsevišķs video.",
             "playlistAssociationRemoved": "Saistība ar atskaņošanas sarakstu noņemta",
             "loading": "Ielāde",
-            "rendered": "Renderēti"
+            "rendered": "Renderēti",
+            "previews": "Priekšskatījumi",
+            "migratingData": "Migrē saglabātos datus no iepriekšējās versijas...",
+            "migratingDataProgress": "Migrē datus... {count} ieraksti apstrādāti",
+            "migrationComplete": "Migrācija pabeigta: {migrated} video veiksmīgi migrēti",
+            "migrationNoData": "Nav atrasti dati migrācijai"
         },
         "uk": {
             "settings": "Налаштування",
@@ -3272,7 +3402,12 @@
             "confirmRemoveFromPlaylist": "Ви впевнені, що хочете видалити це відео з плейлиста? Воно залишиться як окреме відео.",
             "playlistAssociationRemoved": "Зв’язок із плейлистом видалено",
             "loading": "Завантаження",
-            "rendered": "Відрендерено"
+            "rendered": "Відрендерено",
+            "previews": "Попередні перегляди",
+            "migratingData": "Міграція збережених даних з попередньої версії...",
+            "migratingDataProgress": "Міграція даних... {count} записів оброблено",
+            "migrationComplete": "Міграцію завершено: {migrated} відео успішно перенесено",
+            "migrationNoData": "Дані для міграції не знайдено"
         },
         "ru": {
             "settings": "Настройки",
@@ -3383,7 +3518,12 @@
             "confirmRemoveFromPlaylist": "Вы уверены, что хотите удалить это видео из плейлиста? Оно останется как отдельное видео.",
             "playlistAssociationRemoved": "Связь с плейлистом удалена",
             "loading": "Загрузка",
-            "rendered": "Отрендерены"
+            "rendered": "Отрендерены",
+            "previews": "Предпросмотры",
+            "migratingData": "Миграция сохранённых данных из предыдущей версии...",
+            "migratingDataProgress": "Миграция данных... обработано {count} записей",
+            "migrationComplete": "Миграция завершена: {migrated} видео успешно перенесено",
+            "migrationNoData": "Данные для миграции не найдены"
         },
         "tr": {
             "settings": "Ayarlar",
@@ -3494,7 +3634,12 @@
             "confirmRemoveFromPlaylist": "Bu videoyu oynatma listesinden kaldırmak istediğinizden emin misiniz? Bireysel video olarak kalacaktır.",
             "playlistAssociationRemoved": "Oynatma listesi ilişkilendirmesi kaldırıldı",
             "loading": "Yükleniyor",
-            "rendered": "Oluşturuldu"
+            "rendered": "Oluşturuldu",
+            "previews": "Önizlemeler",
+            "migratingData": "Önceki sürümden kaydedilmiş veriler taşınıyor...",
+            "migratingDataProgress": "Veriler taşınıyor... {count} kayıt işlendi",
+            "migrationComplete": "Taşıma tamamlandı: {migrated} video başarıyla taşındı",
+            "migrationNoData": "Taşınacak veri bulunamadı"
         },
         "ar": {
             "settings": "الإعدادات",
@@ -3605,7 +3750,12 @@
             "confirmRemoveFromPlaylist": "هل أنت متأكد أنك تريد إزالة هذا الفيديو من قائمة التشغيل؟ سيبقى كفيديو فردي.",
             "playlistAssociationRemoved": "تمت إزالة ارتباط قائمة التشغيل",
             "loading": "جارٍ التحميل",
-            "rendered": "تم العرض"
+            "rendered": "تم العرض",
+            "previews": "معاينات",
+            "migratingData": "جارٍ ترحيل البيانات المحفوظة من الإصدار السابق...",
+            "migratingDataProgress": "جارٍ ترحيل البيانات... تمت معالجة {count} عنصر",
+            "migrationComplete": "اكتملت عملية الترحيل: تم ترحيل {migrated} فيديو بنجاح",
+            "migrationNoData": "لم يتم العثور على بيانات للترحيل"
         },
         "fa": {
             "settings": "تنظیمات",
@@ -3716,7 +3866,12 @@
             "confirmRemoveFromPlaylist": "آیا مطمئن هستید که می‌خواهید این ویدیو را از فهرست پخش حذف کنید؟ به‌صورت ویدیوی جداگانه باقی می‌ماند.",
             "playlistAssociationRemoved": "ارتباط با فهرست پخش حذف شد",
             "loading": "در حال بارگذاری",
-            "rendered": "رندر شده"
+            "rendered": "رندر شده",
+            "previews": "پیش‌نمایش‌ها",
+            "migratingData": "در حال انتقال داده‌های ذخیره‌شده از نسخه قبلی...",
+            "migratingDataProgress": "در حال انتقال داده‌ها... {count} مورد پردازش شد",
+            "migrationComplete": "انتقال کامل شد: {migrated} ویدیو با موفقیت منتقل شد",
+            "migrationNoData": "داده‌ای برای انتقال یافت نشد"
         },
         "he": {
             "settings": "הגדרות",
@@ -3827,7 +3982,12 @@
             "confirmRemoveFromPlaylist": "האם אתה בטוח שברצונך להסיר סרטון זה מרשימת ההשמעה? הוא יישאר כסרטון בודד.",
             "playlistAssociationRemoved": "הקישור לרשימת ההשמעה הוסר",
             "loading": "טוען",
-            "rendered": "עובדו"
+            "rendered": "עובדו",
+            "previews": "תצוגות מקדימות",
+            "migratingData": "מעביר נתונים שמורים מהגרסה הקודמת...",
+            "migratingDataProgress": "מעביר נתונים... {count} רשומות עובדו",
+            "migrationComplete": "ההעברה הושלמה: {migrated} סרטונים הועברו בהצלחה",
+            "migrationNoData": "לא נמצאו נתונים להעברה"
         },
         "hi": {
             "settings": "सेटिंग्स",
@@ -3938,7 +4098,12 @@
             "confirmRemoveFromPlaylist": "क्या आप वाकई इस वीडियो को प्लेलिस्ट से हटाना चाहते हैं? यह एकल वीडियो के रूप में बना रहेगा।",
             "playlistAssociationRemoved": "प्लेलिस्ट संबंध हटाया गया",
             "loading": "लोड हो रहा है",
-            "rendered": "रेंडर किया गया"
+            "rendered": "रेंडर किया गया",
+            "previews": "पूर्वावलोकन",
+            "migratingData": "पिछले संस्करण से सहेजा गया डेटा माइग्रेट किया जा रहा है...",
+            "migratingDataProgress": "डेटा माइग्रेट किया जा रहा है... {count} प्रविष्टियाँ संसाधित",
+            "migrationComplete": "माइग्रेशन पूर्ण: {migrated} वीडियो सफलतापूर्वक माइग्रेट किए गए",
+            "migrationNoData": "माइग्रेट करने के लिए कोई डेटा नहीं मिला"
         },
         "bn": {
             "settings": "সেটিংস",
@@ -4049,7 +4214,12 @@
             "confirmRemoveFromPlaylist": "আপনি কি নিশ্চিত যে এই ভিডিওটি প্লেলিস্ট থেকে সরাতে চান? এটি পৃথক ভিডিও হিসেবে থাকবে।",
             "playlistAssociationRemoved": "প্লেলিস্ট সংযোগ সরানো হয়েছে",
             "loading": "লোড হচ্ছে",
-            "rendered": "রেন্ডার করা হয়েছে"
+            "rendered": "রেন্ডার করা হয়েছে",
+            "previews": "প্রিভিউসমূহ",
+            "migratingData": "পূর্ববর্তী সংস্করণ থেকে সংরক্ষিত ডেটা স্থানান্তর করা হচ্ছে...",
+            "migratingDataProgress": "ডেটা স্থানান্তর করা হচ্ছে... {count} এন্ট্রি প্রক্রিয়াকৃত",
+            "migrationComplete": "স্থানান্তর সম্পন্ন: {migrated} ভিডিও সফলভাবে স্থানান্তরিত হয়েছে",
+            "migrationNoData": "স্থানান্তরের জন্য কোনো ডেটা পাওয়া যায়নি"
         },
         "te": {
             "settings": "సెట్టింగులు",
@@ -4160,7 +4330,12 @@
             "confirmRemoveFromPlaylist": "ఈ వీడియోను ప్లేలిస్ట్ నుండి తొలగించాలనుకుంటున్నారా? ఇది వ్యక్తిగత వీడియోగా మిగులుతుంది.",
             "playlistAssociationRemoved": "ప్లేలిస్ట్ అనుబంధం తొలగించబడింది",
             "loading": "లోడ్ అవుతోంది",
-            "rendered": "రెండర్ చేయబడింది"
+            "rendered": "రెండర్ చేయబడింది",
+            "previews": "ప్రీవ్యూ‌లు",
+            "migratingData": "మునుపటి సంస్కరణ నుండి సేవ్ చేసిన డేటాను మైగ్రేట్ చేస్తున్నాం...",
+            "migratingDataProgress": "డేటాను మైగ్రేట్ చేస్తున్నాం... {count} ఎంట్రీలు ప్రాసెస్ అయ్యాయి",
+            "migrationComplete": "మైగ్రేషన్ పూర్తైంది: {migrated} వీడియోలు విజయవంతంగా మైగ్రేట్ అయ్యాయి",
+            "migrationNoData": "మైగ్రేట్ చేయడానికి డేటా కనబడలేదు"
         },
         "ta": {
             "settings": "அமைப்புகள்",
@@ -4271,7 +4446,12 @@
             "confirmRemoveFromPlaylist": "இந்த வீடியோவை ப்ளேலிஸ்டில் இருந்து நீக்க விரும்புகிறீர்களா? இது தனி வீடியோவாக இருக்கும்.",
             "playlistAssociationRemoved": "ப்ளேலிஸ்ட் தொடர்பு நீக்கப்பட்டது",
             "loading": "ஏற்றுகிறது",
-            "rendered": "ரெண்டர் செய்யப்பட்டது"
+            "rendered": "ரெண்டர் செய்யப்பட்டது",
+            "previews": "முன்னோட்டங்கள்",
+            "migratingData": "முந்தைய பதிப்பிலிருந்து சேமிக்கப்பட்ட தரவை மாற்றுகிறது...",
+            "migratingDataProgress": "தரவு மாற்றப்படுகிறது... {count} பதிவுகள் செயலாக்கப்பட்டன",
+            "migrationComplete": "மாற்றம் நிறைவு: {migrated} வீடியோக்கள் வெற்றிகரமாக மாற்றப்பட்டன",
+            "migrationNoData": "மாற்றுவதற்கு தரவு எதுவும் கிடைக்கவில்லை"
         },
         "mr": {
             "settings": "सेटिंग्ज",
@@ -4382,7 +4562,12 @@
             "confirmRemoveFromPlaylist": "आपण हा व्हिडिओ प्लेलिस्टमधून काढू इच्छिता का? तो स्वतंत्र व्हिडिओ म्हणून राहील.",
             "playlistAssociationRemoved": "प्लेलिस्ट संबंध काढला गेला",
             "loading": "लोड होत आहे",
-            "rendered": "रेंडर केले"
+            "rendered": "रेंडर केले",
+            "previews": "पूर्वावलोकने",
+            "migratingData": "मागील आवृत्तीतील जतन केलेला डेटा स्थलांतरित केला जात आहे...",
+            "migratingDataProgress": "डेटा स्थलांतरित केला जात आहे... {count} नोंदी प्रक्रिया केल्या",
+            "migrationComplete": "स्थलांतर पूर्ण: {migrated} व्हिडिओ यशस्वीरित्या स्थलांतरित झाले",
+            "migrationNoData": "स्थलांतरासाठी कोणताही डेटा सापडला नाही"
         },
         "zh": {
             "settings": "设置",
@@ -4493,7 +4678,12 @@
             "confirmRemoveFromPlaylist": "确定要将此视频从播放列表中移除吗？它将保留为单个视频。",
             "playlistAssociationRemoved": "播放列表关联已移除",
             "loading": "加载中",
-            "rendered": "已渲染"
+            "rendered": "已渲染",
+            "previews": "预览",
+            "migratingData": "正在从旧版本迁移已保存的数据...",
+            "migratingDataProgress": "正在迁移数据... 已处理 {count} 条记录",
+            "migrationComplete": "迁移完成：已成功迁移 {migrated} 个视频",
+            "migrationNoData": "未找到可迁移的数据"
         },
         "zh-TW": {
             "settings": "設定",
@@ -4604,7 +4794,12 @@
             "confirmRemoveFromPlaylist": "確定要將此影片從播放清單中移除嗎？它將保留為個別影片。",
             "playlistAssociationRemoved": "播放清單關聯已移除",
             "loading": "載入中",
-            "rendered": "已轉譯"
+            "rendered": "已轉譯",
+            "previews": "預覽",
+            "migratingData": "正在從舊版本遷移已儲存的資料...",
+            "migratingDataProgress": "正在遷移資料... 已處理 {count} 筆資料",
+            "migrationComplete": "遷移完成：已成功遷移 {migrated} 部影片",
+            "migrationNoData": "找不到可遷移的資料"
         },
         "yue": {
             "settings": "設定",
@@ -4715,7 +4910,12 @@
             "confirmRemoveFromPlaylist": "確定要將此影片從播放清單中移除嗎？它將保留為個別影片。",
             "playlistAssociationRemoved": "播放清單關聯已移除",
             "loading": "載入中",
-            "rendered": "已轉譯"
+            "rendered": "已轉譯",
+            "previews": "預覽",
+            "migratingData": "正從舊版本遷移已儲存嘅資料...",
+            "migratingDataProgress": "正遷移資料... 已處理 {count} 筆記錄",
+            "migrationComplete": "遷移完成：成功遷移 {migrated} 條影片",
+            "migrationNoData": "搵唔到可遷移嘅資料"
         },
         "zh-HK": {
             "settings": "設定",
@@ -4826,7 +5026,12 @@
             "confirmRemoveFromPlaylist": "確定要將此影片從播放清單中移除嗎？它將保留為個別影片。",
             "playlistAssociationRemoved": "播放清單關聯已移除",
             "loading": "載入中",
-            "rendered": "已轉譯"
+            "rendered": "已轉譯",
+            "previews": "預覽",
+            "migratingData": "正在從舊版本遷移已儲存的資料...",
+            "migratingDataProgress": "正在遷移資料... 已處理 {count} 筆資料",
+            "migrationComplete": "遷移完成：已成功遷移 {migrated} 部影片",
+            "migrationNoData": "找不到可遷移的資料"
         },
         "ja": {
             "settings": "設定",
@@ -4937,7 +5142,12 @@
             "confirmRemoveFromPlaylist": "この動画をプレイリストから削除してもよろしいですか？個別の動画として残ります。",
             "playlistAssociationRemoved": "プレイリストの関連付けが削除されました",
             "loading": "読み込み中",
-            "rendered": "レンダリング済み"
+            "rendered": "レンダリング済み",
+            "previews": "プレビュー",
+            "migratingData": "以前のバージョンから保存されたデータを移行しています...",
+            "migratingDataProgress": "データを移行しています... {count} 件処理済み",
+            "migrationComplete": "移行完了：{migrated} 件の動画を正常に移行しました",
+            "migrationNoData": "移行するデータが見つかりません"
         },
         "ko": {
             "settings": "설정",
@@ -5048,7 +5258,12 @@
             "confirmRemoveFromPlaylist": "이 동영상을 재생목록에서 제거하시겠습니까? 개별 동영상으로 유지됩니다.",
             "playlistAssociationRemoved": "재생목록 연결이 제거되었습니다",
             "loading": "로딩 중",
-            "rendered": "렌더링됨"
+            "rendered": "렌더링됨",
+            "previews": "미리보기",
+            "migratingData": "이전 버전에서 저장된 데이터를 마이그레이션하는 중...",
+            "migratingDataProgress": "데이터를 마이그레이션하는 중... {count}개 항목 처리됨",
+            "migrationComplete": "마이그레이션 완료: {migrated}개 동영상이 성공적으로 마이그레이션됨",
+            "migrationNoData": "마이그레이션할 데이터가 없습니다"
         },
         "th": {
             "settings": "การตั้งค่า",
@@ -5159,7 +5374,12 @@
             "confirmRemoveFromPlaylist": "คุณแน่ใจหรือไม่ว่าต้องการลบวิดีโอนี้ออกจากเพลย์ลิสต์? วิดีโอนี้จะยังคงเป็นวิดีโอเดี่ยว",
             "playlistAssociationRemoved": "การเชื่อมโยงเพลย์ลิสต์ถูกลบแล้ว",
             "loading": "กำลังโหลด",
-            "rendered": "แสดงผลแล้ว"
+            "rendered": "แสดงผลแล้ว",
+            "previews": "ตัวอย่าง",
+            "migratingData": "กำลังย้ายข้อมูลที่บันทึกไว้จากเวอร์ชันก่อนหน้า...",
+            "migratingDataProgress": "กำลังย้ายข้อมูล... ประมวลผลแล้ว {count} รายการ",
+            "migrationComplete": "การย้ายข้อมูลเสร็จสิ้น: ย้ายวิดีโอ {migrated} รายการสำเร็จ",
+            "migrationNoData": "ไม่พบข้อมูลสำหรับการย้าย"
         },
         "vi": {
             "settings": "Cài đặt",
@@ -5270,7 +5490,12 @@
             "confirmRemoveFromPlaylist": "Bạn có chắc chắn muốn xóa video này khỏi danh sách phát không? Video sẽ vẫn là video riêng lẻ.",
             "playlistAssociationRemoved": "Liên kết danh sách phát đã được xóa",
             "loading": "Đang tải",
-            "rendered": "Đã kết xuất"
+            "rendered": "Đã kết xuất",
+            "previews": "Xem trước",
+            "migratingData": "Đang di chuyển dữ liệu đã lưu từ phiên bản trước...",
+            "migratingDataProgress": "Đang di chuyển dữ liệu... đã xử lý {count} mục",
+            "migrationComplete": "Hoàn tất di chuyển: {migrated} video đã được di chuyển thành công",
+            "migrationNoData": "Không tìm thấy dữ liệu để di chuyển"
         },
         "id": {
             "settings": "Pengaturan",
@@ -5381,7 +5606,12 @@
             "confirmRemoveFromPlaylist": "Apakah Anda yakin ingin menghapus video ini dari playlist? Video akan tetap sebagai video individu.",
             "playlistAssociationRemoved": "Asosiasi playlist dihapus",
             "loading": "Memuat",
-            "rendered": "Dirender"
+            "rendered": "Dirender",
+            "previews": "Pratinjau",
+            "migratingData": "Memigrasikan data yang disimpan dari versi sebelumnya...",
+            "migratingDataProgress": "Memigrasikan data... {count} entri diproses",
+            "migrationComplete": "Migrasi selesai: {migrated} video berhasil dimigrasikan",
+            "migrationNoData": "Tidak ditemukan data untuk dimigrasikan"
         },
         "ms": {
             "settings": "Tetapan",
@@ -5492,7 +5722,12 @@
             "confirmRemoveFromPlaylist": "Adakah anda pasti mahu mengalih keluar video ini daripada senarai main? Ia akan kekal sebagai video individu.",
             "playlistAssociationRemoved": "Perkaitan senarai main telah dialih keluar",
             "loading": "Memuatkan",
-            "rendered": "Dirender"
+            "rendered": "Dirender",
+            "previews": "Pratonton",
+            "migratingData": "Memindahkan data yang disimpan dari versi sebelumnya...",
+            "migratingDataProgress": "Memindahkan data... {count} entri diproses",
+            "migrationComplete": "Pemindahan selesai: {migrated} video berjaya dipindahkan",
+            "migrationNoData": "Tiada data ditemui untuk dipindahkan"
         },
         "tl": {
             "settings": "Mga Setting",
@@ -5603,7 +5838,12 @@
             "confirmRemoveFromPlaylist": "Sigurado ka bang gusto mong alisin ang video na ito sa playlist? Mananatili ito bilang hiwalay na video.",
             "playlistAssociationRemoved": "Inalis ang pagkakaugnay sa playlist",
             "loading": "Naglo-load",
-            "rendered": "Na-render"
+            "rendered": "Na-render",
+            "previews": "Mga Preview",
+            "migratingData": "Inililipat ang naka-save na data mula sa nakaraang bersyon...",
+            "migratingDataProgress": "Inililipat ang data... {count} na entry ang naproseso",
+            "migrationComplete": "Kumpleto ang paglipat: {migrated} na video ang matagumpay na nailipat",
+            "migrationNoData": "Walang nahanap na data na ililipat"
         },
         "my": {
             "settings": "ဆက်တင်များ",
@@ -5714,7 +5954,12 @@
             "confirmRemoveFromPlaylist": "ဤဗီဒီယိုကို ပလေယာစာရင်းမှ ဖယ်ရှားလိုသည်မှာ သေချာပါသလား။ ၎င်းသည် သီးခြားဗီဒီယိုအဖြစ် ဆက်လက်ရှိနေမည်ဖြစ်သည်။",
             "playlistAssociationRemoved": "ပလေယာစာရင်း ချိတ်ဆက်မှု ဖယ်ရှားပြီး",
             "loading": "ဖွင့်နေသည်",
-            "rendered": "တင်ဆက်ပြီး"
+            "rendered": "တင်ဆက်ပြီး",
+            "previews": "အစမ်းကြည့်ရှုမှုများ",
+            "migratingData": "ယခင်ဗားရှင်းမှ သိမ်းဆည်းထားသော ဒေတာများကို ပြောင်းရွှေ့နေသည်...",
+            "migratingDataProgress": "ဒေတာများကို ပြောင်းရွှေ့နေသည်... {count} ခုကို လုပ်ဆောင်ပြီး",
+            "migrationComplete": "ပြောင်းရွှေ့မှု ပြီးဆုံးပါပြီ - ဗီဒီယို {migrated} ခု အောင်မြင်စွာ ပြောင်းရွှေ့ပြီး",
+            "migrationNoData": "ပြောင်းရွှေ့ရန် ဒေတာ မတွေ့ရှိပါ"
         },
         "sw": {
             "settings": "Mipangilio",
@@ -5825,7 +6070,12 @@
             "confirmRemoveFromPlaylist": "Je, una uhakika unataka kuondoa video hii kwenye orodha ya kucheza? Itabaki kama video ya pekee.",
             "playlistAssociationRemoved": "Muunganiko wa orodha ya kucheza umeondolewa",
             "loading": "Inapakia",
-            "rendered": "Zimetolewa"
+            "rendered": "Zimetolewa",
+            "previews": "Hakikisho",
+            "migratingData": "Inahamisha data iliyohifadhiwa kutoka toleo la awali...",
+            "migratingDataProgress": "Inahamisha data... {count} maingizo yamechakatwa",
+            "migrationComplete": "Uhamishaji umekamilika: video {migrated} zimehamishwa kwa mafanikio",
+            "migrationNoData": "Hakuna data iliyopatikana kwa ajili ya kuhamisha"
         },
         "am": {
             "settings": "ማስተካከያ",
@@ -5936,7 +6186,12 @@
             "confirmRemoveFromPlaylist": "ይህን ቪዲዮ ከፕሌይሊስት ማስወገድ እርግጠኛ ነዎት? እንደ ብቻ ቪዲዮ ይቀራል።",
             "playlistAssociationRemoved": "የፕሌይሊስት ግንኙነት ተወግዷል",
             "loading": "በመጫን ላይ",
-            "rendered": "ተቀርቧል"
+            "rendered": "ተቀርቧል",
+            "previews": "ቅድመ እይታዎች",
+            "migratingData": "ከቀድሞ ስሪት የተቀመጡ ውሂቦችን በመቀየር ላይ...",
+            "migratingDataProgress": "ውሂብ በመቀየር ላይ... {count} መዝገቦች ተከናውነዋል",
+            "migrationComplete": "መቀየር ተጠናቋል: {migrated} ቪዲዮዎች በተሳካ ሁኔታ ተቀይረዋል",
+            "migrationNoData": "ለመቀየር ውሂብ አልተገኘም"
         },
         "ha": {
             "settings": "Saituna",
@@ -6047,7 +6302,12 @@
             "confirmRemoveFromPlaylist": "Ka tabbata kana son cire wannan bidiyon daga jerin waƙoƙi? Zai kasance a matsayin bidiyo ɗaya.",
             "playlistAssociationRemoved": "An cire haɗin jerin waƙoƙi",
             "loading": "Ana lodawa",
-            "rendered": "An nuna"
+            "rendered": "An nuna",
+            "previews": "Dubawa",
+            "migratingData": "Ana ƙaura da bayanan da aka adana daga sigar da ta gabata...",
+            "migratingDataProgress": "Ana ƙaura da bayanai... an sarrafa shigarwa {count}",
+            "migrationComplete": "An kammala ƙaura: an ƙaura bidiyo {migrated} cikin nasara",
+            "migrationNoData": "Ba a sami bayanan da za a ƙaura ba"
         },
         "ur": {
             "settings": "ترتیبات",
@@ -6158,7 +6418,12 @@
             "confirmRemoveFromPlaylist": "کیا آپ واقعی اس ویڈیو کو پلے لسٹ سے ہٹانا چاہتے ہیں؟ یہ ایک علیحدہ ویڈیو کے طور پر رہے گی۔",
             "playlistAssociationRemoved": "پلے لسٹ کا تعلق ہٹا دیا گیا",
             "loading": "لوڈ ہو رہا ہے",
-            "rendered": "رینڈر کیا گیا"
+            "rendered": "رینڈر کیا گیا",
+            "previews": "پیش نظارے",
+            "migratingData": "پچھلے ورژن سے محفوظ کردہ ڈیٹا منتقل کیا جا رہا ہے...",
+            "migratingDataProgress": "ڈیٹا منتقل کیا جا رہا ہے... {count} اندراجات پر عمل ہو چکا",
+            "migrationComplete": "منتقلی مکمل: {migrated} ویڈیوز کامیابی سے منتقل ہو گئیں",
+            "migrationNoData": "منتقل کرنے کے لیے کوئی ڈیٹا نہیں ملا"
         },
         "zu": {
             "settings": "Izilungiselelo",
@@ -6269,7 +6534,12 @@
             "confirmRemoveFromPlaylist": "Uqinisekile ukuthi ufuna ukususa le vidiyo ku-playlist? Izohlala njengevidiyo eyodwa.",
             "playlistAssociationRemoved": "Ukuhlotshaniswa kwe-playlist kususiwe",
             "loading": "Iyalayisha",
-            "rendered": "Kukhonjisiwe"
+            "rendered": "Kukhonjisiwe",
+            "previews": "Ukubuka kuqala",
+            "migratingData": "Kudluliswa idatha egciniwe kusuka kunguqulo yangaphambilini...",
+            "migratingDataProgress": "Kudluliswa idatha... {count} okufakiwe sekucutshunguliwe",
+            "migrationComplete": "Ukudlulisa kuqediwe: amavidiyo angu-{migrated} adluliselwe ngempumelelo",
+            "migrationNoData": "Ayikho idatha etholakele yokudlulisa"
         }
     }
 }

--- a/translations.json
+++ b/translations.json
@@ -1,7 +1,7 @@
 {
     "DESCRIPTION": "Traducciones para userscript YouTube Playback Plox. Hechas con LLM's y revisadas un poco manualmente.",
     "AUTHOR": "Alplox",
-    "VERSION": "0.0.7-3",
+    "VERSION": "0.0.8",
     "GITHUB": "https://github.com/Alplox/Youtube-Playback-Plox",
     "GREASYFORK": "https://greasyfork.org/es/scripts/553387-youtube-playback-plox",
     "LANGUAGE_FLAGS": {

--- a/translations.json
+++ b/translations.json
@@ -1,7 +1,7 @@
 {
     "DESCRIPTION": "Traducciones para userscript YouTube Playback Plox. Hechas con LLM's y revisadas un poco manualmente.",
     "AUTHOR": "Alplox",
-    "VERSION": "0.0.7-2",
+    "VERSION": "0.0.7-3",
     "GITHUB": "https://github.com/Alplox/Youtube-Playback-Plox",
     "GREASYFORK": "https://greasyfork.org/es/scripts/553387-youtube-playback-plox",
     "LANGUAGE_FLAGS": {
@@ -312,6 +312,7 @@
             "export": "Export",
             "import": "Import",
             "progressSaved": "Progress saved",
+            "storageFull": "Storage full - Unable to save progress",
             "dataExported": "Data exported",
             "itemsImported": "Imported {count} items",
             "importError": "Error importing. Make sure the file is valid.",
@@ -378,7 +379,14 @@
             "copyLink": "Copy link",
             "linkCopied": "Link copied to clipboard",
             "selectAtLeastOne": "Select at least one video",
-            "tooManyVideos": "Too many videos selected (max 200)"
+            "tooManyVideos": "Too many videos selected (max 200)",
+            "miniplayerVideos": "Miniplayer videos",
+            "inlinePreviews": "Inline previews on Home",
+            "removeFromPlaylist": "Remove from playlist",
+            "confirmRemoveFromPlaylist": "Are you sure you want to remove this video from the playlist? It will remain as an individual video.",
+            "playlistAssociationRemoved": "Playlist association removed",
+            "loading": "Loading",
+            "rendered": "Rendered"
         },
         "en-US": {
             "settings": "Settings",
@@ -415,6 +423,7 @@
             "export": "Export",
             "import": "Import",
             "progressSaved": "Progress saved",
+            "storageFull": "Storage full - Progress cannot be saved",
             "dataExported": "Data exported",
             "itemsImported": "Imported {count} items",
             "importError": "Error importing. Make sure the file is valid.",
@@ -481,7 +490,14 @@
             "copyLink": "Copy link",
             "linkCopied": "Link copied to clipboard",
             "selectAtLeastOne": "Select at least one video",
-            "tooManyVideos": "Too many videos selected (max 200)"
+            "tooManyVideos": "Too many videos selected (max 200)",
+            "miniplayerVideos": "Miniplayer videos",
+            "inlinePreviews": "Inline previews on Home",
+            "removeFromPlaylist": "Remove from playlist",
+            "confirmRemoveFromPlaylist": "Are you sure you want to remove this video from the playlist? It will remain as an individual video.",
+            "playlistAssociationRemoved": "Playlist association removed",
+            "loading": "Loading",
+            "rendered": "Rendered"
         },
         "es-ES": {
             "settings": "Configuración",
@@ -518,6 +534,7 @@
             "export": "Exportar",
             "import": "Importar",
             "progressSaved": "Progreso guardado",
+            "storageFull": "Almacenamiento lleno - No se puede guardar el progreso",
             "dataExported": "Datos exportados",
             "itemsImported": "Importados {count} elementos",
             "importError": "Error al importar. Asegúrate de que el archivo sea válido.",
@@ -584,7 +601,14 @@
             "copyLink": "Copiar enlace",
             "linkCopied": "Enlace copiado al portapapeles",
             "selectAtLeastOne": "Selecciona al menos un video",
-            "tooManyVideos": "Demasiados videos seleccionados (máx 200)"
+            "tooManyVideos": "Demasiados videos seleccionados (máx 200)",
+            "miniplayerVideos": "Vídeos en minirreproductor",
+            "inlinePreviews": "Previsualizaciones en inicio (Home)",
+            "removeFromPlaylist": "Quitar de la lista de reproducción",
+            "confirmRemoveFromPlaylist": "¿Estás seguro de que quieres quitar este vídeo de la lista de reproducción? Se mantendrá como vídeo individual.",
+            "playlistAssociationRemoved": "Asociación de la lista de reproducción eliminada",
+            "loading": "Cargando",
+            "rendered": "Renderizados"
         },
         "es-419": {
             "settings": "Configuración",
@@ -621,6 +645,7 @@
             "export": "Exportar",
             "import": "Importar",
             "progressSaved": "Progreso guardado",
+            "storageFull": "Almacenamiento lleno - No se puede guardar el progreso",
             "dataExported": "Datos exportados",
             "itemsImported": "Se importaron {count} elementos",
             "importError": "Error al importar. Asegúrate de que el archivo sea válido.",
@@ -686,8 +711,15 @@
             "playlistLinkGenerated": "Enlace de lista generado",
             "copyLink": "Copiar enlace",
             "linkCopied": "Enlace copiado al portapapeles",
-            "selectAtLeastOne": "Selecciona al menos un video",
-            "tooManyVideos": "Demasiados videos seleccionados (máx. 200)"
+            "selectAtLeastOne": "Seleccione al menos un video",
+            "tooManyVideos": "Demasiados videos seleccionados (máx. 200)",
+            "miniplayerVideos": "Videos del miniplayer",
+            "inlinePreviews": "Vistas previas en línea",
+            "removeFromPlaylist": "Quitar de la playlist",
+            "confirmRemoveFromPlaylist": "¿Estás seguro de que quieres quitar este video de la playlist?",
+            "playlistAssociationRemoved": "Asociación de playlist eliminada",
+            "loading": "Cargando",
+            "rendered": "renderizados"
         },
         "ca": {
             "settings": "Configuració",
@@ -724,6 +756,7 @@
             "export": "Exporta",
             "import": "Importa",
             "progressSaved": "Progrés desat",
+            "storageFull": "Emmagatzematge ple - No es pot desar el progrés",
             "dataExported": "Dades exportades",
             "itemsImported": "{count} elements importats",
             "importError": "Error a l'importar. Comprova que el fitxer és correcte.",
@@ -790,7 +823,14 @@
             "copyLink": "Copia l'enllaç",
             "linkCopied": "Enllaç copiat al porta-retalls",
             "selectAtLeastOne": "Selecciona almenys un vídeo",
-            "tooManyVideos": "Massa vídeos seleccionats (màx. 200)"
+            "tooManyVideos": "Massa vídeos seleccionats (màx. 200)",
+            "miniplayerVideos": "Vídeos al minireproductor",
+            "inlinePreviews": "Previsualitzacions a l'inici (Home)",
+            "removeFromPlaylist": "Treure de la llista de reproducció",
+            "confirmRemoveFromPlaylist": "Estàs segur que vols treure aquest vídeo de la llista de reproducció? Es mantindrà com a vídeo individual.",
+            "playlistAssociationRemoved": "Associació de la llista de reproducció eliminada",
+            "loading": "Carregant",
+            "rendered": "Renderitzats"
         },
         "fr": {
             "settings": "Paramètres",
@@ -827,6 +867,7 @@
             "export": "Exporter",
             "import": "Importer",
             "progressSaved": "Progrès enregistré",
+            "storageFull": "Stockage plein - Impossible d’enregistrer la progression",
             "dataExported": "Données exportées",
             "itemsImported": "{count} éléments importés",
             "importError": "Erreur lors de l'importation. Assurez-vous que le fichier est valide.",
@@ -893,7 +934,14 @@
             "copyLink": "Copier le lien",
             "linkCopied": "Lien copié dans le presse-papiers",
             "selectAtLeastOne": "Sélectionnez au moins une vidéo",
-            "tooManyVideos": "Trop de vidéos sélectionnées (max 200)"
+            "tooManyVideos": "Trop de vidéos sélectionnées (max 200)",
+            "miniplayerVideos": "Vidéos en mini-lecteur",
+            "inlinePreviews": "Aperçus intégrés sur l’accueil (Home)",
+            "removeFromPlaylist": "Retirer de la playlist",
+            "confirmRemoveFromPlaylist": "Êtes-vous sûr de vouloir retirer cette vidéo de la playlist ? Elle restera comme vidéo individuelle.",
+            "playlistAssociationRemoved": "Association à la playlist supprimée",
+            "loading": "Chargement",
+            "rendered": "Rendus"
         },
         "de": {
             "settings": "Einstellungen",
@@ -930,6 +978,7 @@
             "export": "Exportieren",
             "import": "Importieren",
             "progressSaved": "Fortschritt gespeichert",
+            "storageFull": "Speicher voll - Fortschritt kann nicht gespeichert werden",
             "dataExported": "Daten exportiert",
             "itemsImported": "{count} Elemente importiert",
             "importError": "Fehler beim Importieren. Bitte sicherstellen, dass die Datei gültig ist.",
@@ -996,7 +1045,14 @@
             "copyLink": "Link kopieren",
             "linkCopied": "Link in die Zwischenablage kopiert",
             "selectAtLeastOne": "Wählen Sie mindestens ein Video aus",
-            "tooManyVideos": "Zu viele Videos ausgewählt (max. 200)"
+            "tooManyVideos": "Zu viele Videos ausgewählt (max. 200)",
+            "miniplayerVideos": "Videos im Miniplayer",
+            "inlinePreviews": "Inline-Vorschauen auf der Startseite (Home)",
+            "removeFromPlaylist": "Aus der Playlist entfernen",
+            "confirmRemoveFromPlaylist": "Möchten Sie dieses Video wirklich aus der Playlist entfernen? Es bleibt als einzelnes Video erhalten.",
+            "playlistAssociationRemoved": "Playlist-Zuordnung entfernt",
+            "loading": "Wird geladen",
+            "rendered": "Gerendert"
         },
         "it": {
             "settings": "Impostazioni",
@@ -1033,6 +1089,7 @@
             "export": "Esporta",
             "import": "Importa",
             "progressSaved": "Progresso salvato",
+            "storageFull": "Memoria piena - Impossibile salvare i progressi",
             "dataExported": "Dati esportati",
             "itemsImported": "{count} elementi importati",
             "importError": "Errore durante l'importazione. Assicurati che il file sia valido.",
@@ -1099,7 +1156,14 @@
             "copyLink": "Copia link",
             "linkCopied": "Link copiato negli appunti",
             "selectAtLeastOne": "Seleziona almeno un video",
-            "tooManyVideos": "Troppi video selezionati (max 200)"
+            "tooManyVideos": "Troppi video selezionati (max 200)",
+            "miniplayerVideos": "Video nel mini player",
+            "inlinePreviews": "Anteprime nella Home",
+            "removeFromPlaylist": "Rimuovi dalla playlist",
+            "confirmRemoveFromPlaylist": "Sei sicuro di voler rimuovere questo video dalla playlist? Rimarrà come video singolo.",
+            "playlistAssociationRemoved": "Associazione alla playlist rimossa",
+            "loading": "Caricamento",
+            "rendered": "Renderizzati"
         },
         "pt": {
             "settings": "Configurações",
@@ -1136,6 +1200,7 @@
             "export": "Exportar",
             "import": "Importar",
             "progressSaved": "Progresso salvo",
+            "storageFull": "Armazenamento cheio - Não é possível salvar o progresso",
             "dataExported": "Dados exportados",
             "itemsImported": "{count} itens importados",
             "importError": "Erro ao importar. Verifique se o arquivo é válido.",
@@ -1202,7 +1267,14 @@
             "copyLink": "Copiar link",
             "linkCopied": "Link copiado para a área de transferência",
             "selectAtLeastOne": "Selecione pelo menos um vídeo",
-            "tooManyVideos": "Vídeos demais selecionados (máx. 200)"
+            "tooManyVideos": "Vídeos demais selecionados (máx. 200)",
+            "miniplayerVideos": "Vídeos no miniplayer",
+            "inlinePreviews": "Pré-visualizações na página inicial (Home)",
+            "removeFromPlaylist": "Remover da playlist",
+            "confirmRemoveFromPlaylist": "Tem certeza de que deseja remover este vídeo da playlist? Ele permanecerá como vídeo individual.",
+            "playlistAssociationRemoved": "Associação à playlist removida",
+            "loading": "Carregando",
+            "rendered": "Renderizados"
         },
         "nl": {
             "settings": "Instellingen",
@@ -1239,6 +1311,7 @@
             "export": "Exporteren",
             "import": "Importeren",
             "progressSaved": "Voortgang opgeslagen",
+            "storageFull": "Opslag vol - Voortgang kan niet worden opgeslagen",
             "dataExported": "Gegevens geëxporteerd",
             "itemsImported": "{count} items geïmporteerd",
             "importError": "Fout bij importeren. Zorg dat het bestand geldig is.",
@@ -1305,7 +1378,14 @@
             "copyLink": "Link kopiëren",
             "linkCopied": "Link gekopieerd naar klembord",
             "selectAtLeastOne": "Selecteer ten minste één video",
-            "tooManyVideos": "Te veel video's geselecteerd (max. 200)"
+            "tooManyVideos": "Te veel video's geselecteerd (max. 200)",
+            "miniplayerVideos": "Video's in minispeler",
+            "inlinePreviews": "Inline previews op Home",
+            "removeFromPlaylist": "Verwijderen uit afspeellijst",
+            "confirmRemoveFromPlaylist": "Weet je zeker dat je deze video uit de afspeellijst wilt verwijderen? Deze blijft als individuele video bestaan.",
+            "playlistAssociationRemoved": "Koppeling met afspeellijst verwijderd",
+            "loading": "Laden",
+            "rendered": "Gerenderd"
         },
         "pl": {
             "settings": "Ustawienia",
@@ -1342,6 +1422,7 @@
             "export": "Eksportuj",
             "import": "Importuj",
             "progressSaved": "Postęp zapisany",
+            "storageFull": "Pamięć pełna — Nie można zapisać postępu",
             "dataExported": "Dane wyeksportowano",
             "itemsImported": "Zaimportowano {count} elementów",
             "importError": "Błąd importu. Upewnij się, że plik jest prawidłowy.",
@@ -1408,7 +1489,14 @@
             "copyLink": "Kopiuj link",
             "linkCopied": "Link skopiowany do schowka",
             "selectAtLeastOne": "Wybierz co najmniej jeden film",
-            "tooManyVideos": "Zbyt wiele wybranych filmów (maks. 200)"
+            "tooManyVideos": "Zbyt wiele wybranych filmów (maks. 200)",
+            "miniplayerVideos": "Wideo w miniodtwarzaczu",
+            "inlinePreviews": "Podglądy na stronie głównej (Home)",
+            "removeFromPlaylist": "Usuń z playlisty",
+            "confirmRemoveFromPlaylist": "Czy na pewno chcesz usunąć ten film z playlisty? Pozostanie jako osobny film.",
+            "playlistAssociationRemoved": "Powiązanie z playlistą usunięte",
+            "loading": "Ładowanie",
+            "rendered": "Wyrenderowane"
         },
         "sv": {
             "settings": "Inställningar",
@@ -1445,6 +1533,7 @@
             "export": "Exportera",
             "import": "Importera",
             "progressSaved": "Framsteg sparat",
+            "storageFull": "Lagringen är full – Det går inte att spara framsteg",
             "dataExported": "Data exporterad",
             "itemsImported": "{count} objekt importerade",
             "importError": "Fel vid import. Kontrollera att filen är giltig.",
@@ -1511,7 +1600,14 @@
             "copyLink": "Kopiera länk",
             "linkCopied": "Länk kopierad till urklipp",
             "selectAtLeastOne": "Välj minst en video",
-            "tooManyVideos": "För många videor valda (max 200)"
+            "tooManyVideos": "För många videor valda (max 200)",
+            "miniplayerVideos": "Videor i minispelare",
+            "inlinePreviews": "Förhandsvisningar på startsidan (Home)",
+            "removeFromPlaylist": "Ta bort från spellista",
+            "confirmRemoveFromPlaylist": "Är du säker på att du vill ta bort den här videon från spellistan? Den kommer att finnas kvar som en enskild video.",
+            "playlistAssociationRemoved": "Spellistekoppling borttagen",
+            "loading": "Laddar",
+            "rendered": "Renderade"
         },
         "da": {
             "settings": "Indstillinger",
@@ -1548,6 +1644,7 @@
             "export": "Eksporter",
             "import": "Importer",
             "progressSaved": "Fremskridt gemt",
+            "storageFull": "Lagerplads fuld – Kan ikke gemme fremskridt",
             "dataExported": "Data eksporteret",
             "itemsImported": "{count} elementer importeret",
             "importError": "Fejl ved import. Sørg for, at filen er gyldig.",
@@ -1614,7 +1711,14 @@
             "copyLink": "Kopiér link",
             "linkCopied": "Link kopieret til udklipsholder",
             "selectAtLeastOne": "Vælg mindst én video",
-            "tooManyVideos": "For mange videoer valgt (maks. 200)"
+            "tooManyVideos": "For mange videoer valgt (maks. 200)",
+            "miniplayerVideos": "Videoer i miniafspiller",
+            "inlinePreviews": "Forhåndsvisninger på startsiden (Home)",
+            "removeFromPlaylist": "Fjern fra playliste",
+            "confirmRemoveFromPlaylist": "Er du sikker på, at du vil fjerne denne video fra playlisten? Den forbliver som en individuel video.",
+            "playlistAssociationRemoved": "Playliste-tilknytning fjernet",
+            "loading": "Indlæser",
+            "rendered": "Renderede"
         },
         "no": {
             "settings": "Innstillinger",
@@ -1651,6 +1755,7 @@
             "export": "Eksporter",
             "import": "Importer",
             "progressSaved": "Fremdrift lagret",
+            "storageFull": "Lagring full – Kan ikke lagre fremdrift",
             "dataExported": "Data eksportert",
             "itemsImported": "{count} elementer importert",
             "importError": "Feil ved import. Kontroller at filen er gyldig.",
@@ -1717,7 +1822,14 @@
             "copyLink": "Kopier lenke",
             "linkCopied": "Lenke kopiert til utklippstavlen",
             "selectAtLeastOne": "Velg minst én video",
-            "tooManyVideos": "For mange videoer valgt (maks 200)"
+            "tooManyVideos": "For mange videoer valgt (maks 200)",
+            "miniplayerVideos": "Videoer i minispiller",
+            "inlinePreviews": "Forhåndsvisninger på startsiden (Home)",
+            "removeFromPlaylist": "Fjern fra spilleliste",
+            "confirmRemoveFromPlaylist": "Er du sikker på at du vil fjerne denne videoen fra spillelisten? Den vil forbli som en individuell video.",
+            "playlistAssociationRemoved": "Spilleliste-tilknytning fjernet",
+            "loading": "Laster",
+            "rendered": "Rendret"
         },
         "fi": {
             "settings": "Asetukset",
@@ -1754,6 +1866,7 @@
             "export": "Vie",
             "import": "Tuo",
             "progressSaved": "Edistyminen tallennettu",
+            "storageFull": "Tallennustila täynnä – Edistymistä ei voida tallentaa",
             "dataExported": "Tiedot viety",
             "itemsImported": "Tuotu {count} kohdetta",
             "importError": "Tuontivirhe. Varmista, että tiedosto on kelvollinen.",
@@ -1820,7 +1933,14 @@
             "copyLink": "Kopioi linkki",
             "linkCopied": "Linkki kopioitu leikepöydälle",
             "selectAtLeastOne": "Valitse vähintään yksi video",
-            "tooManyVideos": "Liian monta videota valittu (enint. 200)"
+            "tooManyVideos": "Liian monta videota valittu (enint. 200)",
+            "miniplayerVideos": "Videot minisoittimessa",
+            "inlinePreviews": "Esikatselut etusivulla (Home)",
+            "removeFromPlaylist": "Poista soittolistalta",
+            "confirmRemoveFromPlaylist": "Haluatko varmasti poistaa tämän videon soittolistalta? Se säilyy yksittäisenä videona.",
+            "playlistAssociationRemoved": "Soittolistaliitos poistettu",
+            "loading": "Ladataan",
+            "rendered": "Renderöidyt"
         },
         "cs": {
             "settings": "Nastavení",
@@ -1857,6 +1977,7 @@
             "export": "Exportovat",
             "import": "Importovat",
             "progressSaved": "Postup uložen",
+            "storageFull": "Úložiště je plné – Nelze uložit postup",
             "dataExported": "Data exportována",
             "itemsImported": "Importováno {count} položek",
             "importError": "Chyba importu. Ujistěte se, že je soubor platný.",
@@ -1923,7 +2044,14 @@
             "copyLink": "Kopírovat odkaz",
             "linkCopied": "Odkaz zkopírován do schránky",
             "selectAtLeastOne": "Vyberte alespoň jedno video",
-            "tooManyVideos": "Příliš mnoho vybraných videí (max. 200)"
+            "tooManyVideos": "Příliš mnoho vybraných videí (max. 200)",
+            "miniplayerVideos": "Videa v minipřehrávači",
+            "inlinePreviews": "Náhledy na domovské stránce (Home)",
+            "removeFromPlaylist": "Odebrat z playlistu",
+            "confirmRemoveFromPlaylist": "Opravdu chcete odebrat toto video z playlistu? Zůstane jako samostatné video.",
+            "playlistAssociationRemoved": "Přiřazení k playlistu bylo odstraněno",
+            "loading": "Načítání",
+            "rendered": "Vykresleno"
         },
         "sk": {
             "settings": "Nastavenia",
@@ -1960,6 +2088,7 @@
             "export": "Exportovať",
             "import": "Importovať",
             "progressSaved": "Postup uložený",
+            "storageFull": "Úložisko je plné – Nie je možné uložiť priebeh",
             "dataExported": "Údaje exportované",
             "itemsImported": "Importovaných {count} položiek",
             "importError": "Chyba importu. Uistite sa, že súbor je platný.",
@@ -2026,7 +2155,14 @@
             "copyLink": "Kopírovať odkaz",
             "linkCopied": "Odkaz skopírovaný do schránky",
             "selectAtLeastOne": "Vyberte aspoň jedno video",
-            "tooManyVideos": "Príliš veľa vybraných videí (max. 200)"
+            "tooManyVideos": "Príliš veľa vybraných videí (max. 200)",
+            "miniplayerVideos": "Videá v miniprehrávači",
+            "inlinePreviews": "Náhľady na domovskej stránke (Home)",
+            "removeFromPlaylist": "Odstrániť z playlistu",
+            "confirmRemoveFromPlaylist": "Naozaj chcete odstrániť toto video z playlistu? Zostane ako samostatné video.",
+            "playlistAssociationRemoved": "Prepojenie s playlistom bolo odstránené",
+            "loading": "Načítava sa",
+            "rendered": "Vykreslené"
         },
         "hu": {
             "settings": "Beállítások",
@@ -2063,6 +2199,7 @@
             "export": "Exportálás",
             "import": "Importálás",
             "progressSaved": "Előrehaladás mentve",
+            "storageFull": "Tárhely megtelt – A folyamat nem menthető",
             "dataExported": "Adatok exportálva",
             "itemsImported": "{count} elem importálva",
             "importError": "Importálási hiba. Győződj meg róla, hogy a fájl érvényes.",
@@ -2129,7 +2266,14 @@
             "copyLink": "Link másolása",
             "linkCopied": "Link a vágólapra másolva",
             "selectAtLeastOne": "Válasszon ki legalább egy videót",
-            "tooManyVideos": "Túl sok videó kiválasztva (max. 200)"
+            "tooManyVideos": "Túl sok videó kiválasztva (max. 200)",
+            "miniplayerVideos": "Videók minilejátszóban",
+            "inlinePreviews": "Előnézetek a kezdőlapon (Home)",
+            "removeFromPlaylist": "Eltávolítás a lejátszási listáról",
+            "confirmRemoveFromPlaylist": "Biztosan el szeretnéd távolítani ezt a videót a lejátszási listáról? Önálló videóként megmarad.",
+            "playlistAssociationRemoved": "Lejátszási lista-hozzárendelés eltávolítva",
+            "loading": "Betöltés",
+            "rendered": "Renderelve"
         },
         "ro": {
             "settings": "Setări",
@@ -2166,6 +2310,7 @@
             "export": "Exportă",
             "import": "Importă",
             "progressSaved": "Progres salvat",
+            "storageFull": "Spațiu de stocare plin – Progresul nu poate fi salvat",
             "dataExported": "Date exportate",
             "itemsImported": "{count} elemente importate",
             "importError": "Eroare la import. Asigură-te că fișierul este valid.",
@@ -2232,7 +2377,14 @@
             "copyLink": "Copiază linkul",
             "linkCopied": "Link copiat în clipboard",
             "selectAtLeastOne": "Selectează cel puțin un videoclip",
-            "tooManyVideos": "Prea multe videoclipuri selectate (max. 200)"
+            "tooManyVideos": "Prea multe videoclipuri selectate (max. 200)",
+            "miniplayerVideos": "Videoclipuri în miniplayer",
+            "inlinePreviews": "Previzualizări pe pagina principală (Home)",
+            "removeFromPlaylist": "Elimină din playlist",
+            "confirmRemoveFromPlaylist": "Sigur doriți să eliminați acest videoclip din playlist? Va rămâne ca videoclip individual.",
+            "playlistAssociationRemoved": "Asocierea cu playlistul a fost eliminată",
+            "loading": "Se încarcă",
+            "rendered": "Randate"
         },
         "bg": {
             "settings": "Настройки",
@@ -2269,6 +2421,7 @@
             "export": "Експортирай",
             "import": "Импортирай",
             "progressSaved": "Напредъкът е запазен",
+            "storageFull": "Паметта е пълна – Напредъкът не може да бъде запазен",
             "dataExported": "Данните са експортирани",
             "itemsImported": "Импортирани {count} елемента",
             "importError": "Грешка при импортиране. Уверете се, че файлът е валиден.",
@@ -2335,7 +2488,14 @@
             "copyLink": "Копирай линк",
             "linkCopied": "Линкът е копиран в клипборда",
             "selectAtLeastOne": "Избери поне едно видео",
-            "tooManyVideos": "Твърде много избрани видеа (макс. 200)"
+            "tooManyVideos": "Твърде много избрани видеа (макс. 200)",
+            "miniplayerVideos": "Видеа в миниплейър",
+            "inlinePreviews": "Прегледи на началната страница (Home)",
+            "removeFromPlaylist": "Премахни от плейлиста",
+            "confirmRemoveFromPlaylist": "Сигурни ли сте, че искате да премахнете това видео от плейлиста? То ще остане като отделно видео.",
+            "playlistAssociationRemoved": "Асоциацията с плейлиста е премахната",
+            "loading": "Зареждане",
+            "rendered": "Рендерирани"
         },
         "el": {
             "settings": "Ρυθμίσεις",
@@ -2372,6 +2532,7 @@
             "export": "Εξαγωγή",
             "import": "Εισαγωγή",
             "progressSaved": "Η πρόοδος αποθηκεύτηκε",
+            "storageFull": "Ο αποθηκευτικός χώρος είναι πλήρης – Δεν είναι δυνατή η αποθήκευση της προόδου",
             "dataExported": "Τα δεδομένα εξήχθησαν",
             "itemsImported": "Εισήχθησαν {count} στοιχεία",
             "importError": "Σφάλμα εισαγωγής. Βεβαιωθείτε ότι το αρχείο είναι έγκυρο.",
@@ -2438,7 +2599,14 @@
             "copyLink": "Αντιγραφή συνδέσμου",
             "linkCopied": "Ο σύνδεσμος αντιγράφηκε στο πρόχειρο",
             "selectAtLeastOne": "Επιλέξτε τουλάχιστον ένα βίντεο",
-            "tooManyVideos": "Πάρα πολλά βίντεο επιλέχθηκαν (μέγ. 200)"
+            "tooManyVideos": "Πάρα πολλά βίντεο επιλέχθηκαν (μέγ. 200)",
+            "miniplayerVideos": "Βίντεο σε mini player",
+            "inlinePreviews": "Προεπισκοπήσεις στην αρχική σελίδα (Home)",
+            "removeFromPlaylist": "Αφαίρεση από τη λίστα αναπαραγωγής",
+            "confirmRemoveFromPlaylist": "Είστε βέβαιοι ότι θέλετε να αφαιρέσετε αυτό το βίντεο από τη λίστα αναπαραγωγής; Θα παραμείνει ως μεμονωμένο βίντεο.",
+            "playlistAssociationRemoved": "Η συσχέτιση με τη λίστα αναπαραγωγής αφαιρέθηκε",
+            "loading": "Φόρτωση",
+            "rendered": "Αποδομένα"
         },
         "sr": {
             "settings": "Подешавања",
@@ -2475,6 +2643,7 @@
             "export": "Извези",
             "import": "Увези",
             "progressSaved": "Напредак сачуван",
+            "storageFull": "Складиште је пуно – Напредак није могуће сачувати",
             "dataExported": "Подаци извезени",
             "itemsImported": "Увезено {count} ставки",
             "importError": "Грешка при увозу. Проверите да ли је датотека исправна.",
@@ -2541,7 +2710,14 @@
             "copyLink": "Копирај линк",
             "linkCopied": "Линк је копиран у клипборд",
             "selectAtLeastOne": "Изаберите бар један видео",
-            "tooManyVideos": "Превише изабраних видео снимака (макс. 200)"
+            "tooManyVideos": "Превише изабраних видео снимака (макс. 200)",
+            "miniplayerVideos": "Видео снимци у мини плејеру",
+            "inlinePreviews": "Прегледи на почетној страници (Home)",
+            "removeFromPlaylist": "Уклони са плејлисте",
+            "confirmRemoveFromPlaylist": "Да ли сте сигурни да желите да уклоните овај видео са плејлисте? Остаће као појединачни видео.",
+            "playlistAssociationRemoved": "Повезаност са плејлистом је уклоњена",
+            "loading": "Учитавање",
+            "rendered": "Рендеровано"
         },
         "hr": {
             "settings": "Postavke",
@@ -2578,6 +2754,7 @@
             "export": "Izvezi",
             "import": "Uvezi",
             "progressSaved": "Napredak spremljen",
+            "storageFull": "Pohrana je puna – Napredak se ne može spremiti",
             "dataExported": "Podaci izvezeni",
             "itemsImported": "Uvezeno {count} stavki",
             "importError": "Pogreška pri uvozu. Provjeri je li datoteka valjana.",
@@ -2644,7 +2821,14 @@
             "copyLink": "Kopiraj poveznicu",
             "linkCopied": "Poveznica kopirana u međuspremnik",
             "selectAtLeastOne": "Odaberi barem jedan video",
-            "tooManyVideos": "Previše odabranih videozapisa (maks. 200)"
+            "tooManyVideos": "Previše odabranih videozapisa (maks. 200)",
+            "miniplayerVideos": "Videozapisi u mini reproduktoru",
+            "inlinePreviews": "Pretpregledi na početnoj stranici (Home)",
+            "removeFromPlaylist": "Ukloni s playliste",
+            "confirmRemoveFromPlaylist": "Jeste li sigurni da želite ukloniti ovaj video s playliste? Ostat će kao pojedinačni video.",
+            "playlistAssociationRemoved": "Povezanost s playlistom je uklonjena",
+            "loading": "Učitavanje",
+            "rendered": "Renderirani"
         },
         "sl": {
             "settings": "Nastavitve",
@@ -2681,6 +2865,7 @@
             "export": "Izvozi",
             "import": "Uvozi",
             "progressSaved": "Napredek shranjen",
+            "storageFull": "Shramba je polna – Napredka ni mogoče shraniti",
             "dataExported": "Podatki izvoženi",
             "itemsImported": "Uvoženih {count} elementov",
             "importError": "Napaka pri uvozu. Preveri veljavnost datoteke.",
@@ -2747,7 +2932,14 @@
             "copyLink": "Kopiraj povezavo",
             "linkCopied": "Povezava kopirana v odložišče",
             "selectAtLeastOne": "Izberite vsaj en videoposnetek",
-            "tooManyVideos": "Preveč izbranih videoposnetkov (največ 200)"
+            "tooManyVideos": "Preveč izbranih videoposnetkov (največ 200)",
+            "miniplayerVideos": "Videoposnetki v mini predvajalniku",
+            "inlinePreviews": "Predogledi na domači strani (Home)",
+            "removeFromPlaylist": "Odstrani s seznama predvajanja",
+            "confirmRemoveFromPlaylist": "Ali ste prepričani, da želite odstraniti ta video s seznama predvajanja? Ostal bo kot posamezen video.",
+            "playlistAssociationRemoved": "Povezava s seznamom predvajanja je odstranjena",
+            "loading": "Nalaganje",
+            "rendered": "Izrisani"
         },
         "lt": {
             "settings": "Nustatymai",
@@ -2784,6 +2976,7 @@
             "export": "Eksportuoti",
             "import": "Importuoti",
             "progressSaved": "Progresas išsaugotas",
+            "storageFull": "Saugykla pilna – Nepavyko išsaugoti progreso",
             "dataExported": "Duomenys eksportuoti",
             "itemsImported": "Importuota {count} elementų",
             "importError": "Importavimo klaida. Įsitikinkite, kad failas galiojantis.",
@@ -2850,7 +3043,14 @@
             "copyLink": "Kopijuoti nuorodą",
             "linkCopied": "Nuoroda nukopijuota į iškarpinę",
             "selectAtLeastOne": "Pasirinkite bent vieną vaizdo įrašą",
-            "tooManyVideos": "Per daug pasirinktų vaizdo įrašų (maks. 200)"
+            "tooManyVideos": "Per daug pasirinktų vaizdo įrašų (maks. 200)",
+            "miniplayerVideos": "Vaizdo įrašai mini grotuve",
+            "inlinePreviews": "Peržiūros pagrindiniame puslapyje (Home)",
+            "removeFromPlaylist": "Pašalinti iš grojaraščio",
+            "confirmRemoveFromPlaylist": "Ar tikrai norite pašalinti šį vaizdo įrašą iš grojaraščio? Jis liks kaip atskiras vaizdo įrašas.",
+            "playlistAssociationRemoved": "Grojaraščio susiejimas pašalintas",
+            "loading": "Įkeliama",
+            "rendered": "Sugeneruoti"
         },
         "lv": {
             "settings": "Iestatījumi",
@@ -2887,6 +3087,7 @@
             "export": "Eksportēt",
             "import": "Importēt",
             "progressSaved": "Progress saglabāts",
+            "storageFull": "Krātuve ir pilna – Nevar saglabāt progresu",
             "dataExported": "Dati eksportēti",
             "itemsImported": "Importēti {count} vienumi",
             "importError": "Importēšanas kļūda. Pārliecinieties, ka fails ir derīgs.",
@@ -2953,7 +3154,14 @@
             "copyLink": "Kopēt saiti",
             "linkCopied": "Saite iekopēta starpliktuvē",
             "selectAtLeastOne": "Atlasiet vismaz vienu video",
-            "tooManyVideos": "Pārāk daudz atlasīto video (maks. 200)"
+            "tooManyVideos": "Pārāk daudz atlasīto video (maks. 200)",
+            "miniplayerVideos": "Video mini atskaņotājā",
+            "inlinePreviews": "Priekšskatījumi sākumlapā (Home)",
+            "removeFromPlaylist": "Noņemt no atskaņošanas saraksta",
+            "confirmRemoveFromPlaylist": "Vai tiešām vēlaties noņemt šo video no atskaņošanas saraksta? Tas paliks kā atsevišķs video.",
+            "playlistAssociationRemoved": "Saistība ar atskaņošanas sarakstu noņemta",
+            "loading": "Ielāde",
+            "rendered": "Renderēti"
         },
         "uk": {
             "settings": "Налаштування",
@@ -2990,6 +3198,7 @@
             "export": "Експортувати",
             "import": "Імпортувати",
             "progressSaved": "Прогрес збережено",
+            "storageFull": "Сховище заповнене – Неможливо зберегти прогрес",
             "dataExported": "Дані експортовано",
             "itemsImported": "Імпортовано {count} елементів",
             "importError": "Помилка імпорту. Переконайтеся, що файл дійсний.",
@@ -3056,7 +3265,14 @@
             "copyLink": "Копіювати посилання",
             "linkCopied": "Посилання скопійовано в буфер обміну",
             "selectAtLeastOne": "Виберіть принаймні одне відео",
-            "tooManyVideos": "Забагато вибраних відео (макс. 200)"
+            "tooManyVideos": "Забагато вибраних відео (макс. 200)",
+            "miniplayerVideos": "Відео в мініплеєрі",
+            "inlinePreviews": "Попередній перегляд на головній сторінці (Home)",
+            "removeFromPlaylist": "Видалити з плейлиста",
+            "confirmRemoveFromPlaylist": "Ви впевнені, що хочете видалити це відео з плейлиста? Воно залишиться як окреме відео.",
+            "playlistAssociationRemoved": "Зв’язок із плейлистом видалено",
+            "loading": "Завантаження",
+            "rendered": "Відрендерено"
         },
         "ru": {
             "settings": "Настройки",
@@ -3093,6 +3309,7 @@
             "export": "Экспорт",
             "import": "Импорт",
             "progressSaved": "Прогресс сохранён",
+            "storageFull": "Хранилище заполнено — Невозможно сохранить прогресс",
             "dataExported": "Данные экспортированы",
             "itemsImported": "Импортировано элементов: {count}",
             "importError": "Ошибка импорта. Убедитесь, что файл действителен.",
@@ -3159,7 +3376,14 @@
             "copyLink": "Копировать ссылку",
             "linkCopied": "Ссылка скопирована в буфер обмена",
             "selectAtLeastOne": "Выберите хотя бы одно видео",
-            "tooManyVideos": "Слишком много выбранных видео (макс. 200)"
+            "tooManyVideos": "Слишком много выбранных видео (макс. 200)",
+            "miniplayerVideos": "Видео в мини-плеере",
+            "inlinePreviews": "Предпросмотры на главной странице (Home)",
+            "removeFromPlaylist": "Удалить из плейлиста",
+            "confirmRemoveFromPlaylist": "Вы уверены, что хотите удалить это видео из плейлиста? Оно останется как отдельное видео.",
+            "playlistAssociationRemoved": "Связь с плейлистом удалена",
+            "loading": "Загрузка",
+            "rendered": "Отрендерены"
         },
         "tr": {
             "settings": "Ayarlar",
@@ -3196,6 +3420,7 @@
             "export": "Dışa aktar",
             "import": "İçe aktar",
             "progressSaved": "İlerleme kaydedildi",
+            "storageFull": "Depolama dolu – İlerleme kaydedilemiyor",
             "dataExported": "Veriler dışa aktarıldı",
             "itemsImported": "{count} öğe içe aktarıldı",
             "importError": "İçe aktarma hatası. Dosyanın geçerli olduğundan emin olun.",
@@ -3262,7 +3487,14 @@
             "copyLink": "Bağlantıyı kopyala",
             "linkCopied": "Bağlantı panoya kopyalandı",
             "selectAtLeastOne": "En az bir video seçin",
-            "tooManyVideos": "Çok fazla video seçildi (maks. 200)"
+            "tooManyVideos": "Çok fazla video seçildi (maks. 200)",
+            "miniplayerVideos": "Mini oynatıcıda videolar",
+            "inlinePreviews": "Ana sayfada satır içi önizlemeler (Home)",
+            "removeFromPlaylist": "Oynatma listesinden kaldır",
+            "confirmRemoveFromPlaylist": "Bu videoyu oynatma listesinden kaldırmak istediğinizden emin misiniz? Bireysel video olarak kalacaktır.",
+            "playlistAssociationRemoved": "Oynatma listesi ilişkilendirmesi kaldırıldı",
+            "loading": "Yükleniyor",
+            "rendered": "Oluşturuldu"
         },
         "ar": {
             "settings": "الإعدادات",
@@ -3299,6 +3531,7 @@
             "export": "تصدير",
             "import": "استيراد",
             "progressSaved": "تم حفظ التقدم",
+            "storageFull": "التخزين ممتلئ - لا يمكن حفظ التقدم",
             "dataExported": "تم تصدير البيانات",
             "itemsImported": "تم استيراد {count} عنصر",
             "importError": "حدث خطأ أثناء الاستيراد. تأكد من أن الملف صالح.",
@@ -3365,7 +3598,14 @@
             "copyLink": "نسخ الرابط",
             "linkCopied": "تم نسخ الرابط إلى الحافظة",
             "selectAtLeastOne": "اختر فيديو واحدًا على الأقل",
-            "tooManyVideos": "تم تحديد فيديوهات كثيرة جدًا (الحد الأقصى 200)"
+            "tooManyVideos": "تم تحديد فيديوهات كثيرة جدًا (الحد الأقصى 200)",
+            "miniplayerVideos": "مقاطع الفيديو في المشغل المصغر",
+            "inlinePreviews": "معاينات مضمنة في الصفحة الرئيسية (Home)",
+            "removeFromPlaylist": "إزالة من قائمة التشغيل",
+            "confirmRemoveFromPlaylist": "هل أنت متأكد أنك تريد إزالة هذا الفيديو من قائمة التشغيل؟ سيبقى كفيديو فردي.",
+            "playlistAssociationRemoved": "تمت إزالة ارتباط قائمة التشغيل",
+            "loading": "جارٍ التحميل",
+            "rendered": "تم العرض"
         },
         "fa": {
             "settings": "تنظیمات",
@@ -3402,6 +3642,7 @@
             "export": "خروجی گرفتن",
             "import": "وارد کردن",
             "progressSaved": "پیشرفت ذخیره شد",
+            "storageFull": "فضای ذخیره‌سازی پر است - امکان ذخیره پیشرفت وجود ندارد",
             "dataExported": "داده‌ها خروجی گرفته شدند",
             "itemsImported": "{count} مورد وارد شد",
             "importError": "خطا در وارد کردن. از معتبر بودن فایل اطمینان حاصل کنید.",
@@ -3468,7 +3709,14 @@
             "copyLink": "کپی کردن لینک",
             "linkCopied": "لینک در کلیپ‌بورد کپی شد",
             "selectAtLeastOne": "حداقل یک ویدیو انتخاب کنید",
-            "tooManyVideos": "ویدیوهای زیادی انتخاب شده (حداکثر ۲۰۰)"
+            "tooManyVideos": "ویدیوهای زیادی انتخاب شده (حداکثر ۲۰۰)",
+            "miniplayerVideos": "ویدیوها در پخش‌کننده کوچک",
+            "inlinePreviews": "پیش‌نمایش‌های درون‌خطی در صفحه اصلی (Home)",
+            "removeFromPlaylist": "حذف از فهرست پخش",
+            "confirmRemoveFromPlaylist": "آیا مطمئن هستید که می‌خواهید این ویدیو را از فهرست پخش حذف کنید؟ به‌صورت ویدیوی جداگانه باقی می‌ماند.",
+            "playlistAssociationRemoved": "ارتباط با فهرست پخش حذف شد",
+            "loading": "در حال بارگذاری",
+            "rendered": "رندر شده"
         },
         "he": {
             "settings": "הגדרות",
@@ -3505,6 +3753,7 @@
             "export": "ייצא",
             "import": "ייבא",
             "progressSaved": "התקדמות נשמרה",
+            "storageFull": "האחסון מלא - לא ניתן לשמור את ההתקדמות",
             "dataExported": "הנתונים יוצאו",
             "itemsImported": "יובאו {count} פריטים",
             "importError": "שגיאה בייבוא. ודא שהקובץ תקין.",
@@ -3571,7 +3820,14 @@
             "copyLink": "העתק קישור",
             "linkCopied": "הקישור הועתק ללוח",
             "selectAtLeastOne": "בחר לפחות סרטון אחד",
-            "tooManyVideos": "נבחרו יותר מדי סרטונים (מקסימום 200)"
+            "tooManyVideos": "נבחרו יותר מדי סרטונים (מקסימום 200)",
+            "miniplayerVideos": "סרטונים במיני-נגן",
+            "inlinePreviews": "תצוגות מקדימות בדף הבית (Home)",
+            "removeFromPlaylist": "הסר מרשימת ההשמעה",
+            "confirmRemoveFromPlaylist": "האם אתה בטוח שברצונך להסיר סרטון זה מרשימת ההשמעה? הוא יישאר כסרטון בודד.",
+            "playlistAssociationRemoved": "הקישור לרשימת ההשמעה הוסר",
+            "loading": "טוען",
+            "rendered": "עובדו"
         },
         "hi": {
             "settings": "सेटिंग्स",
@@ -3608,6 +3864,7 @@
             "export": "निर्यात",
             "import": "आयात",
             "progressSaved": "प्रगति सहेजी गई",
+            "storageFull": "स्टोरेज भरा हुआ है - प्रगति सहेजी नहीं जा सकती",
             "dataExported": "डेटा निर्यात किया गया",
             "itemsImported": "{count} आइटम आयात किए गए",
             "importError": "आयात त्रुटि। सुनिश्चित करें कि फ़ाइल मान्य है।",
@@ -3674,7 +3931,14 @@
             "copyLink": "लिंक कॉपी करें",
             "linkCopied": "लिंक क्लिपबोर्ड में कॉपी हो गया",
             "selectAtLeastOne": "कम से कम एक वीडियो चुनें",
-            "tooManyVideos": "बहुत सारे वीडियो चुने गए (अधिकतम 200)"
+            "tooManyVideos": "बहुत सारे वीडियो चुने गए (अधिकतम 200)",
+            "miniplayerVideos": "मिनी प्लेयर में वीडियो",
+            "inlinePreviews": "होम पर इनलाइन प्रीव्यू (Home)",
+            "removeFromPlaylist": "प्लेलिस्ट से हटाएं",
+            "confirmRemoveFromPlaylist": "क्या आप वाकई इस वीडियो को प्लेलिस्ट से हटाना चाहते हैं? यह एकल वीडियो के रूप में बना रहेगा।",
+            "playlistAssociationRemoved": "प्लेलिस्ट संबंध हटाया गया",
+            "loading": "लोड हो रहा है",
+            "rendered": "रेंडर किया गया"
         },
         "bn": {
             "settings": "সেটিংস",
@@ -3711,6 +3975,7 @@
             "export": "রপ্তানি",
             "import": "আমদানি",
             "progressSaved": "অগ্রগতি সংরক্ষিত",
+            "storageFull": "স্টোরেজ পূর্ণ - অগ্রগতি সংরক্ষণ করা যায়নি",
             "dataExported": "ডেটা রপ্তানি হয়েছে",
             "itemsImported": "{count}টি আইটেম আমদানি হয়েছে",
             "importError": "আমদানি ত্রুটি। নিশ্চিত করুন ফাইলটি বৈধ।",
@@ -3777,7 +4042,14 @@
             "copyLink": "লিঙ্ক কপি করুন",
             "linkCopied": "লিঙ্ক ক্লিপবোর্ডে কপি হয়েছে",
             "selectAtLeastOne": "কমপক্ষে একটি ভিডিও নির্বাচন করুন",
-            "tooManyVideos": "অনেক বেশি ভিডিও নির্বাচিত (সর্বোচ্চ ২০০)"
+            "tooManyVideos": "অনেক বেশি ভিডিও নির্বাচিত (সর্বোচ্চ ২০০)",
+            "miniplayerVideos": "মিনি প্লেয়ারে ভিডিও",
+            "inlinePreviews": "হোমে ইনলাইন প্রিভিউ (Home)",
+            "removeFromPlaylist": "প্লেলিস্ট থেকে সরান",
+            "confirmRemoveFromPlaylist": "আপনি কি নিশ্চিত যে এই ভিডিওটি প্লেলিস্ট থেকে সরাতে চান? এটি পৃথক ভিডিও হিসেবে থাকবে।",
+            "playlistAssociationRemoved": "প্লেলিস্ট সংযোগ সরানো হয়েছে",
+            "loading": "লোড হচ্ছে",
+            "rendered": "রেন্ডার করা হয়েছে"
         },
         "te": {
             "settings": "సెట్టింగులు",
@@ -3814,6 +4086,7 @@
             "export": "ఎక్స్‌పోర్ట్",
             "import": "ఇంపోర్ట్",
             "progressSaved": "ప్రగతి సేవ్ చేయబడింది",
+            "storageFull": "స్టోరేజ్ నిండిపోయింది - పురోగతిని సేవ్ చేయలేము",
             "dataExported": "డేటా ఎక్స్‌పోర్ట్ చేయబడింది",
             "itemsImported": "{count} ఐటెంలు ఇంపోర్ట్ చేయబడ్డాయి",
             "importError": "ఇంపోర్ట్ లో లోపం. ఫైల్ సరియైనదో తనిఖీ చేయండి.",
@@ -3880,7 +4153,14 @@
             "copyLink": "లింక్ కాపీ చేయండి",
             "linkCopied": "లింక్ క్లిప్‌బోర్డ్‌కు కాపీ అయింది",
             "selectAtLeastOne": "కనీసం ఒక వీడియో ఎంచుకోండి",
-            "tooManyVideos": "చాలా ఎక్కువ వీడియోలు ఎంచుకున్నారు (గరిష్టం 200)"
+            "tooManyVideos": "చాలా ఎక్కువ వీడియోలు ఎంచుకున్నారు (గరిష్టం 200)",
+            "miniplayerVideos": "మినీ ప్లేయర్‌లో వీడియోలు",
+            "inlinePreviews": "హోమ్‌లో ఇన్‌లైన్ ప్రీవ్యూలు (Home)",
+            "removeFromPlaylist": "ప్లేలిస్ట్ నుండి తొలగించండి",
+            "confirmRemoveFromPlaylist": "ఈ వీడియోను ప్లేలిస్ట్ నుండి తొలగించాలనుకుంటున్నారా? ఇది వ్యక్తిగత వీడియోగా మిగులుతుంది.",
+            "playlistAssociationRemoved": "ప్లేలిస్ట్ అనుబంధం తొలగించబడింది",
+            "loading": "లోడ్ అవుతోంది",
+            "rendered": "రెండర్ చేయబడింది"
         },
         "ta": {
             "settings": "அமைப்புகள்",
@@ -3917,6 +4197,7 @@
             "export": "ஏற்றுமதி",
             "import": "இறக்குமதி",
             "progressSaved": "முன்னேற்றம் சேமிக்கப்பட்டது",
+            "storageFull": "சேமிப்பு நிரம்பியுள்ளது - முன்னேற்றத்தை சேமிக்க முடியாது",
             "dataExported": "தரவு ஏற்றுமதி செய்யப்பட்டது",
             "itemsImported": "{count} உருப்படிகள் இறக்குமதி செய்யப்பட்டன",
             "importError": "இறக்குமதியில் பிழை. கோப்பு செல்லுபடியாக இருப்பதை உறுதி செய்யவும்.",
@@ -3983,7 +4264,14 @@
             "copyLink": "இணைப்பை நகலெடு",
             "linkCopied": "இணைப்பு கிளிப்போர்டுக்கு நகலெடுக்கப்பட்டது",
             "selectAtLeastOne": "குறைந்தது ஒரு வீடியோவைத் தேர்ந்தெடு",
-            "tooManyVideos": "மிக அதிக வீடியோக்கள் தேர்ந்தெடுக்கப்பட்டன (அதிகபட்சம் 200)"
+            "tooManyVideos": "மிக அதிக வீடியோக்கள் தேர்ந்தெடுக்கப்பட்டன (அதிகபட்சம் 200)",
+            "miniplayerVideos": "மினி பிளேயரில் வீடியோக்கள்",
+            "inlinePreviews": "முகப்புப் பக்கத்தில் உள்ளமை முன்னோட்டங்கள் (Home)",
+            "removeFromPlaylist": "ப்ளேலிஸ்டில் இருந்து நீக்கு",
+            "confirmRemoveFromPlaylist": "இந்த வீடியோவை ப்ளேலிஸ்டில் இருந்து நீக்க விரும்புகிறீர்களா? இது தனி வீடியோவாக இருக்கும்.",
+            "playlistAssociationRemoved": "ப்ளேலிஸ்ட் தொடர்பு நீக்கப்பட்டது",
+            "loading": "ஏற்றுகிறது",
+            "rendered": "ரெண்டர் செய்யப்பட்டது"
         },
         "mr": {
             "settings": "सेटिंग्ज",
@@ -4020,6 +4308,7 @@
             "export": "निर्यात करा",
             "import": "आयात करा",
             "progressSaved": "प्रगती जतन झाली",
+            "storageFull": "स्टोरेज भरले आहे - प्रगती जतन करता येत नाही",
             "dataExported": "डेटा निर्यात झाला",
             "itemsImported": "{count} वस्तू आयात केल्या",
             "importError": "आयात करताना त्रुटी. फाइल योग्य आहे याची खात्री करा.",
@@ -4086,7 +4375,14 @@
             "copyLink": "लिंक कॉपी करा",
             "linkCopied": "लिंक क्लिपबोर्डवर कॉपी झाली",
             "selectAtLeastOne": "किमान एक व्हिडिओ निवडा",
-            "tooManyVideos": "खूप जास्त व्हिडिओ निवडले (कमाल २००)"
+            "tooManyVideos": "खूप जास्त व्हिडिओ निवडले (कमाल २००)",
+            "miniplayerVideos": "मिनी प्लेयरमधील व्हिडिओ",
+            "inlinePreviews": "होमवर इनलाइन पूर्वावलोकने (Home)",
+            "removeFromPlaylist": "प्लेलिस्टमधून काढा",
+            "confirmRemoveFromPlaylist": "आपण हा व्हिडिओ प्लेलिस्टमधून काढू इच्छिता का? तो स्वतंत्र व्हिडिओ म्हणून राहील.",
+            "playlistAssociationRemoved": "प्लेलिस्ट संबंध काढला गेला",
+            "loading": "लोड होत आहे",
+            "rendered": "रेंडर केले"
         },
         "zh": {
             "settings": "设置",
@@ -4123,6 +4419,7 @@
             "export": "导出",
             "import": "导入",
             "progressSaved": "进度已保存",
+            "storageFull": "存储空间已满 - 无法保存进度",
             "dataExported": "数据已导出",
             "itemsImported": "已导入 {count} 项",
             "importError": "导入出错。请确保文件有效。",
@@ -4189,7 +4486,14 @@
             "copyLink": "复制链接",
             "linkCopied": "链接已复制到剪贴板",
             "selectAtLeastOne": "至少选择一个视频",
-            "tooManyVideos": "选择视频过多（最多 200 个）"
+            "tooManyVideos": "选择视频过多（最多 200 个）",
+            "miniplayerVideos": "迷你播放器中的视频",
+            "inlinePreviews": "首页中的内嵌预览 (Home)",
+            "removeFromPlaylist": "从播放列表中移除",
+            "confirmRemoveFromPlaylist": "确定要将此视频从播放列表中移除吗？它将保留为单个视频。",
+            "playlistAssociationRemoved": "播放列表关联已移除",
+            "loading": "加载中",
+            "rendered": "已渲染"
         },
         "zh-TW": {
             "settings": "設定",
@@ -4226,6 +4530,7 @@
             "export": "匯出",
             "import": "匯入",
             "progressSaved": "進度已儲存",
+            "storageFull": "儲存空間已滿 - 無法儲存進度",
             "dataExported": "資料已匯出",
             "itemsImported": "已匯入 {count} 個項目",
             "importError": "匯入錯誤。請確認檔案是否有效。",
@@ -4292,7 +4597,14 @@
             "copyLink": "複製連結",
             "linkCopied": "連結已複製到剪貼簿",
             "selectAtLeastOne": "至少選擇一個影片",
-            "tooManyVideos": "選擇過多影片（最多 200 個）"
+            "tooManyVideos": "選擇過多影片（最多 200 個）",
+            "miniplayerVideos": "迷你播放器中的影片",
+            "inlinePreviews": "首頁中的內嵌預覽 (Home)",
+            "removeFromPlaylist": "從播放清單中移除",
+            "confirmRemoveFromPlaylist": "確定要將此影片從播放清單中移除嗎？它將保留為個別影片。",
+            "playlistAssociationRemoved": "播放清單關聯已移除",
+            "loading": "載入中",
+            "rendered": "已轉譯"
         },
         "yue": {
             "settings": "設定",
@@ -4329,6 +4641,7 @@
             "export": "匯出",
             "import": "匯入",
             "progressSaved": "進度已儲存",
+            "storageFull": "儲存空間已滿 - 無法儲存進度",
             "dataExported": "資料已匯出",
             "itemsImported": "已匯入 {count} 項",
             "importError": "匯入錯誤。請確認檔案正確。",
@@ -4395,7 +4708,14 @@
             "copyLink": "複製連結",
             "linkCopied": "連結已複製到剪貼簿",
             "selectAtLeastOne": "至少選擇一個影片",
-            "tooManyVideos": "選擇過多影片（最多 200 個）"
+            "tooManyVideos": "選擇過多影片（最多 200 個）",
+            "miniplayerVideos": "迷你播放器中的影片",
+            "inlinePreviews": "首頁中的內嵌預覽 (Home)",
+            "removeFromPlaylist": "從播放清單中移除",
+            "confirmRemoveFromPlaylist": "確定要將此影片從播放清單中移除嗎？它將保留為個別影片。",
+            "playlistAssociationRemoved": "播放清單關聯已移除",
+            "loading": "載入中",
+            "rendered": "已轉譯"
         },
         "zh-HK": {
             "settings": "設定",
@@ -4432,6 +4752,7 @@
             "export": "匯出",
             "import": "匯入",
             "progressSaved": "進度已儲存",
+            "storageFull": "儲存空間已滿 - 無法儲存進度",
             "dataExported": "資料已匯出",
             "itemsImported": "已匯入 {count} 項",
             "importError": "匯入錯誤，請確認檔案有效。",
@@ -4498,7 +4819,14 @@
             "copyLink": "複製連結",
             "linkCopied": "連結已複製到剪貼簿",
             "selectAtLeastOne": "至少選擇一個影片",
-            "tooManyVideos": "選擇過多影片（最多 200 個）"
+            "tooManyVideos": "選擇過多影片（最多 200 個）",
+            "miniplayerVideos": "迷你播放器中的影片",
+            "inlinePreviews": "首頁中的內嵌預覽 (Home)",
+            "removeFromPlaylist": "從播放清單中移除",
+            "confirmRemoveFromPlaylist": "確定要將此影片從播放清單中移除嗎？它將保留為個別影片。",
+            "playlistAssociationRemoved": "播放清單關聯已移除",
+            "loading": "載入中",
+            "rendered": "已轉譯"
         },
         "ja": {
             "settings": "設定",
@@ -4535,6 +4863,7 @@
             "export": "エクスポート",
             "import": "インポート",
             "progressSaved": "進行状況を保存しました",
+            "storageFull": "ストレージがいっぱいです - 進行状況を保存できません",
             "dataExported": "データをエクスポートしました",
             "itemsImported": "{count} 項目をインポートしました",
             "importError": "インポートエラー。ファイルが有効であることを確認してください。",
@@ -4601,7 +4930,14 @@
             "copyLink": "リンクをコピー",
             "linkCopied": "リンクがクリップボードにコピーされました",
             "selectAtLeastOne": "少なくとも1つの動画を選択してください",
-            "tooManyVideos": "選択された動画が多すぎます（最大200）"
+            "tooManyVideos": "選択された動画が多すぎます（最大200）",
+            "miniplayerVideos": "ミニプレーヤーの動画",
+            "inlinePreviews": "ホームのインラインプレビュー (Home)",
+            "removeFromPlaylist": "プレイリストから削除",
+            "confirmRemoveFromPlaylist": "この動画をプレイリストから削除してもよろしいですか？個別の動画として残ります。",
+            "playlistAssociationRemoved": "プレイリストの関連付けが削除されました",
+            "loading": "読み込み中",
+            "rendered": "レンダリング済み"
         },
         "ko": {
             "settings": "설정",
@@ -4638,6 +4974,7 @@
             "export": "내보내기",
             "import": "가져오기",
             "progressSaved": "진행 상황 저장됨",
+            "storageFull": "저장 공간이 가득 찼습니다 - 진행 상황을 저장할 수 없습니다",
             "dataExported": "데이터 내보내기 완료",
             "itemsImported": "{count}개 항목 가져옴",
             "importError": "가져오기 오류. 파일이 올바른지 확인하세요.",
@@ -4704,7 +5041,14 @@
             "copyLink": "링크 복사",
             "linkCopied": "링크가 클립보드에 복사됨",
             "selectAtLeastOne": "최소 하나의 동영상을 선택하세요",
-            "tooManyVideos": "선택된 동영상이 너무 많습니다 (최대 200개)"
+            "tooManyVideos": "선택된 동영상이 너무 많습니다 (최대 200개)",
+            "miniplayerVideos": "미니 플레이어의 동영상",
+            "inlinePreviews": "홈의 인라인 미리보기 (Home)",
+            "removeFromPlaylist": "재생목록에서 제거",
+            "confirmRemoveFromPlaylist": "이 동영상을 재생목록에서 제거하시겠습니까? 개별 동영상으로 유지됩니다.",
+            "playlistAssociationRemoved": "재생목록 연결이 제거되었습니다",
+            "loading": "로딩 중",
+            "rendered": "렌더링됨"
         },
         "th": {
             "settings": "การตั้งค่า",
@@ -4741,6 +5085,7 @@
             "export": "ส่งออก",
             "import": "นำเข้า",
             "progressSaved": "บันทึกความคืบหน้าแล้ว",
+            "storageFull": "พื้นที่เก็บข้อมูลเต็ม - ไม่สามารถบันทึกความคืบหน้าได้",
             "dataExported": "ส่งออกข้อมูลเรียบร้อย",
             "itemsImported": "นำเข้า {count} รายการแล้ว",
             "importError": "เกิดข้อผิดพลาดในการนำเข้า ตรวจสอบว่าไฟล์ถูกต้อง",
@@ -4807,7 +5152,14 @@
             "copyLink": "คัดลอกลิงก์",
             "linkCopied": "คัดลอกลิงก์ไปยังคลิปบอร์ดแล้ว",
             "selectAtLeastOne": "เลือกวิดีโออย่างน้อยหนึ่งรายการ",
-            "tooManyVideos": "เลือกวิดีโอมากเกินไป (สูงสุด 200)"
+            "tooManyVideos": "เลือกวิดีโอมากเกินไป (สูงสุด 200)",
+            "miniplayerVideos": "วิดีโอในมินิเพลเยอร์",
+            "inlinePreviews": "ตัวอย่างแบบอินไลน์บนหน้าแรก (Home)",
+            "removeFromPlaylist": "ลบออกจากเพลย์ลิสต์",
+            "confirmRemoveFromPlaylist": "คุณแน่ใจหรือไม่ว่าต้องการลบวิดีโอนี้ออกจากเพลย์ลิสต์? วิดีโอนี้จะยังคงเป็นวิดีโอเดี่ยว",
+            "playlistAssociationRemoved": "การเชื่อมโยงเพลย์ลิสต์ถูกลบแล้ว",
+            "loading": "กำลังโหลด",
+            "rendered": "แสดงผลแล้ว"
         },
         "vi": {
             "settings": "Cài đặt",
@@ -4844,6 +5196,7 @@
             "export": "Xuất",
             "import": "Nhập",
             "progressSaved": "Đã lưu tiến trình",
+            "storageFull": "Bộ nhớ đầy - Không thể lưu tiến trình",
             "dataExported": "Dữ liệu đã xuất",
             "itemsImported": "Đã nhập {count} mục",
             "importError": "Lỗi nhập. Hãy đảm bảo tệp hợp lệ.",
@@ -4910,7 +5263,14 @@
             "copyLink": "Sao chép liên kết",
             "linkCopied": "Liên kết đã được sao chép vào bộ nhớ tạm",
             "selectAtLeastOne": "Chọn ít nhất một video",
-            "tooManyVideos": "Quá nhiều video được chọn (tối đa 200)"
+            "tooManyVideos": "Quá nhiều video được chọn (tối đa 200)",
+            "miniplayerVideos": "Video trong trình phát mini",
+            "inlinePreviews": "Bản xem trước trên trang chủ (Home)",
+            "removeFromPlaylist": "Xóa khỏi danh sách phát",
+            "confirmRemoveFromPlaylist": "Bạn có chắc chắn muốn xóa video này khỏi danh sách phát không? Video sẽ vẫn là video riêng lẻ.",
+            "playlistAssociationRemoved": "Liên kết danh sách phát đã được xóa",
+            "loading": "Đang tải",
+            "rendered": "Đã kết xuất"
         },
         "id": {
             "settings": "Pengaturan",
@@ -4947,6 +5307,7 @@
             "export": "Ekspor",
             "import": "Impor",
             "progressSaved": "Progres tersimpan",
+            "storageFull": "Penyimpanan penuh - Kemajuan tidak dapat disimpan",
             "dataExported": "Data diekspor",
             "itemsImported": "{count} item diimpor",
             "importError": "Kesalahan impor. Pastikan file valid.",
@@ -5013,7 +5374,14 @@
             "copyLink": "Salin tautan",
             "linkCopied": "Tautan disalin ke papan klip",
             "selectAtLeastOne": "Pilih setidaknya satu video",
-            "tooManyVideos": "Terlalu banyak video yang dipilih (maks. 200)"
+            "tooManyVideos": "Terlalu banyak video yang dipilih (maks. 200)",
+            "miniplayerVideos": "Video di pemutar mini",
+            "inlinePreviews": "Pratinjau sebaris di Beranda (Home)",
+            "removeFromPlaylist": "Hapus dari playlist",
+            "confirmRemoveFromPlaylist": "Apakah Anda yakin ingin menghapus video ini dari playlist? Video akan tetap sebagai video individu.",
+            "playlistAssociationRemoved": "Asosiasi playlist dihapus",
+            "loading": "Memuat",
+            "rendered": "Dirender"
         },
         "ms": {
             "settings": "Tetapan",
@@ -5050,6 +5418,7 @@
             "export": "Eksport",
             "import": "Import",
             "progressSaved": "Kemajuan disimpan",
+            "storageFull": "Storan penuh - Kemajuan tidak dapat disimpan",
             "dataExported": "Data dieksport",
             "itemsImported": "{count} item diimport",
             "importError": "Ralat import. Pastikan fail sah.",
@@ -5116,7 +5485,14 @@
             "copyLink": "Salin pautan",
             "linkCopied": "Pautan disalin ke papan keratan",
             "selectAtLeastOne": "Pilih sekurang-kurangnya satu video",
-            "tooManyVideos": "Terlalu banyak video dipilih (maks. 200)"
+            "tooManyVideos": "Terlalu banyak video dipilih (maks. 200)",
+            "miniplayerVideos": "Video dalam pemain mini",
+            "inlinePreviews": "Pratonton sebaris di Laman Utama (Home)",
+            "removeFromPlaylist": "Alih keluar daripada senarai main",
+            "confirmRemoveFromPlaylist": "Adakah anda pasti mahu mengalih keluar video ini daripada senarai main? Ia akan kekal sebagai video individu.",
+            "playlistAssociationRemoved": "Perkaitan senarai main telah dialih keluar",
+            "loading": "Memuatkan",
+            "rendered": "Dirender"
         },
         "tl": {
             "settings": "Mga Setting",
@@ -5153,6 +5529,7 @@
             "export": "I-export",
             "import": "I-import",
             "progressSaved": "Na-save ang Progreso",
+            "storageFull": "Puno na ang storage - Hindi mase-save ang progreso",
             "dataExported": "Na-export ang Data",
             "itemsImported": "Na-import ang {count} na item",
             "importError": "Error sa pag-import. Tiyaking tama ang file.",
@@ -5219,7 +5596,14 @@
             "copyLink": "Kopyahin ang link",
             "linkCopied": "Nakopya na ang link sa clipboard",
             "selectAtLeastOne": "Pumili ng kahit isang video",
-            "tooManyVideos": "Masyadong maraming napiling video (max 200)"
+            "tooManyVideos": "Masyadong maraming napiling video (max 200)",
+            "miniplayerVideos": "Mga video sa mini player",
+            "inlinePreviews": "Mga inline preview sa Home",
+            "removeFromPlaylist": "Alisin sa playlist",
+            "confirmRemoveFromPlaylist": "Sigurado ka bang gusto mong alisin ang video na ito sa playlist? Mananatili ito bilang hiwalay na video.",
+            "playlistAssociationRemoved": "Inalis ang pagkakaugnay sa playlist",
+            "loading": "Naglo-load",
+            "rendered": "Na-render"
         },
         "my": {
             "settings": "ဆက်တင်များ",
@@ -5256,6 +5640,7 @@
             "export": "တင်ပို့ရန်",
             "import": "တင်သွင်းရန်",
             "progressSaved": "တိုးတက်မှု သိမ်းဆည်းပြီးပါပြီ",
+            "storageFull": "သိုလှောင်မှု ပြည့်နေသည် - တိုးတက်မှုကို သိမ်းဆည်း၍ မရပါ",
             "dataExported": "ဒေတာ တင်ပို့ပြီးပါပြီ",
             "itemsImported": "{count} အရာများ တင်သွင်းပြီး",
             "importError": "တင်သွင်းမှုအမှား။ ဖိုင်မှန်ကန်ကြောင်း အတည်ပြုပါ။",
@@ -5322,7 +5707,14 @@
             "copyLink": "လင့်ခ်ကူးယူပါ",
             "linkCopied": "လင့်ခ်ကို ကလစ်ဘုတ်သို့ ကူးယူပြီး",
             "selectAtLeastOne": "အနည်းဆုံး ဗီဒီယိုတစ်ခုရွေးပါ",
-            "tooManyVideos": "ရွေးထားသော ဗီဒီယိုများလွန်းသည် (အများဆုံး ၂၀၀)"
+            "tooManyVideos": "ရွေးထားသော ဗီဒီယိုများလွန်းသည် (အများဆုံး ၂၀၀)",
+            "miniplayerVideos": "မီနီပလေယာရှိ ဗီဒီယိုများ",
+            "inlinePreviews": "ပင်မစာမျက်နှာရှိ အတွင်းပါ အကြိုကြည့်ရှုမှုများ (Home)",
+            "removeFromPlaylist": "ပလေယာစာရင်းမှ ဖယ်ရှားရန်",
+            "confirmRemoveFromPlaylist": "ဤဗီဒီယိုကို ပလေယာစာရင်းမှ ဖယ်ရှားလိုသည်မှာ သေချာပါသလား။ ၎င်းသည် သီးခြားဗီဒီယိုအဖြစ် ဆက်လက်ရှိနေမည်ဖြစ်သည်။",
+            "playlistAssociationRemoved": "ပလေယာစာရင်း ချိတ်ဆက်မှု ဖယ်ရှားပြီး",
+            "loading": "ဖွင့်နေသည်",
+            "rendered": "တင်ဆက်ပြီး"
         },
         "sw": {
             "settings": "Mipangilio",
@@ -5359,6 +5751,7 @@
             "export": "Hamisha",
             "import": "Leta",
             "progressSaved": "Maendeleo yamehifadhiwa",
+            "storageFull": "Hifadhi imejaa - Haiwezekani kuhifadhi maendeleo",
             "dataExported": "Data imehamishwa",
             "itemsImported": "Vitu {count} vimeletwa",
             "importError": "Hitilafu ya kuleta. Hakikisha faili ni sahihi.",
@@ -5425,7 +5818,14 @@
             "copyLink": "Nakili kiungo",
             "linkCopied": "Kiungo kimenakiliwa kwenye ubao wa kunakili",
             "selectAtLeastOne": "Chagua angalau video moja",
-            "tooManyVideos": "Video nyingi sana zimechaguliwa (maks. 200)"
+            "tooManyVideos": "Video nyingi sana zimechaguliwa (maks. 200)",
+            "miniplayerVideos": "Video kwenye kicheza kidogo",
+            "inlinePreviews": "Muhtasari wa ndani kwenye ukurasa wa nyumbani (Home)",
+            "removeFromPlaylist": "Ondoa kwenye orodha ya kucheza",
+            "confirmRemoveFromPlaylist": "Je, una uhakika unataka kuondoa video hii kwenye orodha ya kucheza? Itabaki kama video ya pekee.",
+            "playlistAssociationRemoved": "Muunganiko wa orodha ya kucheza umeondolewa",
+            "loading": "Inapakia",
+            "rendered": "Zimetolewa"
         },
         "am": {
             "settings": "ማስተካከያ",
@@ -5462,6 +5862,7 @@
             "export": "ዋስትና ውጤት",
             "import": "ጫን",
             "progressSaved": "እድገት ተቀምጧል",
+            "storageFull": "ማከማቻ ሙሉ ነው - ሂደትን ማስቀመጥ አይቻልም",
             "dataExported": "መረጃ ወጥቷል",
             "itemsImported": "{count} ንጥሎች ጫነዋል",
             "importError": "ጫን ላይ አስቸጋሪ ስህተት። ፋይሉ ትክክል እንደሆነ ያረጋግጡ።",
@@ -5528,7 +5929,14 @@
             "copyLink": "ሊንኩን ቅዳ",
             "linkCopied": "ሊንኩ ወደ ክሊፕቦርድ ተቀድቷል",
             "selectAtLeastOne": "ቢያንስ አንድ ቪዲዮ ምረጥ",
-            "tooManyVideos": "በጣም ብዙ ቪዲዮዎች ተመርጠዋል (ከፍተኛ 200)"
+            "tooManyVideos": "በጣም ብዙ ቪዲዮዎች ተመርጠዋል (ከፍተኛ 200)",
+            "miniplayerVideos": "ቪዲዮዎች በሚኒ ማጫወቻ",
+            "inlinePreviews": "በመነሻ ገጽ ላይ የውስጥ ቅድመ እይታ (Home)",
+            "removeFromPlaylist": "ከፕሌይሊስት አስወግድ",
+            "confirmRemoveFromPlaylist": "ይህን ቪዲዮ ከፕሌይሊስት ማስወገድ እርግጠኛ ነዎት? እንደ ብቻ ቪዲዮ ይቀራል።",
+            "playlistAssociationRemoved": "የፕሌይሊስት ግንኙነት ተወግዷል",
+            "loading": "በመጫን ላይ",
+            "rendered": "ተቀርቧል"
         },
         "ha": {
             "settings": "Saituna",
@@ -5565,6 +5973,7 @@
             "export": "Fitarwa",
             "import": "Shigo",
             "progressSaved": "Ci gaban an adana",
+            "storageFull": "Ma'ajiya ta cika - Ba za a iya adana ci gaba ba",
             "dataExported": "Bayanan an fitar",
             "itemsImported": "An shigo da {count} abubuwa",
             "importError": "Kuskure yayin shigo da. Tabbatar fayil ɗin daidai ne.",
@@ -5631,7 +6040,14 @@
             "copyLink": "Kwafi hanyar haɗi",
             "linkCopied": "An kwafi hanyar haɗi zuwa allo",
             "selectAtLeastOne": "Zaɓi aƙalla bidiyo ɗaya",
-            "tooManyVideos": "Bidiyoyi da yawa sun zaɓu (iyaka 200)"
+            "tooManyVideos": "Bidiyoyi da yawa sun zaɓu (iyaka 200)",
+            "miniplayerVideos": "Bidiyo a ƙaramin mai kunnawa",
+            "inlinePreviews": "Duban kai tsaye a shafin gida (Home)",
+            "removeFromPlaylist": "Cire daga jerin waƙoƙi",
+            "confirmRemoveFromPlaylist": "Ka tabbata kana son cire wannan bidiyon daga jerin waƙoƙi? Zai kasance a matsayin bidiyo ɗaya.",
+            "playlistAssociationRemoved": "An cire haɗin jerin waƙoƙi",
+            "loading": "Ana lodawa",
+            "rendered": "An nuna"
         },
         "ur": {
             "settings": "ترتیبات",
@@ -5668,6 +6084,7 @@
             "export": "برآمد کریں",
             "import": "درآمد کریں",
             "progressSaved": "پیش رفت محفوظ ہو گئی",
+            "storageFull": "اسٹوریج بھر گیا ہے - پیش رفت محفوظ نہیں کی جا سکتی",
             "dataExported": "ڈیٹا برآمد ہو گیا",
             "itemsImported": "{count} اشیاء درآمد کی گئیں",
             "importError": "درآمد میں خرابی۔ یقینی بنائیں کہ فائل درست ہے۔",
@@ -5734,7 +6151,14 @@
             "copyLink": "لنک کاپی کریں",
             "linkCopied": "لنک کلپ بورڈ میں کاپی ہو گیا",
             "selectAtLeastOne": "کم از کم ایک ویڈیو منتخب کریں",
-            "tooManyVideos": "بہت ساری ویڈیوز منتخب ہوئیں (زیادہ سے زیادہ 200)"
+            "tooManyVideos": "بہت ساری ویڈیوز منتخب ہوئیں (زیادہ سے زیادہ 200)",
+            "miniplayerVideos": "منی پلیئر میں ویڈیوز",
+            "inlinePreviews": "ہوم پر ان لائن پیش نظارے (Home)",
+            "removeFromPlaylist": "پلے لسٹ سے ہٹائیں",
+            "confirmRemoveFromPlaylist": "کیا آپ واقعی اس ویڈیو کو پلے لسٹ سے ہٹانا چاہتے ہیں؟ یہ ایک علیحدہ ویڈیو کے طور پر رہے گی۔",
+            "playlistAssociationRemoved": "پلے لسٹ کا تعلق ہٹا دیا گیا",
+            "loading": "لوڈ ہو رہا ہے",
+            "rendered": "رینڈر کیا گیا"
         },
         "zu": {
             "settings": "Izilungiselelo",
@@ -5771,6 +6195,7 @@
             "export": "Thumela",
             "import": "Ngenisa",
             "progressSaved": "Inqubekela phambili igcinwe",
+            "storageFull": "Isitoreji sigcwele - Inqubekelaphambili ayikwazi ukulondolozwa",
             "dataExported": "Idatha ithunyelwe",
             "itemsImported": "Izinto {count} zingenisiwe",
             "importError": "Iphutha ekungeniseni. Qinisekisa ukuthi ifayela lilungile.",
@@ -5837,7 +6262,14 @@
             "copyLink": "Kopisha isixhumanisi",
             "linkCopied": "Isixhumanisi sikopishelwe ebhodini lokubhala",
             "selectAtLeastOne": "Khetha okungenani ividiyo eyodwa",
-            "tooManyVideos": "Kuningi kakhulu amavidiyo akhethiwe (ubuningi 200)"
+            "tooManyVideos": "Kuningi kakhulu amavidiyo akhethiwe (ubuningi 200)",
+            "miniplayerVideos": "Amavidiyo kusidlali esincane",
+            "inlinePreviews": "Ukubuka kuqala ku-Home",
+            "removeFromPlaylist": "Susa ku-playlist",
+            "confirmRemoveFromPlaylist": "Uqinisekile ukuthi ufuna ukususa le vidiyo ku-playlist? Izohlala njengevidiyo eyodwa.",
+            "playlistAssociationRemoved": "Ukuhlotshaniswa kwe-playlist kususiwe",
+            "loading": "Iyalayisha",
+            "rendered": "Kukhonjisiwe"
         }
     }
 }

--- a/youtube-playback-plox.meta.js
+++ b/youtube-playback-plox.meta.js
@@ -111,7 +111,7 @@
 // @description:es-419  Guarda y reanuda automáticamente el progreso de reproducción de videos en YouTube sin necesidad de iniciar sesión.
 // @homepage     https://github.com/Alplox/Youtube-Playback-Plox
 // @supportURL   https://github.com/Alplox/Youtube-Playback-Plox/issues
-// @version      0.0.7-3
+// @version      0.0.8
 // @author       Alplox
 // @match        https://www.youtube.com/*
 // @exclude      https://www.youtube.com/live_chat*

--- a/youtube-playback-plox.meta.js
+++ b/youtube-playback-plox.meta.js
@@ -111,9 +111,10 @@
 // @description:es-419  Guarda y reanuda automáticamente el progreso de reproducción de videos en YouTube sin necesidad de iniciar sesión.
 // @homepage     https://github.com/Alplox/Youtube-Playback-Plox
 // @supportURL   https://github.com/Alplox/Youtube-Playback-Plox/issues
-// @version      0.0.7-2
+// @version      0.0.7-3
 // @author       Alplox
 // @match        https://www.youtube.com/*
+// @exclude      https://www.youtube.com/live_chat*
 // @icon         https://raw.githubusercontent.com/Alplox/StartpagePlox/refs/heads/main/assets/favicon/favicon.ico
 // @grant        GM_getValue
 // @grant        GM_setValue
@@ -124,5 +125,5 @@
 // @license      MIT
 // @downloadURL  https://raw.githubusercontent.com/Alplox/Youtube-Playback-Plox/refs/heads/main/youtube-playback-plox.user.js
 // @updateURL    https://raw.githubusercontent.com/Alplox/Youtube-Playback-Plox/refs/heads/main/youtube-playback-plox.meta.js
-// @require      https://update.greasyfork.org/scripts/549881/1684270/YouTube%20Helper%20API.js
+// @require      https://update.greasyfork.org/scripts/549881/1708128/YouTube%20Helper%20API.js
 // ==/UserScript==

--- a/youtube-playback-plox.meta.js
+++ b/youtube-playback-plox.meta.js
@@ -118,6 +118,8 @@
 // @icon         https://raw.githubusercontent.com/Alplox/StartpagePlox/refs/heads/main/assets/favicon/favicon.ico
 // @grant        GM_getValue
 // @grant        GM_setValue
+// @grant        GM_deleteValue
+// @grant        GM_listValues
 // @grant        GM_registerMenuCommand
 // @grant        GM_xmlhttpRequest
 // @run-at       document-end

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -7857,6 +7857,8 @@ background: var(--ypp-danger);
     // MARK: 📺 Get Playlist Name
     const playlistNameCache = new Map();
     const pendingPlaylistRequests = new Map(); // Track pending HTTP requests
+    const playlistNameFetchCooldowns = new Map();
+    const PLAYLIST_NAME_FETCH_COOLDOWN_MS = 15 * 60 * 1000;
     // Helper para búsqueda profunda en objetos JSON
     const findDeepInObject = (obj, key) => {
         if (!obj || typeof obj !== 'object') return null;
@@ -7884,6 +7886,17 @@ background: var(--ypp-danger);
         }
 
         return null;
+    };
+
+    /**
+     * Determina si se debe evitar una nueva solicitud HTTP del título de playlist.
+     * @param {string} playlistId - ID de la playlist.
+     * @returns {boolean} True si la petición debe ser aplazada.
+     */
+    const shouldThrottlePlaylistNameFetch = (playlistId) => {
+        const lastAttempt = playlistNameFetchCooldowns.get(playlistId);
+        if (!lastAttempt) return false;
+        return (Date.now() - lastAttempt) < PLAYLIST_NAME_FETCH_COOLDOWN_MS;
     };
 
     /**
@@ -7959,8 +7972,13 @@ background: var(--ypp-danger);
             }
 
             // Solo hacer HTTP request si no hay cache válido o si el cache es genérico
+            if (shouldThrottlePlaylistNameFetch(playlistId)) {
+                log('getPlaylistName', `⏳ Cooldown activo para ${playlistId}, evitando nueva solicitud`);
+                return playlistNameCache.get(playlistId) || playlistId;
+            }
             return new Promise((resolve) => {
                 log('getPlaylistName', `🌐 Making HTTP request for playlist ${playlistId}`);
+                playlistNameFetchCooldowns.set(playlistId, Date.now());
                 GM_xmlhttpRequest({
                     method: 'GET',
                     url: `https://www.youtube.com/playlist?list=${playlistId}`,

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -111,7 +111,7 @@
 // @description:es-419  Guarda y reanuda automáticamente el progreso de reproducción de videos en YouTube sin necesidad de iniciar sesión.
 // @homepage     https://github.com/Alplox/Youtube-Playback-Plox
 // @supportURL   https://github.com/Alplox/Youtube-Playback-Plox/issues
-// @version      0.0.7-3
+// @version      0.0.8
 // @author       Alplox
 // @match        https://www.youtube.com/*
 // @exclude      https://www.youtube.com/live_chat*
@@ -218,7 +218,7 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
     // URL del archivo de traducciones
     const TRANSLATIONS_URL = 'https://raw.githubusercontent.com/Alplox/Youtube-Playback-Plox/refs/heads/main/translations.json';
     const TRANSLATIONS_URL_BACKUP = 'https://cdn.jsdelivr.net/gh/Alplox/Youtube-Playback-Plox@refs/heads/main/translations.json';
-    const TRANSLATIONS_EXPECTED_VERSION = '0.0.7-3';
+    const TRANSLATIONS_EXPECTED_VERSION = '0.0.8';
 
     // Variables globales para las traducciones
     let TRANSLATIONS = {};

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -137,7 +137,7 @@
 
     // Sistema de niveles: silent(0), error(1), warn(2), info(3), debug(4)
     const LEVELS = { silent: 0, error: 1, warn: 2, info: 3, debug: 4 };
-    let currentLevel = LEVELS.debug; // Cambiar a 'debug' para ver todo, o 'warn'/'error' para menos
+    let currentLevel = LEVELS.warn; // Cambiar a 'debug' para ver todo, o 'warn'/'error' para menos
 
     const styleFor = (kind) => {
         switch (kind) {
@@ -6033,9 +6033,10 @@ background: var(--ypp-danger);
                 thumbnail: `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
                 duration,
                 views: shortsMeta.views || null,
-                description: null,
+                /* description: null,
                 published: null,
-                isLive: false
+                isLive: false */
+                videoType: 'shorts'
             };
         };
 
@@ -6457,6 +6458,16 @@ background: var(--ypp-danger);
         // En Shorts, NUNCA usar datos de miniplayer o watch.
         // Buscar SOLO en el metapanel del Short ACTIVO.
         if (pageType === 'shorts') {
+            // 5a: Usar extractShortsMetadata() (consolidada, busca dentro del metapanel activo)
+            try {
+                const shortsMeta = extractShortsMetadata();
+                if (shortsMeta.author && shortsMeta.author.length > 0 && !isPlaceholder(shortsMeta.author)) {
+                    log('getVideoAuthor', `Autor Shorts (extractShortsMetadata): ${shortsMeta.author}`);
+                    return shortsMeta.author;
+                }
+            } catch (_) { }
+
+            // 5b: Fallback con selectores DOM adicionales fuera del metapanel
             try {
                 const shortsAuthor =
                     // Metapanel del Short ACTIVO (máxima prioridad)
@@ -6674,7 +6685,7 @@ background: var(--ypp-danger);
      * @returns {Object} { title: string|null, views: string|null, channelId: string|null }
      */
     function extractShortsMetadata() {
-        const result = { title: null, views: null, channelId: null };
+        const result = { title: null, views: null, channelId: null, author: null };
 
         try {
             // PASO 1: Buscar el contenedor raíz del metapanel activo
@@ -6706,6 +6717,21 @@ background: var(--ypp-danger);
                 const text = source.selector?.textContent?.trim();
                 if (text && text.length > 1) {
                     result.title = text;
+                    break;
+                }
+            }
+
+            // PASO 2.5: Extraer AUTOR desde el metapanel
+            const authorSelectors = [
+                { selector: metapanel.querySelector('#channel-name a'), name: '#channel-name a' },
+                { selector: metapanel.querySelector('a[href*="/@"]'), name: 'a[href*="/@"]' },
+                { selector: metapanel.querySelector('a[href*="/channel/"]'), name: 'a[href*="/channel/"]' }
+            ];
+
+            for (const source of authorSelectors) {
+                const text = source.selector?.textContent?.trim();
+                if (text && text.length > 0 && !isPlaceholder(text)) {
+                    result.author = text;
                     break;
                 }
             }
@@ -6823,7 +6849,7 @@ background: var(--ypp-danger);
 
                                 const description = microformat?.description?.simpleText;
                                 if (description) data.description = description.trim();
-                                warn('fetchwatchmeta', data)
+                                log('fetchwatchmeta', data)
                             }
                         } catch {
                             // Ignore JSON parse errors
@@ -7055,6 +7081,24 @@ background: var(--ypp-danger);
             author = getVideoAuthor(player);
         }
 
+        // Enriquecimiento asíncrono: si el autor sigue siendo 'unknown' en Shorts,
+        // intentar obtenerlo desde fetchWatchMeta (YouTube watch page JSON)
+        if (ptV === 'shorts' && (!author || author === t('unknown') || isPlaceholder(author)) && videoId) {
+            try {
+                const watchMeta = await getWatchMetaCached(videoId);
+                if (watchMeta?.author && !isPlaceholder(watchMeta.author)) {
+                    log('getVideoInfo', `🔄 Shorts: Autor enriquecido desde fetchWatchMeta: "${watchMeta.author}"`);
+                    author = watchMeta.author;
+                }
+                // También enriquecer authorId si no lo tenemos
+                if (watchMeta?.authorId) {
+                    log('getVideoInfo', `🔄 Shorts: AuthorId enriquecido desde fetchWatchMeta: "${watchMeta.authorId}"`);
+                }
+            } catch (_) {
+                log('getVideoInfo', `⚠️ Shorts: Error al enriquecer autor desde fetchWatchMeta para ${videoId}`);
+            }
+        }
+
         // Thumbnail
         let thumb = getVideoThumbnail(videoId)
         log('getVideoInfo', ' 📺 Thumbnail= ', thumb)
@@ -7225,11 +7269,28 @@ background: var(--ypp-danger);
                     if (sViews) viewsNumber = sViews;
                 }
             } catch (_) { }
-            // Fallback seguro: usar meta de la página watch del mismo ID SOLO para vistas (no título/autor)
+            // Fallback seguro: usar meta de la página watch del mismo ID para datos faltantes
             try {
-                if (!viewsNumber || viewsNumber === t('notAvailable')) {
+                const needsAuthor = !author || author === t('unknown') || isPlaceholder(author);
+                const needsAuthorId = !authorId || authorId === t('unknown');
+                const needsViews = !viewsNumber || viewsNumber === t('notAvailable');
+
+                if (needsAuthor || needsAuthorId || needsViews) {
                     const metaForShort = await getWatchMetaCached(videoId);
-                    if (metaForShort && metaForShort.viewsNumber) viewsNumber = metaForShort.viewsNumber;
+                    if (metaForShort) {
+                        if (needsViews && metaForShort.viewsNumber) {
+                            viewsNumber = metaForShort.viewsNumber;
+                            log('getVideoInfo', `🔄 Shorts: Vistas enriquecidas desde fetchWatchMeta: "${viewsNumber}"`);
+                        }
+                        if (needsAuthor && metaForShort.author && !isPlaceholder(metaForShort.author)) {
+                            author = metaForShort.author;
+                            log('getVideoInfo', `🔄 Shorts: Autor enriquecido desde fetchWatchMeta (authorId block): "${author}"`);
+                        }
+                        if (needsAuthorId && metaForShort.authorId) {
+                            authorId = metaForShort.authorId;
+                            log('getVideoInfo', `🔄 Shorts: AuthorId enriquecido desde fetchWatchMeta: "${authorId}"`);
+                        }
+                    }
                 }
             } catch (_) { }
         } else {
@@ -8913,6 +8974,7 @@ background: var(--ypp-danger);
                 }
             } else if (isCleanWatch && prevSaved?.lastViewedPlaylistId) {
                 log('updateStatus', `🧼 Cleaning up stale playlist association because current URL has no list.`);
+                playlistToPersist = null;
             }
 
             // LLAMADA AL NUEVO SISTEMA: Detección de tipo + guardado especializado
@@ -9863,9 +9925,9 @@ background: var(--ypp-danger);
 
         containerSavingOptions.appendChild(savingOptionsTitle)
         containerSavingOptions.appendChild(saveRegularVideosLabel);
+        containerSavingOptions.appendChild(saveMiniplayerVideosLabel);
         containerSavingOptions.appendChild(saveShortsLabel);
         containerSavingOptions.appendChild(saveLiveStreamsLabel);
-        containerSavingOptions.appendChild(saveMiniplayerVideosLabel);
         containerSavingOptions.appendChild(saveInlinePreviewsLabel);
 
         savingOptions.appendChild(containerSavingOptions)
@@ -12272,6 +12334,36 @@ background: var(--ypp-danger);
             });
         }
 
+        // Resolver títulos estables para Mix (RD...) usando el video semilla (RD{videoId}) cuando el título es genérico
+        const videoTitleById = new Map();
+        for (const item of allItems) {
+            if (!item?.videoId) continue;
+            const title = item.info?.title;
+            if (typeof title === 'string' && title.trim().length > 0) {
+                videoTitleById.set(item.videoId, title.trim());
+            }
+        }
+
+        // Publicar en cache global del modal para que createVideoEntry pueda usarlo
+        modalVideoTitleById.clear();
+        for (const [id, title] of videoTitleById) {
+            modalVideoTitleById.set(id, title);
+        }
+        for (const item of allItems) {
+            if (item?.type !== 'playlist-video') continue;
+            const playlistKey = item.playlistKey;
+            if (!playlistKey || !playlistKey.startsWith('RD')) continue;
+
+            const currentTitle = item.playlistTitle || playlistKey;
+            if (currentTitle !== playlistKey) continue; // ya hay un título real (o al menos no genérico)
+
+            const seedVideoId = playlistKey.slice(2);
+            const seedTitle = videoTitleById.get(seedVideoId);
+            if (seedTitle) {
+                item.playlistTitle = `Mix - ${seedTitle}`;
+            }
+        }
+
         // Aplicar filtros
         let filteredItems = allItems.filter(item => {
             const vType = item.info.videoType;
@@ -12725,7 +12817,9 @@ background: var(--ypp-danger);
 
         // Manejo especial para playlists mix (RDxxxx)
         if (isPlaylistItem && finalPlaylistTitle === playlistKey && playlistKey?.startsWith('RD')) {
-            finalPlaylistTitle = `Mix - ${info.title || 'Playlist automática'}`;
+            const seedVideoId = playlistKey.slice(2);
+            const seedTitle = modalVideoTitleById.get(seedVideoId);
+            finalPlaylistTitle = `Mix - ${seedTitle || info.title || 'Playlist automática'}`;
         }
 
         // Limpiar undefined del título de playlist

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -14701,6 +14701,9 @@ background: var(--ypp-danger);
         initializationPromise = (async () => {
             info('initializeGlobal', '🚀 Iniciando inicialización global...');
             let hadLanguageInStorage = false;
+            let loadedSettings = null;
+            let loadedSettingsMeta = null;
+            let externalTranslations = null;
 
             // --- Inicializar YouTube Helper API ---
             try {
@@ -14718,7 +14721,7 @@ background: var(--ypp-danger);
 
             // --- Cargar traducciones ---
             try {
-                const [externalTranslations, loadedSettingsMeta] = await Promise.all([
+                [externalTranslations, loadedSettingsMeta] = await Promise.all([
                     loadTranslations().catch((err) => {
                         conError('initializeGlobal', '❌ Error al cargar traducciones:', err);
                         return null;
@@ -14729,7 +14732,7 @@ background: var(--ypp-danger);
                     })
                 ]);
 
-                const loadedSettings = loadedSettingsMeta?.settings || { ...CONFIG.defaultSettings };
+                loadedSettings = loadedSettingsMeta?.settings || { ...CONFIG.defaultSettings };
                 hadLanguageInStorage = !!loadedSettingsMeta?.hadLanguageInStorage;
 
                 if (externalTranslations && Object.keys(externalTranslations).length > 0) {
@@ -14770,12 +14773,14 @@ background: var(--ypp-danger);
                 await setLanguage(langToUse, { persist: false });
                 info('initializeGlobal', ` Idioma configurado: ${langToUse}`);
 
-                // Guardar preferencia si era primera carga
-                if (!hadLanguageInStorage) {
-                    cachedSettings = cachedSettings || { ...CONFIG.defaultSettings };
-                    cachedSettings.language = langToUse;
+                // Actualizar siempre cachedSettings.language con el idioma detectado/seleccionado
+                cachedSettings = cachedSettings || { ...CONFIG.defaultSettings };
+                cachedSettings.language = langToUse;
+                
+                // Guardar preferencia si era primera carga o si el idioma cambió
+                if (!hadLanguageInStorage || (loadedSettings?.language !== langToUse)) {
                     await Settings.set(cachedSettings);
-                    info('initializeGlobal', `Idioma guardado en settings: ${langToUse}`);
+                    info('initializeGlobal', `Idioma guardado/actualizado en settings: ${langToUse}`);
                 }
             } catch (error) {
                 conError('initializeGlobal', '❌ Error al establecer idioma:', error);

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -3916,12 +3916,7 @@ background: var(--ypp-danger);
     const exportDataToFile = async () => {
         try {
             const exportData = {};
-            const keys = (await Storage.keys()).filter(k =>
-                !k.startsWith('userSettings') &&
-                !k.startsWith('userFilters') &&
-                !k.startsWith('playlist_meta_') &&
-                k !== 'translations_cache_v1'
-            );
+            const keys = (await Storage.keys()).filter(k => !isNonVideoStorageKey(k));
 
             for (const k of keys) {
                 const data = await Storage.get(k);
@@ -4387,12 +4382,7 @@ background: var(--ypp-danger);
     * @returns {Array} Array de videos en formato FreeTube
     */
     async function exportToFreeTubeFormat() {
-        const videoKeys = (await Storage.keys()).filter(key =>
-            !key.includes('userSettings') &&
-            !key.includes('userFilters') &&
-            !key.startsWith('playlist_meta_') && // Excluir metadata de playlists
-            key !== 'translations_cache_v1'
-        );
+        const videoKeys = (await Storage.keys()).filter(key => !isNonVideoStorageKey(key));
 
         const freeTubeData = [];
         let videoCount = 0;
@@ -12368,6 +12358,21 @@ background: var(--ypp-danger);
     }
 
     /**
+     * Determina si una clave de Storage corresponde a metadatos/configuración y no a una entrada de video.
+     * @param {string} key
+     * @returns {boolean}
+     */
+    const isNonVideoStorageKey = (key) => {
+        if (typeof key !== 'string') return true;
+        if (key.startsWith('userSettings')) return true;
+        if (key.startsWith('userFilters')) return true;
+        if (key.startsWith('playlist_meta_')) return true;
+        if (key.startsWith('ypp_')) return true;
+        if (key === 'translations_cache_v1') return true;
+        return false;
+    };
+
+    /**
      * Actualiza la lista de videos usando virtualización para rendimiento óptimo.
      * Solo renderiza los items visibles en el viewport, ideal para miles de videos.
      */
@@ -12388,12 +12393,7 @@ background: var(--ypp-danger);
         });
         listContainer.appendChild(loadingIndicator);
 
-        const keys = (await Storage.keys()).filter(k =>
-            !k.startsWith('userSettings') &&
-            !k.startsWith('userFilters') &&
-            !k.startsWith('playlist_meta_') &&
-            k !== 'translations_cache_v1'
-        );
+        const keys = (await Storage.keys()).filter(k => !isNonVideoStorageKey(k));
 
         // Cargar metadata de playlists para referencia
         const playlistMetas = {};
@@ -14425,7 +14425,8 @@ background: var(--ypp-danger);
         // Obtener todas las claves del sistema actual (ya en IndexedDB)
         const allKeys = (await Storage.keys()).filter(k =>
             !k.startsWith('userSettings') &&
-            k !== 'translations_cache_v1'
+            k !== 'translations_cache_v1' &&
+            !k.startsWith('ypp_')
         );
 
         log('migrateToFreeTubeFormat', `📦 Procesando ${allKeys.length} claves en Storage`);

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -277,6 +277,7 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "export": "Export",
             "import": "Import",
             "progressSaved": "Progress saved",
+            "storageFull": "Storage full - Unable to save progress",
             "dataExported": "Data exported",
             "itemsImported": "Imported {count} items",
             "importError": "Error importing. Make sure the file is valid.",
@@ -344,7 +345,12 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "linkCopied": "Link copied to clipboard",
             "selectAtLeastOne": "Select at least one video",
             "tooManyVideos": "Too many videos selected (max 200)",
-            "inlinePreviews": "Inline previews (Home)"
+            "inlinePreviews": "Inline previews (Home)",
+            "removeFromPlaylist": "Remove from playlist",
+            "confirmRemoveFromPlaylist": "Are you sure you want to remove this video from the playlist? It will be kept as an individual video.",
+            "playlistAssociationRemoved": "Playlist association removed",
+            "loading": "Loading",
+            "rendered": "rendered"
         },
         "es-ES": {
             "settings": "Configuración",
@@ -381,6 +387,7 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "export": "Exportar",
             "import": "Importar",
             "progressSaved": "Progreso guardado",
+            "storageFull": "Almacenamiento lleno - No se puede guardar el progreso",
             "dataExported": "Datos exportados",
             "itemsImported": "Importados {count} elementos",
             "importError": "Error al importar. Asegúrate de que el archivo sea válido.",
@@ -448,7 +455,12 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "linkCopied": "Enlace copiado al portapapeles",
             "selectAtLeastOne": "Selecciona al menos un video",
             "tooManyVideos": "Demasiados videos seleccionados (máx 200)",
-            "inlinePreviews": "Previsualizaciones en inicio (Home)"
+            "inlinePreviews": "Previsualizaciones en inicio (Home)",
+            "removeFromPlaylist": "Quitar de la playlist",
+            "confirmRemoveFromPlaylist": "¿Estás seguro de que quieres quitar este video de la playlist? Se mantendrá como video individual.",
+            "playlistAssociationRemoved": "Asociación de playlist eliminada",
+            "loading": "Cargando",
+            "rendered": "renderizados"
         },
         "fr": {
             "settings": "Paramètres",
@@ -552,7 +564,12 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "linkCopied": "Lien copié dans le presse-papiers",
             "selectAtLeastOne": "Sélectionnez au moins une vidéo",
             "tooManyVideos": "Trop de vidéos sélectionnées (max 200)",
-            "inlinePreviews": "Aperçus intégrés (Accueil)"
+            "inlinePreviews": "Aperçus intégrés (Accueil)",
+            "removeFromPlaylist": "Retirer de la playlist",
+            "confirmRemoveFromPlaylist": "Êtes-vous sûr de vouloir retirer cette vidéo de la playlist ? Elle sera conservée comme vidéo individuelle.",
+            "playlistAssociationRemoved": "Association de playlist supprimée",
+            "loading": "Chargement",
+            "rendered": "rendus"
         }
     };
 
@@ -1076,8 +1093,55 @@ html[dark], body.dark-theme {
 
 #video-list-container {
   flex-grow: 1; /* Ocupar el espacio restante */
-  overflow-y: auto; /* Hacer scrollable solo esta parte */
+  overflow: hidden; /* El scroll lo maneja el virtual scroller */
+  padding: 0; /* Padding se aplica a los elementos internos */
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+#ypp-virtual-scroller-container {
+  flex-grow: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--ypp-spacing-md) var(--ypp-spacing-lg);
+}
+
+/* Virtual Scroller Styles */
+.ypp-virtual-spacer {
+  position: relative;
+  width: 100%;
+}
+
+.ypp-virtual-item {
+  position: absolute;
+  left: 0;
+  right: 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.ypp-virtual-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ypp-spacing-lg);
+  color: var(--ypp-text-muted);
+  font-size: 1.2rem;
+}
+
+.ypp-virtual-stats {
+  position: sticky;
+  top: 0;
+  background: var(--ypp-bg);
+  padding: 8px var(--ypp-spacing-lg);
+  border-bottom: 1px solid var(--ypp-border);
+  font-size: 0.9rem;
+  color: var(--ypp-text-muted);
+  z-index: 10;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .ypp-settingsContent {
@@ -1217,20 +1281,23 @@ html[dark], body.dark-theme {
 .ypp-videoWrapper {
   display: flex;
   align-items: center;
-  margin-bottom: var(--ypp-spacing-md);
+  min-height: 120px; /* Altura fija para virtualización precisa */
   border-bottom: 1px solid var(--ypp-border);
-  padding: var(--ypp-spacing-md);
+  padding: var(--ypp-spacing-sm) var(--ypp-spacing-md);
+  box-sizing: border-box;
+  background: var(--ypp-bg);
 }
 
 .ypp-videoWrapper.playlist-item {
   border-radius: 6px;
-  margin-bottom: var(--ypp-spacing-sm);
   transition: all 0.2s ease;
+  height: 140px !important;
 }
 
 .ypp-videoWrapper.regular-item {
   background-color: var(--ypp-bg-secondary);
   border-left: 4px solid var(--ypp-border);
+  height: 120px !important; /* Altura estándar */
 }
 
 .ypp-playlist-indicator {
@@ -1248,6 +1315,14 @@ html[dark], body.dark-theme {
   font-weight: 600;
   border: 1px solid rgba(255, 255, 255, 0.2);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.ypp-videoWrapper {
+    overflow: hidden !important;
 }
 
 .ypp-playlist-link {
@@ -1260,6 +1335,41 @@ html[dark], body.dark-theme {
 
 .ypp-playlist-link:hover {
   opacity: 1;
+}
+
+.ypp-playlist-header {
+  height: 40px !important;
+  max-height: 40px !important;
+  display: flex;
+  align-items: center;
+  padding: 0 var(--ypp-spacing-md);
+  box-sizing: border-box;
+  font-weight: bold;
+  color: var(--ypp-text-highlight);
+  background: var(--ypp-bg);
+  border-bottom: 1px solid var(--ypp-border);
+  overflow: hidden;
+}
+.ypp-playlist-header a {
+    color: inherit;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0; /* Necesario para que text-overflow funcione en flex child */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.ypp-playlist-header a:hover {
+    text-decoration: underline;
+}
+
+.ypp-virtual-item {
+    position: absolute !important;
+    left: 0;
+    width: 100%;
 }
 
 /* Estilos para modo de selección */
@@ -2146,6 +2256,7 @@ background: var(--ypp-danger);
                 // Verde oscuro (casi completado o completado) - mejor contraste en fondos celestes
                 color = '#00cc00';
             }
+
         }
 
         return color;
@@ -2159,145 +2270,392 @@ background: var(--ypp-danger);
     * Proporciona métodos para guardar, obtener y eliminar datos,
     * así como para listar claves almacenadas con un prefijo específico.
     */
-    // Backend de almacenamiento con fallback: localStorage -> GM_* (sync) -> memoria
-    let storageBackend = 'local';
-    let storageWarned = false;
-    const STORAGE_INDEX_KEY = `${CONFIG.storagePrefix}INDEX_v1`;
-    const memoryStore = {};
-    const memoryIndex = new Set();
+    // Metaclaves para control de migración y configuración
+    const STORAGE_META_KEYS = new Set([
+        'INDEX_v1',
+        '__test__',
+        '__idb_migrated__'
+    ]);
+    const STORAGE_MIGRATION_STATE_KEY = `${CONFIG.storagePrefix}__idb_migrated__`;
+    const storageCache = new Map();
 
-    function supportsSyncGM() {
-        try {
-            if (typeof GM_getValue !== 'function' || typeof GM_setValue !== 'function') return false;
-            const probe = GM_getValue('__ypp_probe__', null);
-            // Si devuelve una promesa, no es síncrono (no compatible con API de Storage)
-            if (probe && typeof probe.then === 'function') return false;
-            return true;
-        } catch (_) { return false; }
-    }
+    // Nueva capa asíncrona de almacenamiento (IndexedDB primario + caché en memoria + fallback)
+    const StorageAsync = (() => {
+        const logger = {
+            info: (...args) => { try { log('StorageAsync', ...args); } catch (_) { console.info('[StorageAsync]', ...args); } },
+            warn: (...args) => { try { warn('StorageAsync', ...args); } catch (_) { console.warn('[StorageAsync]', ...args); } },
+            error: (...args) => { try { conError('StorageAsync', ...args); } catch (_) { console.error('[StorageAsync]', ...args); } }
+        };
 
-    function detectStorageBackend() {
-        try {
-            const testKey = `${CONFIG.storagePrefix}__test__`;
-            localStorage.setItem(testKey, '1');
-            localStorage.removeItem(testKey);
-            return 'local';
-        } catch (_) {
-            return supportsSyncGM() ? 'gm' : 'memory';
+        // Estado de inicialización
+        let isReady = false;
+        let initError = null;
+        let readyPromise = null;
+
+        /**
+         * Inicializa la capa asíncrona: detecta IndexedDB, migra datos si es necesario y llena caché.
+         */
+        async function initialize() {
+            if (readyPromise) return readyPromise;
+            readyPromise = (async () => {
+                try {
+                    logger.info('Iniciando StorageAsync...');
+                    // Detectar si ya se migró
+                    const migrated = localStorage.getItem(STORAGE_MIGRATION_STATE_KEY) === '1';
+                    let legacySnapshot = [];
+                    if (!migrated && IndexedDBAdapter.isSupported) {
+                        // Recolectar snapshot de localStorage/GM directamente para evitar recursión
+                        let allKeys = [];
+                        try {
+                            if (typeof GM_listValues !== 'undefined') {
+                                allKeys = GM_listValues();
+                            } else if (typeof localStorage !== 'undefined') {
+                                allKeys = Object.keys(localStorage);
+                            }
+                        } catch (err) {
+                            logger.warn('Error al obtener claves para migración:', err);
+                        }
+
+                        for (const key of allKeys || []) {
+                            if (STORAGE_META_KEYS.has(key)) continue;
+                            let value = null;
+                            try {
+                                if (typeof GM_getValue !== 'undefined') {
+                                    value = GM_getValue(key);
+                                } else if (typeof localStorage !== 'undefined') {
+                                    const item = localStorage.getItem(key);
+                                    if (item) value = JSON.parse(item);
+                                }
+                            } catch (err) {
+                                logger.warn(`Error al leer clave ${key}:`, err);
+                            }
+                            if (value !== null) {
+                                legacySnapshot.push({ key, value: JSON.stringify(value) });
+                            }
+                        }
+                    }
+                    // Bootstrap IndexedDB (migrará si es necesario)
+                    const result = await IndexedDBAdapter.bootstrap(legacySnapshot);
+                    if (result.source === 'legacy') {
+                        localStorage.setItem(STORAGE_MIGRATION_STATE_KEY, '1');
+                        logger.info(`Migración completada: ${result.entries.length} entradas migradas a IndexedDB`);
+                    }
+                    // Poblar caché en memoria desde IndexedDB
+                    for (const entry of result.entries) {
+                        storageCache.set(entry.key, entry.value);
+                    }
+                    isReady = true;
+                    logger.info('StorageAsync listo. Backend:', IndexedDBAdapter.isSupported ? 'IndexedDB' : 'fallback');
+                } catch (err) {
+                    initError = err;
+                    logger.error('Falló inicialización de StorageAsync:', err);
+                    // En caso de error, mantener caché vacía y delegar a API sincrónica existente
+                }
+            })();
+            return readyPromise;
         }
-    }
 
-    function warnOnceBackend() {
-        if (!storageWarned && storageBackend !== 'local') {
-            try { warn('Storage', `Usando backend alternativo: ${storageBackend}`); } catch (_) { }
-            storageWarned = true;
+        /**
+         * Obtiene un valor desde caché (síncrono) o desde IndexedDB (asíncrono).
+         */
+        async function get(key) {
+            await initialize();
+            if (storageCache.has(key)) {
+                try {
+                    return JSON.parse(storageCache.get(key));
+                } catch (_) {
+                    return null;
+                }
+            }
+            // Si no está en caché y IndexedDB disponible, buscarlo
+            if (IndexedDBAdapter.isSupported) {
+                try {
+                    const raw = await new Promise((resolve, reject) => {
+                        IndexedDBAdapter.runInStore('readonly', (store) => store.get(key)).then((req) => resolve(req?.result?.value)).catch(reject);
+                    });
+                    if (raw !== undefined) {
+                        storageCache.set(key, raw);
+                        return JSON.parse(raw);
+                    }
+                } catch (err) {
+                    logger.warn(`Error al leer ${key} desde IndexedDB:`, err);
+                }
+            }
+            return null;
         }
-    }
 
-    function gmIndexGet() {
-        try {
-            const raw = GM_getValue(STORAGE_INDEX_KEY, '[]');
-            const arr = JSON.parse(raw || '[]');
-            return Array.isArray(arr) ? arr : [];
-        } catch (_) { return []; }
-    }
-    function gmIndexSet(arr) {
-        try { GM_setValue(STORAGE_INDEX_KEY, JSON.stringify(arr || [])); } catch (_) { }
-    }
+        /**
+         * Guarda un valor en IndexedDB y actualiza caché.
+         */
+        async function set(key, value) {
+            await initialize();
+            const serialized = JSON.stringify(value);
+            storageCache.set(key, serialized);
+            if (IndexedDBAdapter.isSupported) {
+                try {
+                    await IndexedDBAdapter.put(key, serialized);
+                } catch (err) {
+                    logger.warn(`Error al escribir ${key} en IndexedDB, usando fallback:`, err);
+                    // Lanzar el error para que el manejador superior lo capture
+                    throw err;
+                }
+            }
+        }
 
-    storageBackend = detectStorageBackend();
+        /**
+         * Elimina una clave de IndexedDB y de la caché.
+         */
+        async function del(key) {
+            await initialize();
+            storageCache.delete(key);
+            if (IndexedDBAdapter.isSupported) {
+                try {
+                    await IndexedDBAdapter.del(key);
+                } catch (err) {
+                    logger.warn(`Error al eliminar ${key} en IndexedDB:`, err);
+                }
+            }
+        }
+
+        /**
+         * Lista todas las claves desde IndexedDB o caché.
+         */
+        async function keys() {
+            await initialize();
+            if (IndexedDBAdapter.isSupported) {
+                try {
+                    const entries = await IndexedDBAdapter.getAllEntries();
+                    return entries.map(e => e.key).filter(k => !STORAGE_META_KEYS.has(k));
+                } catch (err) {
+                    logger.warn('Error al listar claves desde IndexedDB, usando caché:', err);
+                }
+            }
+            // Fallback a caché en memoria
+            return Array.from(storageCache.keys()).filter(k => !STORAGE_META_KEYS.has(k));
+        }
+
+        /**
+         * Devuelve el estado actual del backend.
+         */
+        function getBackendInfo() {
+            return {
+                ready: isReady,
+                error: initError,
+                indexedDBSupported: IndexedDBAdapter.isSupported,
+                cacheSize: storageCache.size,
+                migrated: localStorage.getItem(STORAGE_MIGRATION_STATE_KEY) === '1'
+            };
+        }
+
+        return {
+            initialize,
+            get,
+            set,
+            del,
+            keys,
+            getBackendInfo
+        };
+    })();
+
+    const IndexedDBAdapter = (() => {
+        const DB_NAME = 'YTPlaybackPloxDB';
+        const STORE_NAME = 'keyvalue';
+        const DB_VERSION = 1;
+        const isSupported = (() => {
+            try {
+                return typeof indexedDB !== 'undefined';
+            } catch (_) {
+                return false;
+            }
+        })();
+        let dbPromise = null;
+        let operationQueue = Promise.resolve();
+
+        const idbLogger = {
+            info: (...args) => {
+                try { log('IndexedDB', ...args); } catch (_) { console.info('[IndexedDB]', ...args); }
+            },
+            warn: (...args) => {
+                try { warn('IndexedDB', ...args); } catch (_) { console.warn('[IndexedDB]', ...args); }
+            },
+            error: (...args) => {
+                try { conError('IndexedDB', ...args); } catch (_) { console.error('[IndexedDB]', ...args); }
+            }
+        };
+
+        function openDatabase() {
+            if (dbPromise) return dbPromise;
+            if (!isSupported) return Promise.reject(new Error('IndexedDB no soportado'));
+            dbPromise = new Promise((resolve, reject) => {
+                try {
+                    const request = indexedDB.open(DB_NAME, DB_VERSION);
+                    request.onupgradeneeded = () => {
+                        const db = request.result;
+                        if (!db.objectStoreNames.contains(STORE_NAME)) {
+                            db.createObjectStore(STORE_NAME, { keyPath: 'key' });
+                        }
+                    };
+                    request.onsuccess = () => resolve(request.result);
+                    request.onerror = () => reject(request.error);
+                    request.onblocked = () => idbLogger.warn('Inicialización bloqueada esperando pestañas previas');
+                } catch (error) {
+                    reject(error);
+                }
+            });
+            return dbPromise;
+        }
+
+        function runInStore(mode, executor) {
+            return openDatabase().then((db) => new Promise((resolve, reject) => {
+                try {
+                    const tx = db.transaction(STORE_NAME, mode);
+                    const store = tx.objectStore(STORE_NAME);
+                    const result = executor(store);
+                    tx.oncomplete = () => resolve(result?.result ?? undefined);
+                    tx.onerror = () => reject(tx.error);
+                    tx.onabort = () => reject(tx.error);
+                } catch (error) {
+                    reject(error);
+                }
+            }));
+        }
+
+        function enqueue(operation) {
+            operationQueue = operationQueue
+                .then(() => operation().catch((error) => {
+                    idbLogger.error('Operación fallida', error);
+                }))
+                .catch((error) => idbLogger.error('Error en cola IndexedDB', error));
+            return operationQueue;
+        }
+
+        function sanitizeEntries(rawEntries) {
+            if (!Array.isArray(rawEntries)) return [];
+            return rawEntries
+                .map((entry) => ({
+                    key: entry?.key,
+                    value: typeof entry?.value === 'string' ? entry.value : null,
+                    updatedAt: Number.isFinite(entry?.updatedAt) ? entry.updatedAt : Date.now()
+                }))
+                .filter((entry) => typeof entry.key === 'string' && typeof entry.value === 'string');
+        }
+
+        function getAllEntries() {
+            return runInStore('readonly', (store) => store.getAll()).then(sanitizeEntries);
+        }
+
+        function putEntry(key, value) {
+            return runInStore('readwrite', (store) => store.put({ key, value, updatedAt: Date.now() }));
+        }
+
+        function deleteEntry(key) {
+            return runInStore('readwrite', (store) => store.delete(key));
+        }
+
+        function bulkPut(entries = []) {
+            if (!entries.length) return Promise.resolve();
+            return runInStore('readwrite', (store) => {
+                let lastRequest = null;
+                entries.forEach(({ key, value }) => {
+                    lastRequest = store.put({ key, value, updatedAt: Date.now() });
+                });
+                return lastRequest;
+            });
+        }
+
+        async function bootstrap(legacySnapshot = []) {
+            if (!isSupported) return { entries: [], source: 'unsupported' };
+            const existingEntries = await getAllEntries();
+            if (existingEntries.length > 0) {
+                idbLogger.info(`Recuperando ${existingEntries.length} entradas desde IndexedDB`);
+                return { entries: existingEntries, source: 'idb' };
+            }
+            if (legacySnapshot.length > 0) {
+                idbLogger.info(`Migrando ${legacySnapshot.length} entradas legadas a IndexedDB`);
+                await bulkPut(legacySnapshot);
+                return { entries: legacySnapshot, source: 'legacy' };
+            }
+            return { entries: [], source: 'empty' };
+        }
+
+        return {
+            isSupported,
+            bootstrap,
+            put: (key, value) => {
+                if (!isSupported) return Promise.resolve();
+                return enqueue(() => putEntry(key, value));
+            },
+            del: (key) => {
+                if (!isSupported) return Promise.resolve();
+                return enqueue(() => deleteEntry(key));
+            },
+            getAllEntries,
+            runInStore
+        };
+    })();
 
     const Storage = {
         /**
-         * Obtiene un valor del almacenamiento con backend disponible.
+         * Guarda un valor en el backend disponible (ahora delega a StorageAsync).
          */
-        get(key) {
+        async set(key, value) {
+
+            // TEST: Forzar storage_full para testear alerta
+            // return { success: false, reason: 'storage_full', error: new Error('QuotaExceededError') };
+
             try {
-                if (storageBackend === 'local') {
-                    const raw = localStorage.getItem(`${CONFIG.storagePrefix}${key}`);
-                    return raw ? JSON.parse(raw) : null;
+                await StorageAsync.set(key, value);
+            } catch (err) {
+                conError('Storage', `Storage.set: Error al guardar la clave "${key}"`, err);
+                // Detectar errores de cuota y devolver resultado específico
+                if (err.name === 'QuotaExceededError' || err.name === 'NS_ERROR_DOM_QUOTA_REACHED') {
+                    return { success: false, reason: 'storage_full', error: err };
                 }
-                warnOnceBackend();
-                if (storageBackend === 'gm') {
-                    const raw = GM_getValue(`${CONFIG.storagePrefix}${key}`, null);
-                    return raw ? JSON.parse(raw) : null;
-                }
-                return Object.prototype.hasOwnProperty.call(memoryStore, key) ? memoryStore[key] : null;
-            } catch (error) {
-                conError('Storage', `Storage.get: Error al obtener la clave "${key}"`, error);
+                return { success: false, reason: 'storage_error', error: err };
+            }
+            return { success: true };
+        },
+
+        /**
+         * Obtiene un valor del almacenamiento (ahora delega a StorageAsync).
+         */
+        async get(key) {
+            try {
+                return await StorageAsync.get(key);
+            } catch (err) {
+                conError('Storage', `Storage.get: Error al obtener la clave "${key}"`, err);
                 return null;
             }
         },
 
         /**
-         * Guarda un valor en el backend disponible.
+         * Elimina un valor (ahora delega a StorageAsync).
          */
-        set(key, value) {
+        async del(key) {
             try {
-                if (storageBackend === 'local') {
-                    localStorage.setItem(`${CONFIG.storagePrefix}${key}`, JSON.stringify(value));
-                    return;
-                }
-                warnOnceBackend();
-                if (storageBackend === 'gm') {
-                    GM_setValue(`${CONFIG.storagePrefix}${key}`, JSON.stringify(value));
-                    const idx = new Set(gmIndexGet());
-                    idx.add(key);
-                    gmIndexSet(Array.from(idx));
-                    return;
-                }
-                memoryStore[key] = value;
-                memoryIndex.add(key);
-            } catch (error) {
-                conError('Storage', `Storage.set: Error al guardar la clave "${key}"`, error);
+                await StorageAsync.del(key);
+            } catch (err) {
+                conError('Storage', `Storage.del: Error al eliminar la clave "${key}"`, err);
             }
         },
 
         /**
-         * Elimina un valor del almacenamiento local.
-         * @param {string} key - La clave del valor que se eliminará.
+         * Lista claves (ahora delega a StorageAsync).
          */
-        del(key) {
+        async keys() {
             try {
-                if (storageBackend === 'local') {
-                    localStorage.removeItem(`${CONFIG.storagePrefix}${key}`);
-                    return;
-                }
-                warnOnceBackend();
-                if (storageBackend === 'gm') {
-                    // No hay GM_deleteValue declarado; limpiar índice y sobrescribir con null
-                    GM_setValue(`${CONFIG.storagePrefix}${key}`, null);
-                    const idx = new Set(gmIndexGet());
-                    idx.delete(key);
-                    gmIndexSet(Array.from(idx));
-                    return;
-                }
-                delete memoryStore[key];
-                memoryIndex.delete(key);
-            } catch (error) {
-                conError('Storage', `Storage.del: Error al eliminar la clave "${key}"`, error);
-            }
-        },
-
-        /**
-         * Lista claves según backend disponible.
-         */
-        keys() {
-            try {
-                if (storageBackend === 'local') {
-                    return Object.keys(localStorage)
-                        .filter((fullKey) => fullKey.startsWith(CONFIG.storagePrefix))
-                        .map((fullKey) => fullKey.slice(CONFIG.storagePrefix.length));
-                }
-                warnOnceBackend();
-                if (storageBackend === 'gm') {
-                    return gmIndexGet();
-                }
-                return Array.from(memoryIndex);
-            } catch (error) {
-                conError('Storage', 'Storage.keys: Error al listar claves', error);
+                return await StorageAsync.keys();
+            } catch (err) {
+                conError('Storage', 'Storage.keys: Error al listar claves', err);
                 return [];
             }
+        },
+
+        /**
+         * Diagnóstico del backend actual.
+         */
+        getBackendInfo() {
+            return StorageAsync.getBackendInfo();
         }
     };
 
@@ -2943,19 +3301,29 @@ background: var(--ypp-danger);
     * @param {HTMLElement} element - Elemento HTML al que se le asignará el HTML.
     * @param {string} html - HTML a asignar en su innerHTML.
     */
-    function setInnerHTML(element, html) {
+    let _ttPolicy = null;
+    function getTrustedTypesPolicy() {
+        if (_ttPolicy) return _ttPolicy;
         if (window.trustedTypes && window.trustedTypes.createPolicy) {
             try {
-                const policy = window.trustedTypes.createPolicy('youtube-playback-plox', {
+                // Intentar crear la política. Si ya existe, esto fallará.
+                _ttPolicy = window.trustedTypes.createPolicy('youtube-playback-plox', {
                     createHTML: (string) => string
                 });
-                element.innerHTML = policy.createHTML(html);
             } catch (e) {
-                // Si la creación de la política falla, usar innerHTML directamente
-                element.innerHTML = html;
+                // Si falla (probablemente porque ya existe), intentar recuperarla si es posible o usar fallback
+                console.warn('TrustedTypes policy creation failed:', e);
             }
+        }
+        return _ttPolicy;
+    }
+
+    function setInnerHTML(element, html) {
+        const policy = getTrustedTypesPolicy();
+        if (policy) {
+            element.innerHTML = policy.createHTML(html);
         } else {
-            // Si TrustedHTML no está soportado, usar innerHTML
+            // Fallback para navegadores sin Trusted Types o si falló la creación
             element.innerHTML = html;
         }
     }
@@ -3146,22 +3514,321 @@ background: var(--ypp-danger);
         };
     };
 
+    // MARK: 🎯 VirtualScroller
+    /**
+     * Sistema de virtualización para listas grandes.
+     * Solo renderiza los items visibles en el viewport más un buffer,
+     * reduciendo dramáticamente el número de nodos DOM.
+     * 
+     * @example
+     * const scroller = new VirtualScroller({
+     *     container: listContainer,
+     *     items: videoItems,
+     *     itemHeight: 120,
+     *     renderItem: async (item) => createVideoEntry(item.videoId, item.info),
+     *     bufferSize: 5
+     * });
+     */
+    class VirtualScroller {
+        /**
+         * @param {Object} options - Configuración del scroller
+         * @param {HTMLElement} options.container - Contenedor scrollable
+         * @param {Array} options.items - Array de items a renderizar
+         * @param {number} options.itemHeight - Altura estimada de cada item en px
+         * @param {Function} options.renderItem - Función async que renderiza un item
+         * @param {number} [options.bufferSize=5] - Número de items extra a renderizar arriba/abajo
+         * @param {Function} [options.onRender] - Callback cuando se completa un render
+         */
+        constructor(options) {
+            this.container = options.container;
+            this.items = options.items || [];
+            // Función para obtener altura de un item específico, fallback a itemHeight fijo
+            this.getItemHeight = options.getItemHeight || (() => options.itemHeight || 120);
+            this.renderItem = options.renderItem;
+            this.bufferSize = options.bufferSize ?? 5;
+            this.onRender = options.onRender || null;
+
+            this.renderedItems = new Map();
+            this.renderingItems = new Set();
+            this.spacer = null;
+            this.destroyed = false;
+            this.scrollHandler = null;
+            this.lastScrollTop = -1;
+
+            // Cache de posiciones Y acumuladas
+            this.itemOffsets = [];
+            this.totalHeight = 0;
+
+            this._init();
+        }
+
+        /**
+         * Inicializa el scroller creando el spacer y bindando eventos
+         * @private
+         */
+        _init() {
+            if (!this.container) {
+                console.warn('[VirtualScroller] Container no proporcionado');
+                return;
+            }
+
+            // Limpiar contenido previo
+            setInnerHTML(this.container, '');
+
+            // Crear spacer virtual para mantener altura correcta del scroll
+            this.spacer = document.createElement('div');
+            this.spacer.className = 'ypp-virtual-spacer';
+            this.container.appendChild(this.spacer);
+
+            this._calculateOffsets();
+
+            // Bind scroll con debounce para mejor rendimiento
+            this.scrollHandler = debounce(() => this._onScroll(), 16); // ~60fps
+            this.container.addEventListener('scroll', this.scrollHandler, { passive: true });
+
+            // Render inicial
+            this._render();
+        }
+
+        /**
+         * Pre-calcula la posición Y (offset) de cada item sumando las alturas anteriores.
+         * @private
+         */
+        _calculateOffsets() {
+            this.itemOffsets = new Array(this.items.length);
+            let offset = 0;
+            for (let i = 0; i < this.items.length; i++) {
+                this.itemOffsets[i] = offset;
+                const h = this.getItemHeight(this.items[i], i);
+                offset += h;
+            }
+            this.totalHeight = offset;
+
+            if (this.spacer) {
+                this.spacer.style.height = `${this.totalHeight}px`;
+            }
+        }
+
+        _onScroll() {
+            if (this.destroyed) return;
+            const scrollTop = this.container.scrollTop;
+            if (Math.abs(scrollTop - this.lastScrollTop) > 50) { // Umbral bajo para respuesta rápida
+                this.lastScrollTop = scrollTop;
+                this._render();
+            }
+        }
+
+        /**
+         * Búsqueda binaria para encontrar el índice del primer item visible
+         * @private
+         */
+        _findStartIndex(scrollTop) {
+            let low = 0;
+            let high = this.items.length - 1;
+
+            while (low <= high) {
+                const mid = Math.floor((low + high) / 2);
+                const offset = this.itemOffsets[mid];
+                const height = this.getItemHeight(this.items[mid], mid);
+
+                if (offset + height < scrollTop) {
+                    low = mid + 1;
+                } else if (offset > scrollTop) {
+                    high = mid - 1;
+                } else {
+                    return mid;
+                }
+            }
+            return Math.min(low, this.items.length - 1);
+        }
+
+        /**
+         * Calcula qué items deben estar visibles usando búsqueda binaria
+         * @private
+         * @returns {{startIdx: number, endIdx: number}}
+         */
+        _getVisibleRange() {
+            const scrollTop = this.container.scrollTop;
+            const viewHeight = this.container.clientHeight;
+            const scrollBottom = scrollTop + viewHeight;
+
+            let startIdx = this._findStartIndex(scrollTop);
+            startIdx = Math.max(0, startIdx - this.bufferSize);
+
+            let endIdx = startIdx;
+            // Avanzar linearmente para encontrar el final
+            while (endIdx < this.items.length && this.itemOffsets[endIdx] < scrollBottom) {
+                endIdx++;
+            }
+            endIdx = Math.min(this.items.length, endIdx + this.bufferSize);
+
+            return { startIdx, endIdx };
+        }
+
+        /**
+         * Renderiza los items visibles
+         * @private
+         */
+        async _render() {
+            if (this.destroyed || !this.spacer) return;
+
+            const { startIdx, endIdx } = this._getVisibleRange();
+
+            // Limpieza: remover items fuera de rango
+            for (const [idx, el] of this.renderedItems) {
+                if (idx < startIdx || idx >= endIdx) {
+                    el.remove();
+                    this.renderedItems.delete(idx);
+                }
+            }
+
+            // Renderizado: añadir items nuevos
+            const renderPromises = [];
+            for (let i = startIdx; i < endIdx; i++) {
+                if (!this.renderedItems.has(i) && !this.renderingItems.has(i)) {
+                    this.renderingItems.add(i);
+                    renderPromises.push(this._renderItemAt(i));
+                }
+            }
+
+            if (renderPromises.length > 0) {
+                await Promise.all(renderPromises);
+            }
+
+            if (this.onRender) {
+                this.onRender({
+                    visibleStart: startIdx,
+                    visibleEnd: endIdx,
+                    totalItems: this.items.length,
+                    renderedCount: this.renderedItems.size
+                });
+            }
+        }
+
+        async _renderItemAt(index) {
+            if (this.destroyed || index >= this.items.length) {
+                this.renderingItems.delete(index);
+                return;
+            }
+
+            try {
+                const item = this.items[index];
+                const el = await this.renderItem(item, index);
+
+                if (this.destroyed) return;
+
+                // Posicionamiento absoluto usando offset pre-calculado
+                el.classList.add('ypp-virtual-item');
+                el.style.setProperty('position', 'absolute', 'important');
+                el.style.top = `${this.itemOffsets[index]}px`;
+                el.style.width = '100%';
+
+                this.spacer.appendChild(el);
+                this.renderedItems.set(index, el);
+            } catch (err) {
+                console.error('[VirtualScroller] Error rendering item:', index, err);
+            } finally {
+                this.renderingItems.delete(index);
+            }
+        }
+
+        /**
+         * Actualiza los items y re-renderiza
+         * @param {Array} newItems - Nuevo array de items
+         */
+        updateItems(newItems) {
+            this.items = newItems || [];
+
+            // Limpiar todos los elementos renderizados
+            for (const el of this.renderedItems.values()) {
+                el.remove();
+            }
+            this.renderedItems.clear();
+            this.renderingItems.clear();
+
+            // Actualizar altura y re-renderizar
+            this._calculateOffsets();
+            this.lastScrollTop = -1;
+            this._render();
+        }
+
+        /**
+         * Fuerza un re-render completo
+         */
+        refresh() {
+            for (const el of this.renderedItems.values()) {
+                el.remove();
+            }
+            this.renderedItems.clear();
+            this.lastScrollTop = -1;
+            this._render();
+        }
+
+        /**
+         * Scroll hasta un índice específico
+         * @param {number} index - Índice del item
+         * @param {string} [position='start'] - 'start', 'center', o 'end'
+         */
+        scrollToIndex(index, position = 'start') {
+            if (index < 0 || index >= this.items.length) return;
+            let targetOffset = this.itemOffsets[index];
+            if (position === 'center') {
+                const h = this.getItemHeight(this.items[index], index);
+                targetOffset -= (this.container.clientHeight / 2) - (h / 2);
+            } else if (position === 'end') {
+                const h = this.getItemHeight(this.items[index], index);
+                targetOffset -= this.container.clientHeight - h;
+            }
+            this.container.scrollTop = Math.max(0, targetOffset);
+        }
+
+        /**
+         * Obtiene el número de items actualmente renderizados en el DOM
+         * @returns {number}
+         */
+        getRenderedCount() {
+            return this.renderedItems.size;
+        }
+
+        /**
+         * Destruye el scroller y limpia recursos
+         */
+        destroy() {
+            this.destroyed = true;
+
+            if (this.scrollHandler && this.container) {
+                this.container.removeEventListener('scroll', this.scrollHandler);
+            }
+
+            for (const el of this.renderedItems.values()) {
+                el.remove();
+            }
+            this.renderedItems.clear();
+            this.renderingItems.clear();
+
+            if (this.spacer) {
+                this.spacer.remove();
+                this.spacer = null;
+            }
+        }
+    }
+
     // MARK: 📤 Import/Export JSON
     // Exportación/Importación JSON nativo del userscript (preserva videoType de shorts)
-    const exportDataToFile = () => {
+    const exportDataToFile = async () => {
         try {
             const exportData = {};
-            const keys = Storage.keys().filter(k =>
+            const keys = (await Storage.keys()).filter(k =>
                 !k.startsWith('userSettings') &&
                 !k.startsWith('userFilters') &&
                 !k.startsWith('playlist_meta_') &&
                 k !== 'translations_cache_v1'
             );
 
-            keys.forEach(k => {
-                const data = Storage.get(k);
+            for (const k of keys) {
+                const data = await Storage.get(k);
                 if (data) exportData[k] = data;
-            });
+            }
 
             const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
             const url = URL.createObjectURL(blob);
@@ -3183,7 +3850,7 @@ background: var(--ypp-danger);
         }
     };
 
-    const importDataFromFile = () => {
+    const importDataFromFile = async () => {
         let inputFile = document.getElementById('ypp-import-file');
         if (!inputFile) {
             inputFile = createElement('input', {
@@ -3210,24 +3877,24 @@ background: var(--ypp-danger);
                 let importCount = 0;
                 let skipped = 0;
 
-                Object.entries(data).forEach(([key, value]) => {
+                for (const [key, value] of Object.entries(data)) {
                     // Evitar importar configuraciones
                     if (key.startsWith('userSettings') || key.startsWith('userFilters')) {
                         skipped++;
-                        return;
+                        continue;
                     }
 
                     // Validar que el valor tenga estructura mínima de video
                     if (value && typeof value === 'object' && (value.videoId || value.timestamp !== undefined)) {
-                        Storage.set(key, value);
+                        await Storage.set(key, value);
                         importCount++;
                     } else {
                         log('importDataFromFile', `Entrada inválida ignorada: ${key}`);
                         skipped++;
                     }
-                });
+                }
 
-                updateVideoList();
+                await updateVideoList();
 
                 if (importCount > 0) {
                     showFloatingToast(`${SVG_ICONS.check} ${t('itemsImported', { count: importCount })} ${skipped > 0 ? ` (${skipped} ${t('omitedVideos')})` : ''}`);
@@ -3336,7 +4003,7 @@ background: var(--ypp-danger);
 
                     if (Array.isArray(data) && data.length > 0) {
                         const result = await importFromFreeTubeFormat(data);
-                        updateVideoList();
+                        await updateVideoList();
                         if (result.imported > 0) {
                             showFloatingToast(`${SVG_ICONS.check} ${result.imported} ${t('videosImported')}${result.failed > 0 ? ` (${result.failed} ${t('errors')})` : ''}`);
                         } else {
@@ -3362,7 +4029,7 @@ background: var(--ypp-danger);
                     }
 
                     const result = await importFromFreeTubeFormat(data);
-                    updateVideoList();
+                    await updateVideoList();
 
                     if (result.imported > 0) {
                         showFloatingToast(`${SVG_ICONS.check} ${result.imported} ${t('videosImportedFromFreeTubeDB')} ${result.failed > 0 ? ` (${result.failed} ${t('errors')})` : ''}`);
@@ -3423,7 +4090,7 @@ background: var(--ypp-danger);
                 }
 
                 const result = await importFromFreeTubeFormat(data);
-                updateVideoList();
+                await updateVideoList();
 
                 if (result.imported > 0) {
                     showFloatingToast(`${SVG_ICONS.check} ${result.imported} ${t('videosImportedFromFreeTubeDB')} ${result.failed > 0 ? ` (${result.failed} ${t('errors')})` : ''}`);
@@ -3474,7 +4141,8 @@ background: var(--ypp-danger);
             watchProgress: watchProgress, // Redondeado a 2 decimales
             timeWatched: internalData.lastUpdated || internalData.savedAt || Date.now(),
             isLive: internalData.isLive || false,
-            type: 'watch', // FreeTube siempre usa 'watch', incluso para shorts
+            // FreeTube usa 'video' para todos los formatos
+            type: 'video',
             // Metadatos de playlist (FreeTube los incluye siempre, aunque sean null)
             lastViewedPlaylistId: internalData.lastViewedPlaylistId || null,
             lastViewedPlaylistType: internalData.lastViewedPlaylistType || '',
@@ -3621,7 +4289,7 @@ background: var(--ypp-danger);
     * @returns {Array} Array de videos en formato FreeTube
     */
     async function exportToFreeTubeFormat() {
-        const videoKeys = Storage.keys().filter(key =>
+        const videoKeys = (await Storage.keys()).filter(key =>
             !key.includes('userSettings') &&
             !key.includes('userFilters') &&
             !key.startsWith('playlist_meta_') && // Excluir metadata de playlists
@@ -3634,7 +4302,7 @@ background: var(--ypp-danger);
 
         let iter = 0;
         for (const key of videoKeys) {
-            const data = Storage.get(key);
+            const data = await Storage.get(key);
             if (!data) continue;
 
             // Compatibilidad con formato antiguo (playlists anidadas)
@@ -3644,7 +4312,7 @@ background: var(--ypp-danger);
                     const internal = Object.assign({}, videoObj, { videoId: videoObj.videoId || vidKey });
                     const formatted = toFreeTubeFormat(internal);
                     freeTubeData.push(formatted);
-                    if (formatted.type === 'short') shortCount++;
+                    if (internal.videoType === 'short' || internal.videoType === 'preview_shorts') shortCount++;
                     else videoCount++;
                 });
             } else {
@@ -3652,7 +4320,7 @@ background: var(--ypp-danger);
                 const internal = Object.assign({}, data, { videoId: data.videoId || key });
                 const formatted = toFreeTubeFormat(internal);
                 freeTubeData.push(formatted);
-                if (formatted.type === 'short') {
+                if (internal.videoType === 'short' || internal.videoType === 'preview_shorts') {
                     shortCount++;
                     log('exportToFreeTubeFormat', `Short detectado: ${formatted.videoId} | videoType: ${internal.videoType}`);
                 } else {
@@ -3715,7 +4383,7 @@ background: var(--ypp-danger);
 
                 // Si ya existe el video en Storage, conservar el mayor viewCount como más reciente
                 try {
-                    const existing = Storage.get(video.videoId);
+                    const existing = await Storage.get(video.videoId);
                     if (existing && (existing.viewsNumber != null || internalFormat.viewsNumber != null)) {
                         const parseViews = (val) => {
                             if (typeof val === 'number') return val;
@@ -3742,7 +4410,7 @@ background: var(--ypp-danger);
                     }
                 } catch (_) { }
 
-                Storage.set(video.videoId, internalFormat);
+                await Storage.set(video.videoId, internalFormat);
                 imported++;
                 log('importFromFreeTubeFormat', `✅ Importado: ${video.videoId} - ${video.title || 'Sin título'}`);
             } catch (error) {
@@ -3769,10 +4437,10 @@ background: var(--ypp-danger);
     /**
      * Módulo estratégico para manejar operaciones por tipo de video.
      * Centraliza la validación de configuración y delegación de guardado.
-     * 
+     *
      * IMPORTANTE: Mantiene aislamiento de contexto entre miniplayer y shorts
      * para evitar contaminación de datos cuando ambos coexisten.
-     * 
+     *
      * @namespace VideoTypeHandler
      */
     const VideoTypeHandler = (() => {
@@ -3981,22 +4649,16 @@ background: var(--ypp-danger);
             return 'shorts';
         }
 
-        // Prioridad 3: Si es una preview (inline preview en home/search/channel)
-        if (typeof currentType === 'string' && currentType.startsWith('preview_')) {
-            log('detectContentType', `✅ Tipo detectado: PREVIEW (${currentType})`);
-            return 'preview';
-        }
-
-        // Prioridad 4: Si el video está dentro de un contenedor de Shorts (aunque la página no sea Shorts)
+        // Prioridad 3: Si el video está dentro de un contenedor de Shorts (aunque la página no sea Shorts)
         try {
-            const inShortsContext = videoElement?.closest?.('ytd-reel-video-renderer, ytd-shorts, #shorts-player, .ytp-inline-preview-ui');
+            const inShortsContext = videoElement?.closest?.('ytd-reel-video-renderer, ytd-shorts, #shorts-player');
             if (inShortsContext) {
                 log('detectContentType', `✅ Tipo detectado: SHORTS (contexto de Shorts detectado)`);
                 return 'shorts';
             }
         } catch (_) { }
 
-        // Prioridad 5: Si es un miniplayer reproduciendo
+        // Prioridad 4: Si es un miniplayer reproduciendo (ANTES de verificar preview)
         try {
             const isMiniplayer = videoElement?.closest?.('#miniplayer, .ytp-miniplayer-ui, ytd-miniplayer');
             if (isMiniplayer) {
@@ -4004,6 +4666,26 @@ background: var(--ypp-danger);
                 return 'video';
             }
         } catch (_) { }
+
+        // Prioridad 5: Si estamos en watch page, NUNCA debe ser preview
+        if (pageType === 'watch') {
+            log('detectContentType', `✅ Tipo detectado: VIDEO (watch page)`);
+            return 'video';
+        }
+
+        // Prioridad 6: Si es una preview (inline preview en home/search/channel)
+        // IMPORTANTE: Solo si estamos en un contexto real de preview inline
+        if (typeof currentType === 'string' && currentType.startsWith('preview_')) {
+            try {
+                const isActualPreview = videoElement?.closest?.('#inline-preview-player, .ytp-inline-preview-ui, ytd-thumbnail-overlay-inline-playback-renderer');
+                if (isActualPreview) {
+                    log('detectContentType', `✅ Tipo detectado: PREVIEW (${currentType})`);
+                    return 'preview';
+                } else {
+                    log('detectContentType', `⚠️ currentType sugiere preview pero no hay contexto DOM de preview. Tratando como video regular.`);
+                }
+            } catch (_) { }
+        }
 
         // Default: Es un video regular
         log('detectContentType', `✅ Tipo detectado: VIDEO (default)`);
@@ -4019,10 +4701,10 @@ background: var(--ypp-danger);
      * @param {string|null} playlistId - ID de la playlist si aplica
      * @returns {Object} Resultado de la operación
      */
-    function saveRegularVideo(videoId, currentTime, duration, videoInfo, playlistId) {
+    async function saveRegularVideo(videoId, currentTime, duration, videoInfo, playlistId) {
         log('saveRegularVideo', `Guardando video regular ${videoId} en ${currentTime}s`);
 
-        const sourceData = getSavedVideoData(videoId, playlistId);
+        const sourceData = await getSavedVideoData(videoId, playlistId);
         const now = Date.now();
         const isFinished = duration > 0 && (currentTime / duration) * 100 >= (cachedSettings?.staticFinishPercent || CONFIG.defaultSettings.staticFinishPercent);
 
@@ -4034,7 +4716,7 @@ background: var(--ypp-danger);
                 if (!thumbnailHasVideoId(base.thumb, videoId)) {
                     base.thumb = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;
                 }
-                Storage.set(videoId, base);
+                await Storage.set(videoId, base);
             }
             return { success: false, reason: 'fixed_time_no_overwrite' };
         }
@@ -4061,13 +4743,18 @@ background: var(--ypp-danger);
             lastViewedPlaylistItemId: null
         };
 
-        Storage.set(videoId, videoData);
+        const storageResult = await Storage.set(videoId, videoData);
         log('saveRegularVideo', `✅ Video regular guardado:`, videoData);
+
+        // Verificar si hubo error de almacenamiento
+        if (storageResult && !storageResult.success) {
+            return { success: false, reason: storageResult.reason, videoId, type: 'video' };
+        }
 
         // Actualizar metadata de playlist si aplica
         if (playlistId) {
             const playlistMetaKey = `playlist_meta_${playlistId}`;
-            let playlistMeta = Storage.get(playlistMetaKey) || {
+            let playlistMeta = await Storage.get(playlistMetaKey) || {
                 playlistId,
                 title: '',
                 lastWatchedVideoId: videoId,
@@ -4075,7 +4762,12 @@ background: var(--ypp-danger);
             };
             playlistMeta.lastWatchedVideoId = videoId;
             playlistMeta.lastUpdated = now;
-            Storage.set(playlistMetaKey, playlistMeta);
+            const playlistStorageResult = await Storage.set(playlistMetaKey, playlistMeta);
+
+            // Verificar si hubo error de almacenamiento en metadata de playlist
+            if (playlistStorageResult && !playlistStorageResult.success) {
+                log('saveRegularVideo', `⚠️ Error guardando metadata de playlist: ${playlistStorageResult.reason}`);
+            }
         }
 
         return { success: true, videoId, timestamp: videoData.timestamp, type: 'video' };
@@ -4089,10 +4781,10 @@ background: var(--ypp-danger);
      * @param {Object} videoInfo - Información del short
      * @returns {Object} Resultado de la operación
      */
-    function saveShortsVideo(videoId, currentTime, duration, videoInfo) {
+    async function saveShortsVideo(videoId, currentTime, duration, videoInfo) {
         log('saveShortsVideo', `Guardando short ${videoId} en ${currentTime}s`);
 
-        const sourceData = getSavedVideoData(videoId);
+        const sourceData = await getSavedVideoData(videoId);
         const now = Date.now();
         const isFinished = duration > 0 && (currentTime / duration) * 100 >= (cachedSettings?.staticFinishPercent || CONFIG.defaultSettings.staticFinishPercent);
 
@@ -4110,8 +4802,13 @@ background: var(--ypp-danger);
             lastViewedPlaylistItemId: null
         };
 
-        Storage.set(videoId, videoData);
+        const storageResult = await Storage.set(videoId, videoData);
         log('saveShortsVideo', `✅ Short guardado:`, videoData);
+
+        // Verificar si hubo error de almacenamiento
+        if (storageResult && !storageResult.success) {
+            return { success: false, reason: storageResult.reason, videoId, type: 'shorts' };
+        }
 
         return { success: true, videoId, timestamp: videoData.timestamp, type: 'shorts' };
     }
@@ -4125,10 +4822,10 @@ background: var(--ypp-danger);
      * @param {string} previewType - 'preview_watch' o 'preview_shorts'
      * @returns {Object} Resultado de la operación
      */
-    function savePreview(videoId, currentTime, duration, videoInfo, previewType) {
+    async function savePreview(videoId, currentTime, duration, videoInfo, previewType) {
         log('savePreview', `Guardando preview ${previewType} para ${videoId} en ${currentTime}s`);
 
-        const sourceData = getSavedVideoData(videoId);
+        const sourceData = await getSavedVideoData(videoId);
         const now = Date.now();
         const isFinished = duration > 0 && (currentTime / duration) * 100 >= (cachedSettings?.staticFinishPercent || CONFIG.defaultSettings.staticFinishPercent);
 
@@ -4145,8 +4842,13 @@ background: var(--ypp-danger);
             thumb: `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`
         };
 
-        Storage.set(videoId, videoData);
+        const storageResult = await Storage.set(videoId, videoData);
         log('savePreview', `✅ Preview guardado:`, videoData);
+
+        // Verificar si hubo error de almacenamiento
+        if (storageResult && !storageResult.success) {
+            return { success: false, reason: storageResult.reason, videoId, type: 'preview' };
+        }
 
         return { success: true, videoId, timestamp: videoData.timestamp, type: 'preview' };
     }
@@ -4159,10 +4861,10 @@ background: var(--ypp-danger);
      * @param {Object} videoInfo - Información del livestream
      * @returns {Object} Resultado de la operación
      */
-    function saveLivestream(videoId, currentTime, duration, videoInfo) {
+    async function saveLivestream(videoId, currentTime, duration, videoInfo) {
         log('saveLivestream', `Guardando livestream ${videoId} en ${currentTime}s`);
 
-        const sourceData = getSavedVideoData(videoId);
+        const sourceData = await getSavedVideoData(videoId);
         const now = Date.now();
 
         const videoData = {
@@ -4179,8 +4881,13 @@ background: var(--ypp-danger);
             lastViewedPlaylistItemId: null
         };
 
-        Storage.set(videoId, videoData);
+        const storageResult = await Storage.set(videoId, videoData);
         log('saveLivestream', `✅ Livestream guardado:`, videoData);
+
+        // Verificar si hubo error de almacenamiento
+        if (storageResult && !storageResult.success) {
+            return { success: false, reason: storageResult.reason, videoId, type: 'live' };
+        }
 
         return { success: true, videoId, timestamp: videoData.timestamp, type: 'live' };
     }
@@ -4188,7 +4895,7 @@ background: var(--ypp-danger);
     /**
      * Dispatcher principal: detecta el tipo y delega al VideoTypeHandler.
      * Esta función simplifica el proceso de guardado usando el patrón Strategy.
-     * 
+     *
      * @param {string} videoId - ID del video
      * @param {number} currentTime - Tiempo actual en segundos
      * @param {number} duration - Duración total del video
@@ -4238,13 +4945,13 @@ background: var(--ypp-danger);
     * @param {string|null} playlistId - ID de la playlist (opcional)
     * @returns {Object|null} - Datos guardados o null si no se encuentra
     */
-    function getSavedVideoData(videoId, playlistId = null) {
+    async function getSavedVideoData(videoId, playlistId = null) {
         log('getSavedVideoData', `Buscando datos guardados para ID: ${videoId} | Playlist ID: ${playlistId}`);
         if (!videoId) return null;
 
         // En el formato FreeTube, todos los videos se guardan con video_id como clave
         // independientemente de si fueron vistos en una playlist o no
-        const videoData = Storage.get(videoId);
+        const videoData = await Storage.get(videoId);
 
         if (videoData) {
             // Si encontramos el video y se especificó un playlistId, verificar compatibilidad
@@ -4262,7 +4969,7 @@ background: var(--ypp-danger);
 
         // Compatibilidad con formato antiguo (playlists anidadas)
         if (playlistId) {
-            const oldPlaylistData = Storage.get(playlistId);
+            const oldPlaylistData = await Storage.get(playlistId);
             if (oldPlaylistData?.videos?.[videoId]) {
                 log('getSavedVideoData', `✅ Video encontrado en formato antiguo (playlist anidada)`);
                 return oldPlaylistData.videos[videoId];
@@ -4270,11 +4977,11 @@ background: var(--ypp-danger);
         }
 
         // Búsqueda flexible: por si alguna vez se guardó con prefijos raros
-        const keys = Storage.keys?.() || [];
+        const keys = await Storage.keys?.() || [];
         const altKey = keys.find(k => k.endsWith(videoId) || k.includes(videoId));
         if (altKey && altKey !== `playlist_meta_${videoId}`) {
             log('getSavedVideoData', `✅ Video encontrado con clave alternativa: ${altKey}`);
-            return Storage.get(altKey);
+            return await Storage.get(altKey);
         }
 
         log('getSavedVideoData', `✗ No se encontraron datos para el video`);
@@ -4322,7 +5029,7 @@ background: var(--ypp-danger);
         }
 
         // Obtiene todas las claves almacenadas
-        const allKeys = Storage.keys();
+        const allKeys = await Storage.keys();
         // Contador para llevar registro de cuántas claves se han migrado
         let changes = 0;
 
@@ -4338,12 +5045,12 @@ background: var(--ypp-danger);
             // Si se obtuvo un ID válido y diferente de la clave original
             if (newKey && newKey !== key) {
                 // Obtiene los datos asociados a la clave antigua
-                const data = Storage.get(key);
+                const data = await Storage.get(key);
 
                 // Solo migra si la nueva clave aún no existe (para evitar sobrescribir datos)
-                if (!Storage.get(newKey)) {
-                    Storage.set(newKey, data);  // Guarda los datos bajo la nueva clave
-                    Storage.del(key);           // Elimina la clave antigua
+                if (!(await Storage.get(newKey))) {
+                    await Storage.set(newKey, data);  // Guarda los datos bajo la nueva clave
+                    await Storage.del(key);           // Elimina la clave antigua
                     log('normalizeYouTubeStorageKeys', `✅ Migrado: "${key}" -> "${newKey}"`);
                     changes++;
                 } else {
@@ -4905,7 +5612,7 @@ background: var(--ypp-danger);
      * Determina el contexto/tipo de un elemento <video> basado en su ubicación en el DOM.
      * Extrae la lógica de selección de miniplayer/shorts/watch para que processVideo()
      * ya sepa qué tipo de contenido está procesando.
-     * 
+     *
      * @param {HTMLVideoElement} videoElement - Elemento <video> a analizar
      * @returns {Object} Objeto con propiedades:
      *   - type: 'miniplayer' | 'shorts' | 'watch' | 'preview' | 'unknown'
@@ -4940,6 +5647,16 @@ background: var(--ypp-danger);
                 result.type = 'shorts';
                 result.container = shortsContainer;
                 result.shouldProcess = cachedSettings?.saveShorts !== false;
+                return result;
+            }
+
+            // Fallback para Shorts: verificar si estamos en página de Shorts y el video está reproduciendo
+            const pageType = getYouTubePageType();
+            if (pageType === 'shorts' && videoElement.src && videoElement.src.includes('blob:')) {
+                result.type = 'shorts';
+                result.container = videoElement.closest('div') || videoElement.parentElement;
+                result.shouldProcess = cachedSettings?.saveShorts !== false;
+                log('determineVideoContext', `🔍 Shorts detectado por URL y reproducción activa: ${videoElement.src.substring(0, 50)}...`);
                 return result;
             }
 
@@ -5133,10 +5850,10 @@ background: var(--ypp-danger);
      * Facade para extracción unificada de metadatos de video.
      * Proporciona una interfaz única que delega a las funciones especializadas
      * existentes mientras mantiene el aislamiento de contexto.
-     * 
+     *
      * IMPORTANTE: Detecta automáticamente el contexto (shorts vs miniplayer vs watch)
      * para evitar contaminación de datos entre players coexistentes.
-     * 
+     *
      * @namespace VideoInfoFacade
      */
     const VideoInfoFacade = (() => {
@@ -5159,7 +5876,7 @@ background: var(--ypp-danger);
         /**
          * Extrae metadatos de video con detección automática de contexto.
          * Usa las funciones existentes pero centraliza la lógica de contexto.
-         * 
+         *
          * @param {Object} options - Opciones de extracción
          * @param {Object} [options.player] - Objeto player de YouTube
          * @param {HTMLVideoElement} [options.videoElement] - Elemento <video>
@@ -5184,10 +5901,13 @@ background: var(--ypp-danger);
             try {
                 if (context.type === 'shorts') {
                     metadata = await extractForShorts(resolvedVideoId, videoElement);
+                    log('VideoInfoFacade', `Shorts metadata:`, metadata);
                 } else if (context.type === 'miniplayer') {
                     metadata = await extractForMiniplayer(resolvedVideoId, player);
+                    log('VideoInfoFacade', `Miniplayer metadata:`, metadata);
                 } else {
                     metadata = await extractForWatch(resolvedVideoId, player);
+                    log('VideoInfoFacade', `Watch metadata:`, metadata);
                 }
             } catch (error) {
                 warn('VideoInfoFacade', `Error en extracción para ${context.type}:`, error);
@@ -5453,7 +6173,7 @@ background: var(--ypp-danger);
     // Obtiene el título del video con validación contra datos desactualizados.
     // Usa patrón YTHelper-first con fallbacks en cascada.
     //
-    // CRÍTICO: validateTitle() valida contra document.title para evitar 
+    // CRÍTICO: validateTitle() valida contra document.title para evitar
     // usar títulos de videos ANTERIORES cuando navegas rápido.
     function getVideoTittle(player) {
         // ======================================================================
@@ -5925,11 +6645,11 @@ background: var(--ypp-danger);
     /**
      * Extrae metadatos del Short ACTIVO desde el UI (metapanel/overlay).
      * Consolida las búsquedas de title, views, y channelId en una sola función.
-     * 
+     *
      * OPTIMIZACIÓN: En lugar de 3 funciones separadas que buscan selectores,
      * esta función busca el elemento raíz del Short ACTIVO una sola vez y extrae
      * toda la información del mismo elemento, evitando múltiples querySelector.
-     * 
+     *
      * @returns {Object} { title: string|null, views: string|null, channelId: string|null }
      */
     function extractShortsMetadata() {
@@ -6039,12 +6759,12 @@ background: var(--ypp-danger);
      *
      * @param {string} videoId - ID del video de YouTube.
      * @returns {Promise<WatchMeta>} Metadatos extraídos del video.
-     * 
+     *
      * @example
      * fetchWatchMeta('dQw4w9WgXcQ').then((meta) => {
      *     console.log(meta);
      * });
-     * 
+     *
      */
     const fetchWatchMeta = (videoId) => {
         return new Promise((resolve) => {
@@ -6279,9 +6999,12 @@ background: var(--ypp-danger);
 
     // MARK: getVideoInfo
     async function getVideoInfo(player, videoId) {
+        const startTime = performance.now();
         const now = Date.now();
 
-        warn('getVideoInfo', player.outerHTML + ' ' + videoId)
+        log('getVideoInfo', `🔄 Iniciando extracción para ${videoId}`);
+
+        // warn('getVideoInfo', player.outerHTML + ' ' + videoId)
 
         // Contexto de la página
         const ptV = getYouTubePageType();
@@ -6290,14 +7013,19 @@ background: var(--ypp-danger);
         const isVideoInMiniPlayer = PlayerStateManager.isVideoInMiniPlayer(videoId);
 
         // Título y autor - usar datos específicos del miniplayer si corresponde
-        let title, author;
+        let title, author, metaFromMiniplayer = null;
         if (isVideoInMiniPlayer) {
             // Para miniplayer, obtener datos desde caché de watch metadata para evitar contaminación
             try {
-                const meta = await getWatchMetaCached(videoId);
-                title = meta?.title || getVideoTittle(player);
-                author = meta?.author || getVideoAuthor(player);
+                metaFromMiniplayer = await getWatchMetaCached(videoId);
+                log('getVideoInfo', `📱 Miniplayer: Metadata ${metaFromMiniplayer ? 'OBTENIDA' : 'NO DISPONIBLE'} para ${videoId}`);
+                if (metaFromMiniplayer) {
+                    log('getVideoInfo', `📊 Miniplayer datos: title="${metaFromMiniplayer.title?.substring(0, 30)}..." author="${metaFromMiniplayer.author}" views="${metaFromMiniplayer.viewsNumber}"`);
+                }
+                title = metaFromMiniplayer?.title || getVideoTittle(player);
+                author = metaFromMiniplayer?.author || getVideoAuthor(player);
             } catch (_) {
+                log('getVideoInfo', `⚠️ Miniplayer: Error obteniendo metadata para ${videoId}, usando fallback DOM`);
                 title = getVideoTittle(player);
                 author = getVideoAuthor(player);
             }
@@ -6409,14 +7137,18 @@ background: var(--ypp-danger);
                 document.querySelector('#movie_player a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
                 '';
             // Fusionar con metadata de la página watch del miniplayer para asegurar datos correctos
-            try {
-                const meta = await getWatchMetaCached(videoId);
-                if (meta && meta.authorId) authorId = meta.authorId;
-                if (meta && meta.author) author = meta.author;
-                if (meta && meta.viewsNumber) viewsNumber = meta.viewsNumber;
-                if (meta && meta.title) title = meta.title;
-                if (meta && meta.description) description = meta.description;
-            } catch (_) { }
+            if (metaFromMiniplayer) {
+                log('getVideoInfo', `🔄 Miniplayer: Reutilizando metadata cacheada para ${videoId}`);
+                let appliedFields = [];
+                if (metaFromMiniplayer.authorId) { authorId = metaFromMiniplayer.authorId; appliedFields.push('authorId'); }
+                if (metaFromMiniplayer.author) { author = metaFromMiniplayer.author; appliedFields.push('author'); }
+                if (metaFromMiniplayer.viewsNumber) { viewsNumber = metaFromMiniplayer.viewsNumber; appliedFields.push('viewsNumber'); }
+                if (metaFromMiniplayer.title) { title = metaFromMiniplayer.title; appliedFields.push('title'); }
+                if (metaFromMiniplayer.description) { description = metaFromMiniplayer.description; appliedFields.push('description'); }
+                log('getVideoInfo', `✅ Miniplayer: Campos aplicados: ${appliedFields.join(', ')}`);
+            } else {
+                log('getVideoInfo', `⚠️ Miniplayer: Sin metadata cacheada disponible para ${videoId}`);
+            }
             if (!authorId) authorId = t('unknown');
         } else if (ptV === 'shorts') {
             // Shorts normales (sin miniplayer): primero metapanel/overlay del Short ACTIVO
@@ -6585,9 +7317,10 @@ background: var(--ypp-danger);
 
 
 
+        const extractionTime = performance.now() - startTime;
         log('getVideoInfo', 'Info:', {
-            title,
-            author,
+            title: title?.substring(0, 30),
+            author: author?.substring(0, 20),
             viewsNumber,
             savedAt: now,
             duration,
@@ -6595,7 +7328,10 @@ background: var(--ypp-danger);
             videoId,
             published,
             description,
-            isLive
+            isLive,
+            extractionTime: `${extractionTime.toFixed(2)}ms`,
+            pageType: ptV,
+            isMiniPlayer: isVideoInMiniPlayer
         })
         return {
             title,
@@ -7099,8 +7835,38 @@ background: var(--ypp-danger);
 
     // MARK: 📺 Get Playlist Name
     const playlistNameCache = new Map();
+    const pendingPlaylistRequests = new Map(); // Track pending HTTP requests
+    // Helper para búsqueda profunda en objetos JSON
+    const findDeepInObject = (obj, key) => {
+        if (!obj || typeof obj !== 'object') return null;
+
+        // Si el objeto tiene la clave directamente
+        if (obj.hasOwnProperty(key)) {
+            const value = obj[key];
+            if (typeof value === 'string' && value.trim().length > 0 && value !== 'null' && value !== 'undefined') {
+                return value;
+            }
+            if (value?.simpleText && typeof value.simpleText === 'string' && value.simpleText.trim().length > 0 && value.simpleText !== 'null' && value.simpleText !== 'undefined') {
+                return value.simpleText;
+            }
+            if (value?.runs?.[0]?.text && typeof value.runs[0].text === 'string' && value.runs[0].text.trim().length > 0 && value.runs[0].text !== 'null' && value.runs[0].text !== 'undefined') {
+                return value.runs[0].text;
+            }
+        }
+
+        // Buscar recursivamente
+        for (const prop in obj) {
+            if (obj.hasOwnProperty(prop)) {
+                const result = findDeepInObject(obj[prop], key);
+                if (result) return result;
+            }
+        }
+
+        return null;
+    };
+
     /**
-     * Obtiene el nombre de la playlist desde el DOM o la URL.
+     * Obtiene el nombre de una playlist desde YouTube API o DOM o la URL.
      * @param {string} playlistId - ID de la playlist.
      * @returns {string|null} Nombre de la playlist o null si no se encuentra.
      *
@@ -7108,93 +7874,114 @@ background: var(--ypp-danger);
      * https://www.youtube.com/watch?v=VIDEO_ID&list=PLAYLIST_ID
      */
     async function getPlaylistName(playlistId) {
+        if (!playlistId) return null;
+
+        // 1. Verificar cache en memoria
         if (playlistNameCache.has(playlistId)) {
-            return playlistNameCache.get(playlistId);
-        }
-
-        const url = new URL(location.href);
-        const currentPlaylistId = url.searchParams.get('list');
-
-        if (currentPlaylistId === playlistId) {
-            // Intentar múltiples selectores para el panel de playlist
-            const playlistName =
-                // Playlist panel en el reproductor
-                document.querySelector('ytd-playlist-panel-renderer #title span#text')?.textContent?.trim() ||
-                // Header de la página de playlist
-                document.querySelector('#header .ytd-playlist-header-renderer h1 yt-formatted-string')?.textContent?.trim() ||
-                document.querySelector('ytd-browse[page-subtype="playlist"] ytd-playlist-header-renderer #title')?.textContent?.trim() ||
-                document.querySelector('ytd-playlist-header-renderer h1.title')?.textContent?.trim() ||
-                // Alternativas adicionales
-                document.querySelector('#container #header-description yt-formatted-string')?.textContent?.trim() ||
-                document.querySelector('yt-formatted-string.title:nth-child(1)')?.textContent?.trim() ||
-                // Overlay del reproductor (menos confiable)
-                document.querySelector('.ytp-title-playlist-button')?.getAttribute('aria-label')?.replace(/^Playlist:\s*/, '')?.trim() ||
-                document.querySelector('.byline-title')?.textContent?.trim();
-
-            log('getPlaylistName', 'Playlist name from DOM:', playlistName);
-            if (playlistName) {
-                playlistNameCache.set(playlistId, playlistName);
-                return playlistName;
+            const cachedTitle = playlistNameCache.get(playlistId);
+            // Si el cache tiene un título válido (no genérico), usarlo directamente
+            if (cachedTitle && cachedTitle !== playlistId) {
+                log('getPlaylistName', `✅ Usando título cacheado válido para ${playlistId}: "${cachedTitle}"`);
+                return cachedTitle;
             }
         }
 
-        return new Promise((resolve) => {
-            GM_xmlhttpRequest({
-                method: 'GET',
-                url: `https://www.youtube.com/playlist?list=${playlistId}`,
-                onload: function (response) {
-                    try {
-                        const htmlText = response.responseText;
+        // 2. Verificar si hay una petición en curso
+        if (pendingPlaylistRequests.has(playlistId)) {
+            log('getPlaylistName', `⏳ Ya existe una petición en curso para ${playlistId}, reutilizando promesa...`);
+            return pendingPlaylistRequests.get(playlistId);
+        }
 
-                        // Intentar extraer JSON principal
-                        const ytInitialDataMatch = htmlText.match(/var ytInitialData = ({.+?});/);
-                        let title = null;
+        const requestPromise = (async () => {
+            const url = new URL(location.href);
+            const currentPlaylistId = url.searchParams.get('list');
 
-                        if (ytInitialDataMatch) {
-                            const data = JSON.parse(ytInitialDataMatch[1]);
+            if (currentPlaylistId === playlistId) {
+                // Intentar múltiples selectores para el panel de playlist
+                const playlistName =
+                    // Playlist panel en el reproductor (Watch Page Sidebar)
+                    // NO document.querySelector('ytd-playlist-panel-renderer .header-description h3 a')?.textContent?.trim() ||
+                    // NO document.querySelector('ytd-playlist-panel-renderer .header-description h3')?.textContent?.trim() ||
+                    document.querySelector('ytd-playlist-panel-renderer #header-description h3 a')?.textContent?.trim() ||
+                    document.querySelector('ytd-playlist-panel-renderer #header-description h3')?.textContent?.trim() ||
+                    // NO document.querySelector('ytd-playlist-panel-renderer .playlist-header-content .title')?.textContent?.trim() ||
 
-                            // Intentar extraer título de playlist normal
-                            title = data?.metadata?.playlistMetadataRenderer?.title ||
-                                data?.sidebar?.playlistSidebarRenderer?.items?.[0]?.playlistSidebarPrimaryInfoRenderer?.title?.runs?.[0]?.text ||
-                                data?.header?.playlistHeaderRenderer?.title?.simpleText;
+                    // YouTube Mix y estructuras antiguas
+                    document.querySelector('ytd-playlist-panel-renderer yt-formatted-string.title')?.textContent?.trim() ||
+                    document.querySelector('#header-description yt-formatted-string.title')?.textContent?.trim() ||
+                    // NO document.querySelector('ytd-playlist-panel-renderer #title span#text')?.textContent?.trim() ||
 
-                            // Fallback: intentar rutas típicas de Mixes automáticos
-                            if (!title) {
-                                title = data?.contents?.twoColumnWatchNextResults?.playlist?.playlist?.title ||
-                                    data?.playerOverlays?.playerOverlayRenderer?.autoplay?.autoplay?.title?.simpleText ||
-                                    data?.contents?.twoColumnWatchNextResults?.playlist?.title;
-                            }
-                        }
+                    // Alternativas adicionales
+                    document.querySelector('#container #header-description yt-formatted-string')?.textContent?.trim() ||
+                    document.querySelector('yt-formatted-string.title:nth-child(1)')?.textContent?.trim() ||
 
-                        // Si aún no hay título, buscar en meta tags
-                        if (!title) {
-                            const metaTitleMatch = htmlText.match(/<meta property="og:title" content="([^"]+)">/);
-                            if (metaTitleMatch && metaTitleMatch[1]) {
-                                title = metaTitleMatch[1];
-                            }
-                        }
+                    // Overlay del reproductor
+                    // NO document.querySelector('.ytp-title-playlist-button')?.getAttribute('aria-label')?.replace(/^Playlist:\s*/, '')?.trim() ||
+                    document.querySelector('.byline-title')?.textContent?.trim();
 
-                        // Si no se pudo extraer, usar el ID como fallback
-                        if (!title) {
-                            warn('getPlaylistName', 'No se pudo extraer el título de la playlist, usando ID');
-                            title = playlistId;
-                        }
+                // si PAGE TYPE ES PLAYLIST
+                // Header de la página de playlist (si estamos en la página de playlist)
 
-                        playlistNameCache.set(playlistId, title);
-                        log('getPlaylistName', `Título obtenido: ${title}`);
-                        resolve(title);
-                    } catch (e) {
-                        conError('getPlaylistName', 'Error parsing playlist page:', e);
-                        playlistNameCache.set(playlistId, playlistId);
-                        resolve(playlistId);
-                    }
-                },
-                onerror: function (error) {
-                    conError('getPlaylistName', 'Error fetching playlist page:', error);
-                    playlistNameCache.set(playlistId, playlistId);
-                    resolve(playlistId);
+                const ptNow = getYouTubePageType();
+                const browsePlaylistName = ptNow === 'playlist' ? (
+                    document.querySelector('#header .ytd-playlist-header-renderer h1 yt-formatted-string')?.textContent?.trim() ||
+                    document.querySelector('ytd-browse[page-subtype="playlist"] ytd-playlist-header-renderer #title')?.textContent?.trim() ||
+                    document.querySelector('ytd-playlist-header-renderer h1.title')?.textContent?.trim()
+                ) : null;
+
+                const finalDomName = playlistName || browsePlaylistName;
+
+                if (finalDomName && finalDomName !== playlistId) {
+                    playlistNameCache.set(playlistId, finalDomName);
+                    return finalDomName;
                 }
+            }
+
+            // Solo hacer HTTP request si no hay cache válido o si el cache es genérico
+            return new Promise((resolve) => {
+                log('getPlaylistName', `🌐 Making HTTP request for playlist ${playlistId}`);
+                GM_xmlhttpRequest({
+                    method: 'GET',
+                    url: `https://www.youtube.com/playlist?list=${playlistId}`,
+                    onload: function (response) {
+                        try {
+                            const htmlText = response.responseText;
+                            let ytInitialDataMatch = htmlText.match(/var ytInitialData = ({.+?});/) || htmlText.match(/window\["ytInitialData"\] = ({.+?});/);
+                            let title = null;
+
+                            if (ytInitialDataMatch) {
+                                try {
+                                    const data = JSON.parse(ytInitialDataMatch[1]);
+                                    title = data?.contents?.twoColumnWatchNextResults?.playlist?.playlist?.title ||
+                                        data?.contents?.twoColumnWatchNextResults?.playlist?.playlist?.header?.title ||
+                                        data?.header?.playlistHeaderRenderer?.title?.simpleText ||
+                                        data?.header?.playlistHeaderRenderer?.title?.runs?.[0]?.text ||
+                                        data?.metadata?.playlistMetadataRenderer?.title ||
+                                        data?.microformat?.microformatDataRenderer?.title ||
+                                        findDeepInObject(data, 'title');
+                                } catch (_) { }
+                            }
+
+                            if (!title || title === 'null') {
+                                const titleMatch = htmlText.match(/<title>(.*?) - YouTube<\/title>/) || htmlText.match(/<title>(.*?)<\/title>/);
+                                if (titleMatch) title = titleMatch[1].trim();
+                            }
+
+                            title = (title && title !== 'null' && title !== 'undefined') ? title : playlistId;
+                            playlistNameCache.set(playlistId, title);
+                            resolve(title);
+                        } catch (e) {
+                            resolve(playlistId);
+                        }
+                    },
+                    onerror: () => resolve(playlistId)
+                });
             });
+        })();
+
+        pendingPlaylistRequests.set(playlistId, requestPromise);
+        return requestPromise.finally(() => {
+            pendingPlaylistRequests.delete(playlistId);
         });
     }
 
@@ -7232,6 +8019,8 @@ background: var(--ypp-danger);
     async function getCachedVideoInfo(player, video_id) {
         const cacheKey = video_id;
         const cached = videoInfoCache.get(cacheKey);
+
+        log('getCachedVideoInfo', `🔍 Buscando cache para ${video_id}: ${cached ? 'FOUND' : 'MISS'}`);
 
         // Durante navegación, ser más estricto con el caché para evitar datos obsoletos
         const cacheTimeout = isNavigating ? 30 * 1000 : CACHE_DURATION; // 30 segundos durante navegación, 5 minutos normal
@@ -7281,12 +8070,12 @@ background: var(--ypp-danger);
 
         // Retornar cache solo si es válido Y preciso
         if (effectiveCacheValid && isCacheAccurate) {
-            log('getCachedVideoInfo', `✅ Usando cache para ${video_id}`);
+            log('getCachedVideoInfo', `✅ Cache HIT para ${video_id} (${isNavigating ? 'navegando' : 'normal'})`);
             return cached.data;
         }
 
         // Obtener info fresca
-        log('getCachedVideoInfo', `🔄 Obteniendo info fresca para ${video_id}${isNavigating ? ' (navegando)' : ''}${!isCacheAccurate ? ' (cache impreciso)' : ''}`);
+        log('getCachedVideoInfo', `❌ Cache MISS para ${video_id}${isNavigating ? ' (navegando)' : ''}${!isCacheAccurate ? ' (cache impreciso)' : ''}`);
         const info = await getVideoInfo(player, video_id);
 
         // Solo guardar en cache si no estamos navegando O si los datos parecen válidos
@@ -7297,9 +8086,9 @@ background: var(--ypp-danger);
                 data: info,
                 timestamp: Date.now()
             });
-            log('getCachedVideoInfo', `💾 Info cacheada para ${video_id}: "${info.title}"`);
+            log('getCachedVideoInfo', `💾 Cache guardado para ${video_id}: "${info.title?.substring(0, 30)}..."`);
         } else {
-            log('getCachedVideoInfo', `⏭️ No cacheando durante navegación para ${video_id}`);
+            log('getCachedVideoInfo', `⏭️ Sin cache para ${video_id} (navegando)`);
         }
 
         return info;
@@ -7354,7 +8143,7 @@ background: var(--ypp-danger);
 
 
 
-        if (pageTypeNow === 'home' && homeVideoCheck) {
+        if (pageTypeNow === 'home' && homeVideoCheck && location.pathname !== '/watch') {
             let containerId = null;
             try { containerId = homeVideoCheck.closest('#movie_player, #shorts-player')?.id || null; } catch (_) { }
 
@@ -7374,6 +8163,12 @@ background: var(--ypp-danger);
                     for (const selector of miniPlayerUrlSelectors) {
                         const anchor = document.querySelector(selector);
                         if (anchor) {
+                            // FIX: Strict container check to avoid sidebar Mixes (updateStatus)
+                            const validContainer = anchor.closest('#movie_player, ytd-miniplayer, .ytp-miniplayer-ui, #player, #c4-player');
+                            if (!validContainer) {
+                                log('updateStatus', `⚠️ Ignored sidebar candidate: ${anchor.href}`);
+                                continue;
+                            }
                             const fullUrl = anchor.href;
                             const urlVideoId = extractOrNormalizeVideoId(fullUrl)?.id;
                             if (urlVideoId === expectedVideoId) {
@@ -7410,14 +8205,17 @@ background: var(--ypp-danger);
         const urlDataNow = extractOrNormalizeVideoId(url);
         const urlIdNow = urlDataNow?.id || null;
 
+        // Fuente del playlist en este ciclo
+        let playlistSource = null; // 'url' | 'anchor' | 'fallback' | null
+
         // Para miniplayer con URL verificada, usar directamente el playlist ID de la URL
         const playerState = PlayerStateCache.getCurrentState();
         if (playerState.hasMiniPlayer && urlDataNow?.list) {
             plId = urlDataNow.list;
+            playlistSource = 'url';
             log('updateStatus', `📌 Usando playlist ID de URL verificada para miniplayer: ${plId}`);
         }
-        // Fuente del playlist en este ciclo (solo se usa para Shorts)
-        let playlistSource = null; // 'url' | 'anchor' | 'fallback' | null
+
         let contId = null; // Identificador del contenedor (movie_player | shorts-player | null)
         try { contId = videoEl?.closest?.('#movie_player, #shorts-player')?.id || null; } catch (_) { }
 
@@ -7474,9 +8272,22 @@ background: var(--ypp-danger);
                 playlistSource = pSource;
             } else {
                 // Si plId ya viene como parámetro (desde processVideo), usarlo
+
+                // FIX: Si el plId coincide con la URL actual, marcar como fuente 'url' confiable
+                if (plId && urlDataNow?.list === plId) {
+                    playlistSource = 'url';
+                }
+
                 // Solo resolver si no se proporcionó plId
-                if (!plId) {
+                // FIX: Strict check for clean Watch pages before attempting DOM scraping fallback
+                // This prevents scraping playlists from video descriptions (#anchored-panel) when none are active.
+                const isCleanWatch = location.pathname === '/watch' && !new URLSearchParams(location.search).has('list');
+
+
+                if (!plId && !isCleanWatch) {
                     let p = urlDataNow?.list || null;
+                    let pSrc = p ? 'url' : null;
+
                     if (!p) {
                         try {
                             const a = document.querySelector('#anchored-panel a[href*="list="]') ||
@@ -7485,14 +8296,17 @@ background: var(--ypp-danger);
                             if (a) {
                                 const ua = new URL(a.href, location.origin);
                                 const la = ua.searchParams.get('list');
-                                if (la) p = la;
+                                if (la) { p = la; pSrc = 'anchor'; }
                             }
                         } catch (_) { }
                     }
                     if (!p) {
                         try { if (lastPlaylistId) p = lastPlaylistId; } catch (_) { }
                     }
-                    if (p) plId = p;
+                    if (p) {
+                        plId = p;
+                        if (pSrc) playlistSource = pSrc;
+                    }
                     try { if (plId) lastPlaylistId = plId; } catch (_) { }
                 } else {
                     // plId ya viene del parámetro, solo actualizar lastPlaylistId si es estable
@@ -7687,7 +8501,13 @@ background: var(--ypp-danger);
                 if (isNaN(currentTime) || currentTime < 1) return { success: false, reason: 'invalid_data' };
             } else {
                 // Para no-LIVE requerimos duración finita y datos válidos
-                if (!duration || !isFinite(duration) || isNaN(currentTime) || currentTime < 1) return { success: false, reason: 'invalid_data' };
+                // Tiempo mínimo unificado a 0.1s para todos los tipos (incluyendo regulares)
+                // Esto permite detección temprana inmediata después de anuncios
+                const minTime = 0.1;
+
+                if (!duration || !isFinite(duration) || isNaN(currentTime) || currentTime < minTime) {
+                    return { success: false, reason: 'invalid_data' };
+                }
             }
 
             // Evitar guardar progreso durante anuncios (tipo-aware)
@@ -7733,7 +8553,7 @@ background: var(--ypp-danger);
             }
 
             // Buscar progreso previo siempre
-            const sourceData = getSavedVideoData(video_id, plId);
+            const sourceData = await getSavedVideoData(video_id, plId);
 
             // Verificar si el video está completado (staticFinishPercent porcentaje del video)
             const isFinished = !isLiveType && duration > 0 && (currentTime / duration) * 100 >= (cachedSettings?.staticFinishPercent || CONFIG.defaultSettings.staticFinishPercent);
@@ -7751,13 +8571,13 @@ background: var(--ypp-danger);
                         base.thumb = `https://i.ytimg.com/vi/${video_id}/maxresdefault.jpg`;
                     }
                     if (plId) {
-                        const playlist = Storage.get(plId);
+                        const playlist = await Storage.get(plId);
                         if (playlist?.videos?.[video_id]) {
                             playlist.videos[video_id] = base;
-                            Storage.set(plId, playlist);
+                            await Storage.set(plId, playlist);
                         }
                     } else {
-                        Storage.set(video_id, base);
+                        await Storage.set(video_id, base);
                         log('updateStatus', `Datos guardados para ${video_id}:`, base);
                         return { success: true, video_id, timestamp: base.timestamp };
                     }
@@ -7798,7 +8618,11 @@ background: var(--ypp-danger);
             // Determinar tipo efectivo a guardar: preservar previews inline si están habilitadas y no son anuncios
             let finalType = type;
             try {
-                if (allowInline) {
+                // Solo permitir detección de inline previews en Home, Search o Channel
+                // En modo Watch, el video principal NUNCA debe tratarse como preview inline
+                const isBrowsePage = pageTypeNow === 'home' || pageTypeNow === 'search' || pageTypeNow === 'channel' || pageTypeNow === 'unknown';
+
+                if (allowInline && isBrowsePage) {
                     const isInlineCtx = !!(videoEl?.closest?.('#inline-preview-player') ||
                         videoEl?.closest?.('.ytp-inline-preview-ui') ||
                         videoEl?.closest?.('ytd-thumbnail-overlay-inline-playback-renderer'));
@@ -7865,25 +8689,133 @@ background: var(--ypp-danger);
                 }
             } catch (_) { }
 
+            // CRÍTICO: Verificar si el video actual es un anuncio
+            try {
+                const currentVideoEl = await getActiveVideoElement();
+                if (currentVideoEl && isAdContextNode(currentVideoEl)) {
+                    log('updateStatus', '⏸ Video actual detectado como anuncio, no guardando progreso');
+                    return { success: false, reason: 'ad_playing_current' };
+                }
+            } catch (_) { }
+
             // Guardar progreso usando el sistema especializado por tipo de contenido
             const normalizedDuration = isLiveType ? ((isFinite(duration) && duration > 0) ? duration : 0) : duration;
 
             // Determinar playlist a persistir
             let playlistToPersist = null;
             let prevSaved = null;
-            try { prevSaved = Storage.get(video_id) || null; } catch (_) { prevSaved = null; }
+            try { prevSaved = await Storage.get(video_id) || null; } catch (_) { prevSaved = null; }
+
+            // FIX: Strict check to avoid inheriting stale playlists on clean Watch pages
+            const isCleanWatch = location.pathname === '/watch' && !new URLSearchParams(location.search).has('list');
 
             if (finalType === 'shorts') {
                 playlistToPersist = (plId && (playlistSource === 'url' || playlistSource === 'anchor')) ? plId : null;
-            } else if (plId) {
+            } else if (plId && (playlistSource === 'url' || playlistSource === 'anchor')) {
+                // Solo persistir playlists de fuentes confiables (URL o anchor) para videos regulares
+                // Evitar persistir playlists encontradas en DOM que pertenezcan a otros videos
                 playlistToPersist = plId;
-            } else if (prevSaved?.lastViewedPlaylistId) {
-                playlistToPersist = prevSaved.lastViewedPlaylistId;
-                log('updateStatus', `Manteniendo asociación con lista de reproducción: ${playlistToPersist}`);
+            } else if (plId && /^RD/.test(plId)) {
+                // Excepción para YouTube Mix (RD...) - verificar si está en la URL del video actual
+                // PERO primero verificar si el usuario hizo clic en un video sin playlist
+                const hasUserClick = lastClickedVideoId === video_id && lastClickedVideoLink;
+                const clickHasNoPlaylist = hasUserClick && !new URL(lastClickedVideoLink, location.origin).searchParams.get('list');
+
+                if (clickHasNoPlaylist) {
+                    // Usuario hizo clic en video sin playlist - limpiar asociación incluso si es YouTube Mix
+                    log('updateStatus', `🧼 Usuario clickeó video sin playlist, ignorando YouTube Mix ${plId}`);
+                    playlistToPersist = null;
+                } else {
+                    // Lógica normal de YouTube Mix
+                    let currentUrl = location.href;
+                    let urlPlaylistId = null;
+                    let detectionSource = '';
+
+                    if (videoEl?.src?.includes('blob:')) {
+                        // Miniplayer: reconstruir URL desde videoId y buscar playlist
+                        log('updateStatus', `🔍 YouTube Mix ${plId} - Miniplayer detectado (blob URL), analizando video ${video_id}`);
+
+                        const constructedUrl = `https://www.youtube.com/watch?v=${video_id}`;
+                        const urlParams = new URL(constructedUrl, location.origin).searchParams;
+                        urlPlaylistId = urlParams.get('list');
+                        detectionSource = 'URL reconstruida';
+                        log('updateStatus', `📋 URL reconstruida: ${constructedUrl} | Playlist: ${urlPlaylistId}`);
+
+                        // Si no hay playlist en la URL reconstruida, buscar en lastVideoUrl
+                        if (!urlPlaylistId && lastVideoUrl) {
+                            try {
+                                const lastUrlParams = new URL(lastVideoUrl, location.origin).searchParams;
+                                urlPlaylistId = lastUrlParams.get('list');
+                                detectionSource = 'lastVideoUrl';
+                                log('updateStatus', `📋 lastVideoUrl: ${lastVideoUrl} | Playlist: ${urlPlaylistId}`);
+                            } catch (e) {
+                                log('updateStatus', `⚠️ Error parseando lastVideoUrl: ${e.message}`);
+                            }
+                        }
+
+                        // Si aún no hay playlist, verificar si el plId actual pertenece a este video
+                        if (!urlPlaylistId && plId) {
+                            // CRÍTICO: Verificar si es un anuncio - los anuncios NO deben heredar playlists
+                            const isAd = isAdBlockedFor('watch') || isAdBlockedFor('shorts');
+                            if (isAd) {
+                                log('updateStatus', `🚫 Anuncio detectado, no heredando playlist ${plId}`);
+                                urlPlaylistId = null;
+                                detectionSource = 'anuncio - ignorado';
+                            } else {
+                                // CRÍTICO: Verificar si el usuario hizo clic en video sin playlist ANTES de usar plId como fallback
+                                const hasUserClick = lastClickedVideoId === video_id && lastClickedVideoLink;
+                                const clickHasNoPlaylist = hasUserClick && !new URL(lastClickedVideoLink, location.origin).searchParams.get('list');
+
+                                if (clickHasNoPlaylist) {
+                                    // Usuario hizo clic en video sin playlist - no usar plId actual como fallback
+                                    log('updateStatus', `🧼 Usuario clickeó video sin playlist, ignorando plId actual ${plId} como fallback`);
+                                    urlPlaylistId = null;
+                                    detectionSource = 'click sin playlist - ignorado';
+                                } else {
+                                    // Verificar si este videoId está asociado con el plId actual
+                                    urlPlaylistId = plId; // Asumir que el plId actual es válido para este video
+                                    detectionSource = 'plId actual';
+                                }
+                            }
+                            log('updateStatus', `📋 Usando plId actual como fallback: ${urlPlaylistId ? plId : 'null'} (fuente: ${detectionSource})`);
+                        }
+                    } else {
+                        currentUrl = videoEl?.src || location.href;
+                        const urlParams = new URL(currentUrl, location.origin).searchParams;
+                        urlPlaylistId = urlParams.get('list');
+                        detectionSource = 'URL directa';
+                        log('updateStatus', `📋 URL directa: ${currentUrl} | Playlist: ${urlPlaylistId}`);
+                    }
+
+                    log('updateStatus', `🔍 YouTube Mix análisis: plId=${plId}, urlPlaylistId=${urlPlaylistId}, fuente=${detectionSource}, video_id=${video_id}`);
+
+                    if (urlPlaylistId === plId) {
+                        playlistToPersist = plId;
+                        log('updateStatus', `✅ YouTube Mix detectado para video ${video_id} (${detectionSource}), persistiendo playlist: ${plId}`);
+                    } else {
+                        log('updateStatus', `❌ YouTube Mix ${plId} no asociado a video ${video_id} (URL playlist: ${urlPlaylistId}, fuente: ${detectionSource}), no persistiendo`);
+                    }
+                }
+            } else if (prevSaved?.lastViewedPlaylistId && !isCleanWatch) {
+                // Solo mantener playlist anterior si no hay evidencia de click del usuario sin playlist
+                const hasUserClick = lastClickedVideoId === video_id && lastClickedVideoLink;
+                const clickHasNoPlaylist = hasUserClick && !new URL(lastClickedVideoLink, location.origin).searchParams.get('list');
+
+                if (clickHasNoPlaylist) {
+                    // Usuario hizo clic en video sin playlist - limpiar asociación
+                    log('updateStatus', `🧼 Usuario clickeó video sin playlist, limpiando asociación anterior`);
+                    playlistToPersist = null;
+                } else {
+                    // Mantener playlist anterior solo si no hay evidencia contraria
+                    playlistToPersist = prevSaved.lastViewedPlaylistId;
+                    log('updateStatus', `Manteniendo asociación con lista de reproducción: ${playlistToPersist}`);
+                }
+            } else if (isCleanWatch && prevSaved?.lastViewedPlaylistId) {
+                log('updateStatus', `🧼 Cleaning up stale playlist association because current URL has no list.`);
             }
 
             // LLAMADA AL NUEVO SISTEMA: Detección de tipo + guardado especializado
-            const saveResult = saveVideoDataByType(
+            const saveResult = await saveVideoDataByType(
                 video_id,
                 currentTime,
                 normalizedDuration,
@@ -7899,26 +8831,42 @@ background: var(--ypp-danger);
             // Procesar resultado y metadatos de playlist
             if (saveResult.success && playlistToPersist) {
                 const playlistMetaKey = `playlist_meta_${playlistToPersist}`;
-                let playlistMeta = Storage.get(playlistMetaKey) || {
+                let playlistMeta = await Storage.get(playlistMetaKey) || {
                     playlistId: playlistToPersist,
                     title: '',
                     lastWatchedVideoId: video_id,
                     lastUpdated: now
                 };
 
+                log('updateStatus', `📋 Playlist metadata loaded for ${playlistToPersist}: title="${playlistMeta.title}" | lastUpdated=${playlistMeta.lastUpdated}`);
+
                 playlistMeta.lastWatchedVideoId = video_id;
                 playlistMeta.lastUpdated = now;
-                Storage.set(playlistMetaKey, playlistMeta);
+                const metaStorageResult = await Storage.set(playlistMetaKey, playlistMeta);
 
-                if (!playlistMeta.title) {
-                    log('updateStatus', `Playlist ${playlistToPersist} sin título, buscando...`);
-                    getPlaylistName(playlistToPersist).then(name => {
-                        const updated = Storage.get(playlistMetaKey);
-                        if (updated && !updated.title) {
+                // Verificar si hubo error de almacenamiento en metadata
+                if (metaStorageResult && !metaStorageResult.success) {
+                    log('updateStatus', `⚠️ Error guardando metadata de playlist: ${metaStorageResult.reason}`);
+                    // No retornamos error aquí ya que el video se guardó correctamente
+                }
+
+                // Siempre intentar obtener el título real si no lo tenemos o si es genérico (igual al ID)
+                if (!playlistMeta.title || playlistMeta.title === playlistToPersist) {
+                    log('updateStatus', `Playlist ${playlistToPersist} sin título o con título genérico, buscando...`);
+                    getPlaylistName(playlistToPersist).then(async name => {
+                        const updated = await Storage.get(playlistMetaKey);
+                        if (updated && (!updated.title || updated.title === playlistToPersist)) {
                             updated.title = name;
-                            Storage.set(playlistMetaKey, updated);
+                            const titleStorageResult = await Storage.set(playlistMetaKey, updated);
+                            if (titleStorageResult && !titleStorageResult.success) {
+                                log('updateStatus', `⚠️ Error guardando título de playlist: ${titleStorageResult.reason}`);
+                            } else {
+                                log('updateStatus', `✅ Título de playlist guardado: "${name}" para ${playlistToPersist}`);
+                            }
                         }
                     });
+                } else {
+                    log('updateStatus', `✅ Playlist ${playlistToPersist} ya tiene título: "${playlistMeta.title}"`);
                 }
 
                 return { ...saveResult, playlistId: playlistToPersist };
@@ -8102,7 +9050,7 @@ background: var(--ypp-danger);
             const videoType = type === 'short' ? 'shorts' : 'watch';
             updateProgressBarGradient(timeToSeek, d, videoType);
         } catch (_) { }
-        /* 
+        /*
                 try {
                     const saveResult = await updateStatus(player, videoEl, type, savedData?.lastViewedPlaylistId || null, vid);
                     if (saveResult?.success) {
@@ -8130,6 +9078,9 @@ background: var(--ypp-danger);
                  } catch (_) { }
              }, 500);
          } catch (_) { } */
+
+        // Ensure flag is cleared when resume logic completes
+        setTimeout(() => { isResuming = false; }, 1000);
     };
 
     let timeDisplay;
@@ -8390,7 +9341,7 @@ background: var(--ypp-danger);
         if (timeDisplay) {
             // Dejar siempre un botón/base visible para abrir la lista de guardados
             try {
-                setInnerHTML(timeDisplay, SVG_ICONS.save || '');
+                setInnerHTML(timeDisplay, SVG_ICONS.folder || '');
             } catch (_) {
                 setInnerHTML(timeDisplay, '');
             }
@@ -8659,7 +9610,7 @@ background: var(--ypp-danger);
     // MARK: 🛠 showSettingsUI
     // ------------------------------------------
 
-    function showSettingsUI() {
+    async function showSettingsUI() {
         // Ocultar modal de videos si existe, pero no eliminarlo
         let wasVideosModalOpen = false;
         if (videosOverlay && videosContainer) {
@@ -8852,9 +9803,9 @@ background: var(--ypp-danger);
             className: 'ypp-btn ypp-btn-outlined ypp-sombra',
             id: 'viewSavedBtn',
             text: `${t('savedVideos')}`,
-            onClickEvent: () => {
+            onClickEvent: async () => {
                 overlay.remove();
-                showSavedVideosList();
+                await showSavedVideosList();
             }
         });
         footer.appendChild(viewBtn);
@@ -8867,20 +9818,19 @@ background: var(--ypp-danger);
         overlay.appendChild(modal);
 
         // Cargar configuración actual
-        Settings.get().then(settings => {
-            toggleNotif.checked = settings.showNotifications;
-            toggleButtons.checked = settings.showFloatingButtons;
-            toggleProgressBarGradient.checked = settings.enableProgressBarGradient;
-            intervalInput.value = settings.minSecondsBetweenSaves;
-            staticFinishPercentInput.value = settings.staticFinishPercent;
-            languageSelect.value = settings.language;
-            alertStyleSelect.value = settings.alertStyle;
-            saveRegularVideosCheckbox.checked = settings.saveRegularVideos;
-            saveShortsCheckbox.checked = settings.saveShorts;
-            saveLiveStreamsCheckbox.checked = settings.saveLiveStreams;
-            const inlineEl = document.getElementById('saveInlinePreviews');
-            if (inlineEl) inlineEl.checked = settings.saveInlinePreviews === true;
-        });
+        const settings = await Settings.get();
+        toggleNotif.checked = settings.showNotifications;
+        toggleButtons.checked = settings.showFloatingButtons;
+        toggleProgressBarGradient.checked = settings.enableProgressBarGradient;
+        intervalInput.value = settings.minSecondsBetweenSaves;
+        staticFinishPercentInput.value = settings.staticFinishPercent;
+        languageSelect.value = settings.language;
+        alertStyleSelect.value = settings.alertStyle;
+        saveRegularVideosCheckbox.checked = settings.saveRegularVideos;
+        saveShortsCheckbox.checked = settings.saveShorts;
+        saveLiveStreamsCheckbox.checked = settings.saveLiveStreams;
+        const inlineEl = document.getElementById('saveInlinePreviews');
+        if (inlineEl) inlineEl.checked = settings.saveInlinePreviews === true;
 
         // Añadir al DOM
         document.body.appendChild(overlay);
@@ -8941,7 +9891,11 @@ background: var(--ypp-danger);
                 return;
             }
             const videoId = YTHelper?.video.id || extractOrNormalizeVideoId(location.href)?.id;
-            log('notifySeekOrProgress', 'Video ID:', videoId, 'YTHelper?.video.id:', YTHelper?.video.id, 'extractOrNormalizeVideoId(location.href)?.id:', extractOrNormalizeVideoId(location.href)?.id)
+            // log('notifySeekOrProgress',
+            //     'Video ID:', videoId,
+            //     'YTHelper?.video.id:', YTHelper?.video.id,
+            //     'extractOrNormalizeVideoId(location.href)?.id:', extractOrNormalizeVideoId(location.href)?.id
+            // )
 
             // Usar el playlistId del saveResult si está disponible
             const playlistId = options.saveResult?.playlistId ||
@@ -8968,7 +9922,7 @@ background: var(--ypp-danger);
             }
 
             if (videoId) {
-                const videoData = getSavedVideoData(videoId, playlistId);
+                const videoData = await getSavedVideoData(videoId, playlistId);
                 if (videoData?.forceResumeTime > 0) {
                     log('notifySeekOrProgress', 'Video con tiempo fijo, omitiendo notificación de progreso.');
                     return;
@@ -9030,12 +9984,12 @@ background: var(--ypp-danger);
     /**
      * Activa/desactiva el modo de selección de videos
      */
-    function toggleSelectionMode() {
+    async function toggleSelectionMode() {
         isSelectionMode = !isSelectionMode;
         selectedVideos.clear();
 
         // Actualizar la interfaz
-        updateVideoList();
+        await updateVideoList();
         updateSelectionUI();
 
         log('toggleSelectionMode', `Modo de selección: ${isSelectionMode ? 'ACTIVADO' : 'DESACTIVADO'}`);
@@ -9246,6 +10200,98 @@ background: var(--ypp-danger);
     let lastResumeId = null;
     let currentlyProcessingVideoId = null;
     let currentTimeUpdateHandler = null; // Referencia al manejador actual para limpieza correcta
+    /** @type {Set<string>} Track videos currently being processed to prevent duplicate calls */
+    const currentlyProcessingVideos = new Set();
+
+    // Sistema de captura de clicks del usuario para detección de playlists (optimizado)
+    let lastClickedVideoLink = null;
+    let lastClickedVideoId = null;
+    let lastClickedTimestamp = 0;
+    let blockedAdVideoIds = new Set(); // Track ads blocked by click tracker
+
+    // Escuchar clicks SOLO en contenedores relevantes con throttling
+    const setupClickTracker = () => {
+        try {
+            // Usar delegation en contenedores específicos donde hay enlaces de video
+            const relevantContainers = [
+                'ytd-rich-grid-renderer',      // Grid de videos en home
+                'ytd-video-renderer',          // Video individual
+                'ytd-playlist-video-renderer', // Videos en playlist
+                'ytd-compact-video-renderer',  // Videos relacionados
+                'ytd-reel-video-renderer',     // Shorts
+                '#contents',                   // Contenedor general
+                'ytd-watch-next-secondary-results-renderer' // Videos relacionados en watch
+            ];
+
+            const handleClick = (e) => {
+                // Throttling: ignorar clicks muy rápidos
+                const now = Date.now();
+                if (now - lastClickedTimestamp < 100) return;
+
+                const videoLink = e.target.closest('a[href*="/watch?v="]');
+                if (videoLink) {
+                    const clickedVideoId = extractOrNormalizeVideoId(videoLink.href)?.id;
+                    if (clickedVideoId) {
+                        // CRÍTICO: Detectar si el click es en un anuncio ANTES de procesarlo
+                        const adContainer = videoLink.closest('ytd-ad-slot-renderer, ytd-in-feed-ad-layout-renderer, ytd-display-ad-renderer, ytd-promoted-sparkles-web-renderer');
+                        const hasAdBadge = !!videoLink.closest('ytd-rich-item-renderer')?.querySelector('.yt-badge-shape--ad, [aria-label*="Ad"], [aria-label*="Patrocinado"], [aria-label*="Sponsored"]');
+
+                        if (adContainer || hasAdBadge) {
+                            log('UserClick', `🚫 Click en anuncio detectado y bloqueado: videoId=${clickedVideoId}`);
+                            blockedAdVideoIds.add(clickedVideoId); // Track this ad as blocked
+                            return; // No procesar clicks en anuncios
+                        }
+
+                        lastClickedVideoLink = videoLink.href;
+                        lastClickedVideoId = clickedVideoId;
+                        lastClickedTimestamp = now;
+                        log('UserClick', `🖱️ Click detectado: videoId=${clickedVideoId}`);
+                    }
+                }
+            };
+
+            // Añadir listeners solo a contenedores existentes
+            relevantContainers.forEach(selector => {
+                const container = document.querySelector(selector);
+                if (container) {
+                    container.addEventListener('click', handleClick, true);
+                    log('setupClickTracker', `✅ Listener añadido a: ${selector}`);
+                }
+            });
+
+            // Observer para contenedores dinámicos
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach(mutation => {
+                    mutation.addedNodes.forEach(node => {
+                        if (node.nodeType === Node.ELEMENT_NODE) {
+                            relevantContainers.forEach(selector => {
+                                if (node.matches?.(selector) || node.querySelector?.(selector)) {
+                                    const container = node.matches?.(selector) ? node : node.querySelector(selector);
+                                    if (container && !container.hasAttribute('data-click-tracked')) {
+                                        container.addEventListener('click', handleClick, true);
+                                        container.setAttribute('data-click-tracked', 'true');
+                                        log('setupClickTracker', `✅ Listener dinámico añadido a: ${selector}`);
+                                    }
+                                }
+                            });
+                        }
+                    });
+                });
+            });
+
+            observer.observe(document.body, {
+                childList: true,
+                subtree: true
+            });
+
+            log('setupClickTracker', '✅ Sistema de captura de clicks optimizado inicializado');
+        } catch (e) {
+            log('setupClickTracker', `⚠️ Error inicializando captura de clicks: ${e.message}`);
+        }
+    };
+
+    // Inicializar el sistema de clicks
+    setupClickTracker();
 
     const processVideo = async (playerToProcess, videoEl) => {
         log('processVideo', `Llegando a processVideo con player: ${typeof playerToProcess} | ¿permite getDuration?: ${typeof playerToProcess?.getDuration === 'function'}`);
@@ -9389,6 +10435,20 @@ background: var(--ypp-danger);
         log('processVideo', `URL del video guardada para miniplayer: ${lastVideoUrl}`);
 
         const resolvePlaylistIdForProcess = () => {
+            log('resolvePlaylist', `🔍 ---------- INICIO RESOLUCIÓN PLAYLIST ----------`);
+
+            // Si es página Watch y la URL es del video actual y no tiene lista -> FORZAR NULL.
+            // Esto anula cualquier detección fantasma del DOM o Miniplayer.
+            if (location.pathname === '/watch') {
+                const uParams = new URLSearchParams(location.search);
+                if (uParams.get('v') === videoIdDetected && !uParams.has('list')) {
+                    log('resolvePlaylist', `🛑 Página Watch pura detectada sin playlist. Cancelando búsqueda.`);
+                    return null;
+                }
+            }
+
+            log('resolvePlaylist', `🔍 Video: ${videoIdDetected} | URL Base: ${urlForVideoId}`);
+
             const pickListParam = (maybeUrl) => {
                 if (!maybeUrl) return null;
                 try {
@@ -9400,12 +10460,15 @@ background: var(--ypp-danger);
             };
 
             let candidate = pickListParam(urlForVideoId);
+            if (candidate) log('resolvePlaylist', `✅ Origen: PARAMETRO URL DIRECTO -> ${candidate}`);
+
             const isHomeish = pageType === 'home' || pageType === 'search' || pageType === 'channel';
             const contextElement = currentVideoEl || videoEl || activeVideoEl;
 
             // Para miniplayer, buscar playlist ID directamente desde la URL del miniplayer
             const miniPlayerState = PlayerStateCache.getCurrentState();
             if (miniPlayerState.hasMiniPlayer) {
+                log('resolvePlaylist', `ℹ️ Miniplayer detectado activo. Buscando en DOM...`);
                 try {
                     // Intentar obtener la URL completa del miniplayer desde elementos que la contengan
                     const miniPlayerUrlSelectors = [
@@ -9420,13 +10483,25 @@ background: var(--ypp-danger);
                     for (const selector of miniPlayerUrlSelectors) {
                         const anchor = document.querySelector(selector);
                         if (anchor) {
+                            // FIX: Strict check - anchor must be inside a player container to be valid
+                            // This filters out sidebar recommendations (Mixes) which are outside the player
+                            const validContainer = anchor.closest('#movie_player, ytd-miniplayer, .ytp-miniplayer-ui, #player, #c4-player');
+
+                            if (!validContainer) {
+                                log('processVideo', `⚠️ Playlist candidate ignored because it is outside any known player container: ${anchor.href}`);
+                                continue;
+                            }
                             const fullUrl = anchor.href;
                             const listParam = pickListParam(fullUrl);
                             if (listParam) {
-                                // Verificar que el video ID en la URL coincida con el video actual
+                                // Revert user typo and restore video ID extraction
                                 const urlVideoId = extractOrNormalizeVideoId(fullUrl)?.id;
                                 if (urlVideoId === videoIdDetected) {
                                     candidate = listParam;
+                                    log('resolvePlaylist', `✅ Origen: DOM SELECTOR (${selector}) -> ${candidate}`);
+                                    log('resolvePlaylist', `   Elemento: ${anchor.tagName}.${anchor.className} | Href: ${anchor.href}`);
+                                    log('resolvePlaylist', `   Contenedor detectado: ${validContainer.id || validContainer.tagName}`);
+
                                     log('processVideo', `📌 plId confirmado desde URL completa del miniplayer (${selector}): ${candidate}`);
                                     // Actualizar urlForVideoId con la URL completa si encontramos una
                                     if (!urlForVideoId.includes('list=') && fullUrl.includes('list=')) {
@@ -9482,7 +10557,7 @@ background: var(--ypp-danger);
                             }
                         } catch (_) { }
                         if (!anchor) {
-                            try { anchor = card.querySelector('a[href*="list="]'); } catch (_) { }
+                            // try { anchor = card.querySelector('a[href*="list="]'); } catch (_) { }
                         }
                         if (anchor) {
                             const uCard = new URL(anchor.href, location.origin);
@@ -9508,9 +10583,15 @@ background: var(--ypp-danger);
                         if (anchor) {
                             const u = new URL(anchor.href, location.origin);
                             const l = u.searchParams.get('list');
-                            if (l) {
+                            // Extract video ID from the anchor to ensure it matches the current video
+                            const anchorVideoId = extractOrNormalizeVideoId(anchor.href)?.id;
+
+                            if (l && anchorVideoId === videoIdDetected) {
                                 candidate = l;
+                                log('processVideo', `📌 plId confirmado desde elemento global (${selector}) para ${videoIdDetected}: ${candidate}`);
                                 break;
+                            } else if (l) {
+                                log('processVideo', `⚠️ Playlist encontrada en ${selector} (${l}) ignorada porque pertenece a otro video (${anchorVideoId} ≠ ${videoIdDetected})`);
                             }
                         }
                     }
@@ -9519,11 +10600,12 @@ background: var(--ypp-danger);
 
             // Solo usar lastPlaylistId si no hay información específica del miniplayer
             // y si estamos seguros de que el video pertenece a esa playlist
+            /* DESHABILITADO: Causa falsos positivos asociando videos nuevos a playlists anteriores en la Home.
             if (!candidate && isHomeish && lastPlaylistId && !miniPlayerState.hasMiniPlayer) {
                 log('processVideo', `🔄 Usando lastPlaylistId como fallback (no miniplayer): ${lastPlaylistId}`);
                 candidate = lastPlaylistId;
             }
-
+ 
             if (!candidate && isHomeish && lastVideoUrl) {
                 try {
                     const u3 = new URL(lastVideoUrl, location.origin);
@@ -9531,6 +10613,7 @@ background: var(--ypp-danger);
                     if (l3) candidate = l3;
                 } catch (_) { }
             }
+            */
 
             // No forzar playlists de recomendaciones automáticamente para todos los videos
 
@@ -9574,15 +10657,79 @@ background: var(--ypp-danger);
 
         // Para miniplayer, usar la URL específica del miniplayer si está disponible
         const miniPlayerUrlState = PlayerStateCache.getCurrentState();
+
+        // PRIORIDAD 1: Usar click del usuario si corresponde a este video
+        if (lastClickedVideoId === videoIdDetected && lastClickedVideoLink) {
+            try {
+                const clickedParams = new URL(lastClickedVideoLink, location.origin).searchParams;
+                const clickedPlaylistId = clickedParams.get('list');
+                if (clickedPlaylistId && !plId) {
+                    plId = clickedPlaylistId;
+                    log('processVideo', `🎯 Playlist detectada desde click del usuario: ${plId}`);
+                }
+            } catch (e) {
+                log('processVideo', `⚠️ Error extrayendo playlist de click: ${e.message}`);
+            }
+        }
+        // PRIORIDAD 2: Usar lastVideoUrl para miniplayer
+        else if (miniPlayerUrlState.hasMiniPlayer && lastVideoUrl) {
+            // En miniplayer, extraer playlist de lastVideoUrl si no se encontró por otros medios
+            try {
+                const lastUrlParams = new URL(lastVideoUrl, location.origin).searchParams;
+                const lastUrlPlaylistId = lastUrlParams.get('list');
+                if (lastUrlPlaylistId && !plId) {
+                    plId = lastUrlPlaylistId;
+                    log('processVideo', `🔗 Playlist detectada desde lastVideoUrl para miniplayer: ${plId}`);
+                }
+            } catch (e) {
+                log('processVideo', `⚠️ Error extrayendo playlist de lastVideoUrl: ${e.message}`);
+            }
+        }
+
+        // SIEMPRE asegurar que tenemos metadata básica y título para CUALQUIER playlist
+        if (plId) {
+            log('processVideo', `📋 Actualizando metadata de playlist ${plId} para video ${videoIdDetected}`);
+            // Llamar directamente a la lógica de metadata de playlist
+            (async () => {
+                try {
+                    const playlistMetaKey = `playlist_meta_${plId}`;
+                    let playlistMeta = await Storage.get(playlistMetaKey) || {
+                        playlistId: plId,
+                        title: '',
+                        lastWatchedVideoId: videoIdDetected,
+                        lastUpdated: Date.now()
+                    };
+
+                    log('processVideo', `📋 Playlist metadata for ${plId}: title="${playlistMeta.title}"`);
+
+                    playlistMeta.lastWatchedVideoId = videoIdDetected;
+                    playlistMeta.lastUpdated = Date.now();
+                    await Storage.set(playlistMetaKey, playlistMeta);
+
+                    // Intentar obtener el título real si no lo tenemos o si es genérico
+                    if (!playlistMeta.title || playlistMeta.title === plId) {
+                        log('processVideo', `Playlist ${plId} sin título o con título genérico, buscando...`);
+                        getPlaylistName(plId).then(async name => {
+                            const updated = await Storage.get(playlistMetaKey);
+                            if (updated && (!updated.title || updated.title === plId)) {
+                                updated.title = name;
+                                await Storage.set(playlistMetaKey, updated);
+                                log('processVideo', `✅ Título de playlist actualizado: "${name}" para ${plId}`);
+                            }
+                        });
+                    }
+                } catch (err) {
+                    log('processVideo', `⚠️ Error actualizando metadata de playlist: ${err.message}`);
+                }
+            })();
+        }
         const playerUrl = miniPlayerUrlState.hasMiniPlayer && urlForVideoId ? urlForVideoId : window.location.href;
         log('processVideo', `URL del reproductor: ${playerUrl} | Video ID del reproductor: ${videoIdDetected}`);
 
-        // Conjunto para rastrear videos que están siendo procesados actualmente
-        const currentlyProcessingVideos = new Set();
-
-        // Evitar reprocesar el mismo video
+        // Evitar reprocesar el mismo video (usa el Set a nivel de módulo)
         if (currentlyProcessingVideos.has(videoIdDetected)) {
-            log('processVideo', `El video ${videoIdDetected} ya está siendo procesado. Ignorando.`);
+            log('processVideo', `⏳ El video ${videoIdDetected} ya está siendo procesado. Ignorando y limpiando bloqueo.`);
+            currentlyProcessingVideos.delete(videoIdDetected); // Limpiar bloqueo inmediatamente
             return;
         }
         currentlyProcessingVideos.add(videoIdDetected);
@@ -9632,6 +10779,7 @@ background: var(--ypp-danger);
             if (isLive && cachedSettings?.saveLiveStreams === false) {
                 log('processVideo', '🛑 Video detectado como LIVE y la opción saveLiveStreams está deshabilitada, omitiendo.');
                 isNavigating = false;
+                currentlyProcessingVideos.delete(videoIdDetected);
                 return;
             }
 
@@ -9651,7 +10799,9 @@ background: var(--ypp-danger);
                 const mp = document.querySelector('#movie_player');
                 allowByMiniplayer = (!!cont && (cont.id === 'movie_player')) || !!mp;
             } catch (_) { }
-            if (!cachedSettings[typeToSetting[type]] && !(((getYouTubePageType() === 'home') || allowByMiniplayer) && activeVideoEl)) {
+            // Usar configuración segura (defaults si aún no carga settings) para prevenir crash en carga inicial
+            const safeSettings = cachedSettings || CONFIG.defaultSettings;
+            if (!safeSettings[typeToSetting[type]] && !(((getYouTubePageType() === 'home') || allowByMiniplayer) && activeVideoEl)) {
                 // Loguea un mensaje indicando que este tipo de video no se debe procesar
                 log('processVideo', `🛑 Tipo "${type}" no está habilitado para guardado, omitiendo.`);
                 log('processVideo', `Es home con un video activo? ${!(getYouTubePageType() === 'home' && activeVideoEl)}`);
@@ -9663,6 +10813,7 @@ background: var(--ypp-danger);
                 isNavigating = false;
 
                 // Sale de la función, evitando que el video se procese
+                currentlyProcessingVideos.delete(videoIdDetected);
                 return;
             }
 
@@ -9673,7 +10824,16 @@ background: var(--ypp-danger);
             }
 
             // Buscar progreso previo
-            let savedData = getSavedVideoData(videoIdDetected, plId);
+            let savedData = await getSavedVideoData(videoIdDetected, plId);
+
+            if (savedData?.playlistId) {
+                log('resolvePlaylist', `💾 Origen: STORAGE (Datos previos) -> ${savedData.playlistId}`);
+            } else if (plId) {
+                log('resolvePlaylist', `🆕 Origen: NUEVA ASIGNACIÓN (Resolución actual) -> ${plId}`);
+            } else {
+                log('resolvePlaylist', `⚪ Sin playlist detectada ni guardada.`);
+            }
+
             log('processVideo', `Verificando reanudación: savedData=${!!savedData}, videoIdDetected=${videoIdDetected}, lastResumeId=${lastResumeId}, videoIdDetected === lastResumeId=${videoIdDetected === lastResumeId}`);
 
             // Verifica si hay datos guardados para el video y si el video detectado es diferente al último ID de video que se intentó reanudar.
@@ -9703,6 +10863,14 @@ background: var(--ypp-danger);
 
                 if (shouldResume) {
                     isResuming = true;
+                    // FIX: Safety timeout to prevent isResuming from getting stuck if resumePlayback hangs
+                    setTimeout(() => {
+                        if (isResuming) {
+                            log('processVideo', '⏰ Safety timeout: forcing isResuming = false');
+                            isResuming = false;
+                        }
+                    }, 8000);
+
                     log('processVideo', `✅ Reanudando ${videoIdDetected} (${type})...`);
 
                     if (type === 'short') {
@@ -9742,6 +10910,9 @@ background: var(--ypp-danger);
             const boundType = logicalType;
             const boundPlId = plId;
 
+            // Flag para evitar múltiples llamadas a processVideo desde el handler
+            let isProcessingVideoChange = false;
+
             // Contexto por contenedor (movie_player vs shorts-player) para evitar contaminación entre players
             const boundContainerId = getPlayerContainerId(videoEl) || getPlayerContainerId(activeVideoEl) || 'movie_player';
             const ctx = PlayerContexts.get(boundContainerId);
@@ -9769,6 +10940,18 @@ background: var(--ypp-danger);
                         return;
                     }
 
+                    // PROTECCIÓN CRÍTICA: Detectar handlers "stale" (obsoletos)
+                    // Si el handler se ató como 'preview' (inline) pero ahora estamos en una página Watch
+                    // y el video vive dentro de movie_player, entonces este handler es un remanente
+                    // de la navegación anterior y debe ser ignorado.
+                    const currentPageTypeForCheck = getYouTubePageType();
+                    const containerForCheck = (currentVideoEl || videoEl)?.closest?.('#movie_player, #shorts-player');
+
+                    if (boundType.startsWith('preview') && currentPageTypeForCheck === 'watch' && containerForCheck?.id === 'movie_player') {
+                        if (!window._staleLog) { log('handler', '🛑 Handler preview obsoleto detectado en página Watch (movie_player). Abortando.'); window._staleLog = Date.now(); }
+                        return;
+                    }
+
                     // Verificar visibilidad del video para previews en páginas de inicio/búsqueda
                     const currentPageType = getYouTubePageType();
                     const contNow = (currentVideoEl || videoEl)?.closest?.('#movie_player, #shorts-player');
@@ -9780,13 +10963,23 @@ background: var(--ypp-danger);
                         const isVisible = (el) => {
                             if (!el) return false;
                             const rect = el.getBoundingClientRect();
-                            const isInViewport = (
-                                rect.top >= 0 &&
-                                rect.left >= 0 &&
-                                rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-                                rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+                            // Verificar que tenga dimensiones (no sea 0x0)
+                            const hasSize = rect.width > 0 && rect.height > 0;
+                            if (!hasSize) {
+                                // Fallback: verificar offsetWidth/Height
+                                if (el.offsetWidth > 0 && el.offsetHeight > 0) {
+                                    return true; // Tiene dimensiones aunque getBoundingClientRect no lo detecte
+                                }
+                                return false;
+                            }
+                            // Verificar que al menos parte del video esté en el viewport
+                            const isPartiallyInViewport = (
+                                rect.bottom > 0 &&
+                                rect.top < (window.innerHeight || document.documentElement.clientHeight) &&
+                                rect.right > 0 &&
+                                rect.left < (window.innerWidth || document.documentElement.clientWidth)
                             );
-                            return isInViewport && el.offsetWidth > 0 && el.offsetHeight > 0;
+                            return isPartiallyInViewport;
                         };
 
                         if (!isVisible(videoEl)) {
@@ -9796,8 +10989,10 @@ background: var(--ypp-danger);
 
                         // Para previews, asegurarse de que el tiempo de reproducción sea suficiente
                         const currentTime = videoEl?.currentTime || 0;
-                        if (currentTime < 1.0) {
-                            log('handler', `Tiempo de reproducción insuficiente (${currentTime.toFixed(2)}s) para guardar preview`);
+                        // Reducido a 0.5s para capturar previews rápidos, pero evitar guardar instantáneamente al cargar
+                        if (currentTime < 0.5) {
+                            // Solo loguear en debug para no spammear
+                            // log('handler', `Tiempo de reproducción insuficiente (${currentTime.toFixed(2)}s) para guardar preview`);
                             return;
                         }
                     }
@@ -9868,8 +11063,43 @@ background: var(--ypp-danger);
                     const urlReportsChange = (videoIdFromUrl && isValidNewId(videoIdFromUrl) && videoIdFromUrl !== boundVideoId);
 
                     if (playerReportsChange || urlReportsChange) {
+                        // Evitar múltiples llamadas a processVideo desde el mismo handler
+                        if (isProcessingVideoChange) {
+                            log('handler', '⏳ Cambio de video ya en proceso, omitiendo...');
+                            return;
+                        }
+
                         const newVideoId = playerReportsChange ? videoIdFromPlayer : videoIdFromUrl;
+
+                        // Verificar si el nuevo video YA está siendo procesado por otra instancia (ej: navegación)
+                        if (currentlyProcessingVideos.has(newVideoId)) {
+                            log('handler', `✅ El nuevo video ${newVideoId} ya está siendo procesado por otra instancia. Terminando handler actual.`);
+
+                            // Limpiar handler actual y salir
+                            try {
+                                videoEl.removeEventListener('timeupdate', currentTimeUpdateHandler || handler);
+                            } catch (_) { }
+
+                            // Asegurar que liberamos el video ANTERIOR del set (boundVideoId)
+                            setTimeout(() => {
+                                currentlyProcessingVideos.delete(boundVideoId);
+                            }, 1000);
+
+                            return;
+                        }
+
+                        isProcessingVideoChange = true;
+
                         log('handler', `🔄 CAMBIO DE VIDEO DETECTADO: anterior=${boundVideoId}, nuevo=${newVideoId}, playerReport=${playerReportsChange}, urlReport=${urlReportsChange}`);
+
+                        // CRÍTICO: Verificar si este video fue bloqueado como anuncio por el click tracker
+                        if (blockedAdVideoIds.has(newVideoId)) {
+                            log('handler', `🚫 Video ${newVideoId} fue bloqueado como anuncio previamente, ignorando cambio`);
+                            isProcessingVideoChange = false;
+                            // CRÍTICO: NO eliminar el listener, solo ignorar este cambio
+                            // El listener debe seguir activo para detectar videos futuros
+                            return; // No procesar videos bloqueados como anuncios
+                        }
 
                         // Limpiar el período de gracia post-anuncio cuando se detecta un cambio de video
                         // Esto asegura que el nuevo video no herede el período de gracia del anterior
@@ -9880,7 +11110,7 @@ background: var(--ypp-danger);
                         } finally {
                             // Limpiar el estado de procesamiento con un pequeño retraso
                             setTimeout(() => {
-                                currentlyProcessingVideos.delete(videoIdDetected);
+                                currentlyProcessingVideos.delete(boundVideoId);
                             }, 1000);
                         }
                         try { clearVideoInfoCache(boundVideoId); } catch (_) { }
@@ -9947,6 +11177,12 @@ background: var(--ypp-danger);
                                     try { if (ctx?.lastSaveTimesByVideoId) ctx.lastSaveTimesByVideoId[boundVideoId] = savedTs; } catch (_) { }
                                 } else {
                                     log('processVideo', `⚠️ No se guardó progreso para ${videoIdDetected}:`, saveResult?.reason);
+
+                                    // Mostrar notificación de error de almacenamiento
+                                    if (saveResult?.reason === 'storage_full') {
+                                        showFloatingToast(`${SVG_ICONS.error} ${t('storageFull')}`, 0, { persistent: true });
+                                    }
+
                                     // Throttle de reintentos cuando es preview inline con datos inválidos
                                     try {
                                         if (saveResult?.reason === 'invalid_data') {
@@ -9987,6 +11223,8 @@ background: var(--ypp-danger);
                 const allowInline = cachedSettings?.saveInlinePreviews === true;
                 if (isPreviewType && !allowInline) {
                     log('processVideo', '🔕 Inline preview deshabilitada por configuración. No se enlaza handler.');
+                    // CRÍTICO: Limpiar del Set antes de retornar para evitar deadlock
+                    currentlyProcessingVideos.delete(videoIdDetected);
                     return;
                 }
             } catch (_) { }
@@ -10008,6 +11246,10 @@ background: var(--ypp-danger);
             currentTimeUpdateHandler = handler;
             currentVideoEl = videoEl;
             videoEl.addEventListener('timeupdate', handler);
+
+            // CRÍTICO: Limpiar del Set DESPUÉS de configurar el handler para evitar deadlock
+            currentlyProcessingVideos.delete(videoIdDetected);
+            log('processVideo', `🔓 Video ${videoIdDetected} liberado del Set de procesamiento`);
 
             if (ctx?.timeupdateRebindIntervalId) {
                 try { clearInterval(ctx.timeupdateRebindIntervalId); } catch (_) { }
@@ -10115,6 +11357,11 @@ background: var(--ypp-danger);
                             notifySeekOrProgress(saveResult?.timestamp ?? currentTime, 'progress', { saveResult, videoType: boundType });
                         } else {
                             log('processVideo', `⚠️ No se guardó progreso para ${boundVideoId}:`, saveResult?.reason);
+
+                            // Mostrar notificación de error de almacenamiento
+                            if (saveResult?.reason === 'storage_full') {
+                                showFloatingToast(`${SVG_ICONS.error} ${t('storageFull')}`, 0, { persistent: true });
+                            }
                         }
                         try { ctx.lastSaveTime = nowTs; } catch (_) { }
                         lastSaveTime = nowTs;
@@ -10223,7 +11470,8 @@ background: var(--ypp-danger);
         } catch (error) {
             conError('processVideo', `Error al procesar el video ${videoIdDetected}:`, error);
         } finally {
-            setTimeout(() => (currentlyProcessingVideoId = null), 100);
+            currentlyProcessingVideoId = null;
+            currentlyProcessingVideos.delete(videoIdDetected);
         }
     };
 
@@ -10746,11 +11994,15 @@ background: var(--ypp-danger);
     let videosContainer = null;
     let listContainer = null;
     let currentOrderBy, currentFilterBy, currentSearchQuery;
+    /** @type {VirtualScroller|null} Instancia del scroller virtual para la lista de videos */
+    let virtualScroller = null;
+    /** @type {Array|null} Cache de items preparados para evitar re-procesar en cada render */
+    let preparedItemsCache = null;
 
-    function fixThumbnailsInStorage() {
-        const keys = (Storage.keys?.() || []).filter(k => !k.startsWith('userSettings') && !k.startsWith('userFilters') && !k.startsWith('playlist_meta_'));
+    async function fixThumbnailsInStorage() {
+        const keys = (await Storage.keys?.() || []).filter(k => !k.startsWith('userSettings') && !k.startsWith('userFilters') && !k.startsWith('playlist_meta_'));
         for (const key of keys) {
-            const data = Storage.get(key);
+            const data = await Storage.get(key);
             if (!data) continue;
             if (data.videos && typeof data.videos === 'object') {
                 let modified = false;
@@ -10761,35 +12013,112 @@ background: var(--ypp-danger);
                         modified = true;
                     }
                 }
-                if (modified) Storage.set(key, data);
+                if (modified) await Storage.set(key, data);
             } else {
                 const vId = data.videoId || key;
                 if (!thumbnailHasVideoId(data?.thumb, vId)) {
                     data.thumb = `https://i.ytimg.com/vi/${vId}/maxresdefault.jpg`;
-                    Storage.set(key, data);
+                    await Storage.set(key, data);
                 }
             }
         }
     }
 
-    function updateVideoList() {
-        const keys = Storage.keys().filter(k => !k.startsWith('userSettings') && !k.startsWith('userFilters') && !k.startsWith('playlist_meta_') && k !== 'translations_cache_v1');
-        setInnerHTML(listContainer, ''); // Limpiar contenido previo
+    /**
+     * Altura estimada de cada item de video en px.
+     * Se usa para calcular posiciones en el virtual scroller.
+     * @constant {number}
+     */
+    const VIDEO_ITEM_HEIGHT = 120;
+
+    /**
+     * Carga los datos de video del Storage en lotes paralelos para mejor rendimiento.
+     * @param {string[]} keys - Keys a cargar
+     * @param {number} [batchSize=50] - Tamaño del lote
+     * @returns {Promise<Map<string, any>>}
+     */
+    async function batchLoadStorageData(keys, batchSize = 50) {
+        const results = new Map();
+
+        for (let i = 0; i < keys.length; i += batchSize) {
+            const batch = keys.slice(i, i + batchSize);
+            const promises = batch.map(async key => {
+                const data = await Storage.get(key);
+                return [key, data];
+            });
+
+            const batchResults = await Promise.all(promises);
+            batchResults.forEach(([key, data]) => {
+                if (data) results.set(key, data);
+            });
+
+            // Ceder control al event loop cada lote para no bloquear UI
+            if (i + batchSize < keys.length) {
+                await new Promise(r => requestAnimationFrame(r));
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Actualiza la lista de videos usando virtualización para rendimiento óptimo.
+     * Solo renderiza los items visibles en el viewport, ideal para miles de videos.
+     */
+    async function updateVideoList() {
+        if (!listContainer) return;
+
+        // Mostrar indicador de carga
+        setInnerHTML(listContainer, '');
+        const loadingIndicator = createElement('div', {
+            className: 'ypp-virtual-loading',
+            text: `⏳ ${t('loading')}...`
+        });
+        listContainer.appendChild(loadingIndicator);
+
+        // Destruir scroller anterior si existe
+        if (virtualScroller) {
+            virtualScroller.destroy();
+            virtualScroller = null;
+        }
+
+        const keys = (await Storage.keys()).filter(k =>
+            !k.startsWith('userSettings') &&
+            !k.startsWith('userFilters') &&
+            !k.startsWith('playlist_meta_') &&
+            k !== 'translations_cache_v1'
+        );
 
         // Cargar metadata de playlists para referencia
         const playlistMetas = {};
-        Storage.keys().filter(k => k.startsWith('playlist_meta_')).forEach(metaKey => {
-            const meta = Storage.get(metaKey);
+        const playlistMetaKeys = (await Storage.keys()).filter(k => k.startsWith('playlist_meta_'));
+        for (const metaKey of playlistMetaKeys) {
+            const meta = await Storage.get(metaKey);
             if (meta?.playlistId) {
                 playlistMetas[meta.playlistId] = meta;
+
+                // Refresco proactivo: si el título es genérico o falta, intentar recuperarlo
+                if (!meta.title || meta.title === meta.playlistId) {
+                    getPlaylistName(meta.playlistId).then(async name => {
+                        if (name && name !== meta.playlistId) {
+                            const updated = await Storage.get(metaKey);
+                            if (updated && (!updated.title || updated.title === meta.playlistId)) {
+                                updated.title = name;
+                                await Storage.set(metaKey, updated);
+                                log('updateVideoList', `✅ Título de playlist actualizado en segundo plano: ${name}`);
+                            }
+                        }
+                    });
+                }
             }
-        });
+        }
+
+        // Cargar todos los datos en lotes paralelos (optimización)
+        const allData = await batchLoadStorageData(keys);
 
         let allItems = [];
-        keys.forEach(key => {
-            const data = Storage.get(key);
-
-            if (!data) return;
+        for (const [key, data] of allData) {
+            if (!data) continue;
 
             // Compatibilidad con formato antiguo (playlists anidadas)
             if (data.videos) {
@@ -10806,13 +12135,12 @@ background: var(--ypp-danger);
                         lastWatchedVideoId
                     });
                 });
-                return;
+                continue;
             }
 
             // Formato FreeTube: todos los videos son entradas independientes
             const videoId = data.videoId || key;
             const playlistId = data.lastViewedPlaylistId;
-            // Si no hay metadata local de playlist, usar al menos el propio playlistId como título
             const playlistTitle = playlistId
                 ? (playlistMetas[playlistId]?.title || playlistId)
                 : null;
@@ -10823,20 +12151,27 @@ background: var(--ypp-danger);
                 info: data,
                 playlistKey: playlistId,
                 playlistTitle,
-                lastWatchedVideoId: playlistMetas[playlistId]?.lastWatchedVideoId || null // Usar metadata de playlist
+                lastWatchedVideoId: playlistMetas[playlistId]?.lastWatchedVideoId || null
             });
-        });
+        }
 
-        // No deduplicar: mismo video en diferentes contextos (playlist vs individual) son entradas válidas separadas
-        // Esto es consistente con FreeTube que mantiene entradas por contexto de visualización
-
+        // Aplicar filtros
         let filteredItems = allItems.filter(item => {
+            const vType = item.info.videoType;
             if (currentFilterBy === 'completed') return item.info.isCompleted === true;
             if (currentFilterBy === 'fixedTime') return item.info.forceResumeTime && item.info.forceResumeTime > 0;
             if (currentFilterBy === 'playlist') return item.type === 'playlist-video';
-            if (currentFilterBy === 'preview') return (item.info.videoType && item.info.videoType.startsWith('preview'));
+            if (currentFilterBy === 'preview') return (vType && vType.startsWith('preview'));
+
+            if (currentFilterBy === 'watch') {
+                return vType === 'watch' || vType === 'video' || !vType;
+            }
+
+            if (currentFilterBy === 'shorts') return vType === 'shorts';
+            if (currentFilterBy === 'live') return vType === 'live';
+
             if (currentFilterBy === 'all') return true;
-            return item.info.videoType === currentFilterBy;
+            return vType === currentFilterBy;
         }).filter(item => {
             if (!currentSearchQuery) return true;
             const query = currentSearchQuery.toLowerCase();
@@ -10845,6 +12180,7 @@ background: var(--ypp-danger);
                 (item.playlistTitle || '').toLowerCase().includes(query);
         });
 
+        // Aplicar ordenamiento
         const getSortValue = (item) => {
             if (currentOrderBy === 'title') return (item.info.title || item.videoId).toLowerCase();
             if (currentOrderBy === 'oldest') return item.info.savedAt || 0;
@@ -10857,44 +12193,118 @@ background: var(--ypp-danger);
             return valA - valB;
         });
 
-        let lastRenderedPlaylistKey = null;
-        const fragment = document.createDocumentFragment();
-        filteredItems.forEach(item => {
-            if (item.type === 'playlist-video') {
-                if (item.playlistKey !== lastRenderedPlaylistKey) {
-                    // Si hay un último video visto, enlazar a ese video + playlist (para mixes de YT)
-                    // Si no, enlazar a la playlist completa
-                    const playlistUrl = item.lastWatchedVideoId
-                        ? `https://www.youtube.com/watch?v=${item.lastWatchedVideoId}&list=${item.playlistKey}`
-                        : `https://www.youtube.com/playlist?list=${item.playlistKey}`;
+        // Guardar items preparados en cache
+        preparedItemsCache = filteredItems;
 
-                    const h3 = createElement('a', {
-                        className: 'ypp-playlistTitle',
-                        html: `${SVG_ICONS.folder} ${t('playlistPrefix')}: ${item.playlistTitle}`,
-                        atribute: {
-                            href: playlistUrl,
-                            target: '_blank',
-                            rel: 'noopener noreferrer'
-                        }
-                    });
-                    fragment.appendChild(h3);
-                    lastRenderedPlaylistKey = item.playlistKey;
+        // Limpiar indicador de carga
+        setInnerHTML(listContainer, '');
+
+        // Mostrar mensaje si no hay items
+        if (filteredItems.length === 0) {
+            const emptyMsg = createElement('p', { className: 'ypp-emptyMsg', text: t('noSavedVideos') });
+            listContainer.appendChild(emptyMsg);
+            return;
+        }
+
+        // Crear barra de estadísticas
+        const statsBar = createElement('div', {
+            className: 'ypp-virtual-stats',
+            id: 'ypp-virtual-stats'
+        });
+        setInnerHTML(statsBar, `
+            <span>${filteredItems.length} ${t('videos')}</span>
+            <span id="ypp-render-stats"></span>
+        `);
+        listContainer.appendChild(statsBar);
+
+        // Crear contenedor para el scroller virtual
+        const scrollerContainer = createElement('div', {
+            id: 'ypp-virtual-scroller-container',
+            styles: {
+                flexGrow: '1',
+                overflow: 'auto',
+                position: 'relative'
+            }
+        });
+        listContainer.appendChild(scrollerContainer);
+
+        // Pre-procesar items para incluir headers de playlist
+        const virtualItems = [];
+        let lastPlaylistKey = null;
+
+        for (const item of filteredItems) {
+            if (item.type === 'playlist-video' && item.playlistKey && item.playlistKey !== lastPlaylistKey) {
+                virtualItems.push({
+                    type: 'playlist-header',
+                    playlistKey: item.playlistKey,
+                    playlistTitle: item.playlistTitle || item.playlistKey,
+                    firstVideoId: item.videoId // Guardar ID para enlaces de Mixes
+                });
+                lastPlaylistKey = item.playlistKey;
+            } else if (item.type !== 'playlist-video') {
+                lastPlaylistKey = null;
+            }
+            virtualItems.push(item);
+        }
+
+        // Inicializar VirtualScroller
+        virtualScroller = new VirtualScroller({
+            container: scrollerContainer,
+            items: virtualItems,
+            itemHeight: VIDEO_ITEM_HEIGHT, // Fallback por si acaso
+            getItemHeight: (item) => {
+                if (item.type === 'playlist-header') return 40;
+                if (item.playlistKey) return 140; // Optimizado a 140px
+                return VIDEO_ITEM_HEIGHT;
+            },
+            bufferSize: 8,
+            renderItem: async (item) => {
+                if (item.type === 'playlist-header') {
+                    const header = document.createElement('div');
+                    header.className = 'ypp-playlist-header';
+
+                    let playlistUrl = `https://www.youtube.com/playlist?list=${item.playlistKey}`;
+                    // Para Mixes (RD...), YouTube requiere un v=ID válido.
+                    // También es mejor para la experiencia de usuario empezar a reproducir.
+                    if (item.playlistKey.startsWith('RD') && item.firstVideoId) {
+                        playlistUrl = `https://www.youtube.com/watch?v=${item.firstVideoId}&list=${item.playlistKey}`;
+                    }
+
+                    setInnerHTML(header, `
+                        <a href="${playlistUrl}" target="_blank" rel="noopener noreferrer">
+                            ${SVG_ICONS.folder} ${item.playlistTitle}
+                        </a>
+                    `);
+                    return header;
                 }
-                fragment.appendChild(createVideoEntry(item.videoId, item.info, item.playlistKey, item.playlistTitle));
-            } else {
-                fragment.appendChild(createVideoEntry(item.videoId, item.info, null));
+
+                return await createVideoEntry(
+                    item.videoId,
+                    item.info,
+                    item.playlistKey,
+                    item.playlistTitle
+                );
+            },
+            onRender: ({ renderedCount, totalItems }) => {
+                const statsEl = document.getElementById('ypp-render-stats');
+                if (statsEl) {
+                    statsEl.textContent = `📊 ${renderedCount}/${totalItems} ${t('rendered') || 'rendered'}`;
+                }
             }
         });
 
-        listContainer.appendChild(fragment);
 
-        if (filteredItems.length === 0) {
-            const p = createElement('p', { className: 'ypp-emptyMsg', text: t('noSavedVideos') });
-            listContainer.appendChild(p);
-        }
+        log('updateVideoList', `✅ VirtualScroller inicializado con ${filteredItems.length} items`);
     }
 
     function closeModalVideos() {
+        // Destruir VirtualScroller para liberar recursos
+        if (virtualScroller) {
+            virtualScroller.destroy();
+            virtualScroller = null;
+        }
+        preparedItemsCache = null;
+
         if (videosOverlay) {
             videosOverlay.remove();
             videosOverlay = null;
@@ -10923,7 +12333,7 @@ background: var(--ypp-danger);
         const btnConfig = createElement('div', {
             className: 'ypp-btn ypp-btn-secondary ypp-sombra',
             html: `${SVG_ICONS.settings} ${t('youtubePlaybackPlox')}`,
-            onClickEvent: showSettingsUI
+            onClickEvent: async () => { await showSettingsUI(); }
         });
         wrapper.appendChild(btnConfig);
         document.body.appendChild(wrapper);
@@ -10948,7 +12358,7 @@ background: var(--ypp-danger);
         // Cargar filtros guardados para asegurar sincronización
         const saved = await getSavedFilters();
 
-        fixThumbnailsInStorage();
+        await fixThumbnailsInStorage();
 
         // Usar los filtros pasados como parámetro o los guardados
         currentOrderBy = saved.orderBy ?? CONFIG.defaultFilters.orderBy;
@@ -10980,17 +12390,17 @@ background: var(--ypp-danger);
         filtersContainer.appendChild(createSortSelector(currentOrderBy, async (selected) => {
             currentOrderBy = selected;
             await saveFilters({ orderBy: selected });
-            updateVideoList();
+            await updateVideoList();
         }));
         filtersContainer.appendChild(createFilterSelector(currentFilterBy, async (selected) => {
             currentFilterBy = selected;
             await saveFilters({ filterBy: selected });
-            updateVideoList();
+            await updateVideoList();
         }));
         filtersContainer.appendChild(createSearchInput(currentSearchQuery, async (query) => {
             currentSearchQuery = query;
             await saveFilters({ searchQuery: query });
-            updateVideoList();
+            await updateVideoList();
         }));
         videosContainer.appendChild(filtersContainer);
 
@@ -11004,22 +12414,22 @@ background: var(--ypp-danger);
         const btnExport = createElement('button', {
             className: 'ypp-btn ypp-btn-secondary ypp-sombra',
             html: `${SVG_ICONS.upload} ${t('export')} (JSON)`,
-            onClickEvent: exportDataToFile
+            onClickEvent: async () => await exportDataToFile()
         });
         const btnImport = createElement('button', {
             className: 'ypp-btn ypp-btn-secondary ypp-sombra',
             html: `${SVG_ICONS.download} ${t('import')} (JSON)`,
-            onClickEvent: importDataFromFile
+            onClickEvent: async () => await importDataFromFile()
         });
         const btnExportFreeTube = createElement('button', {
             className: 'ypp-btn ypp-btn-secondary ypp-sombra',
             html: `${SVG_ICONS.upload} ${t('export')} (FreeTube)`,
-            onClickEvent: exportToFreeTube
+            onClickEvent: async () => await exportToFreeTube()
         });
         const btnImportFreeTube = createElement('button', {
             className: 'ypp-btn ypp-btn-secondary ypp-sombra',
             html: `${SVG_ICONS.download} ${t('import')} (FreeTube)`,
-            onClickEvent: importFromFreeTube
+            onClickEvent: async () => await importFromFreeTube()
         });
 
 
@@ -11034,19 +12444,19 @@ background: var(--ypp-danger);
         const btnClearAll = createElement('button', {
             className: 'ypp-btn ypp-btn-danger ypp-sombra',
             html: `${SVG_ICONS.trash} ${t('clearAll')}`,
-            onClickEvent: clearAllData
+            onClickEvent: async () => { await clearAllData(); }
         });
 
         const btnCreatePlaylist = createElement('button', {
             className: 'ypp-btn ypp-btn-primary ypp-sombra',
             html: `${SVG_ICONS.playlist} ${t('createPlaylist')}`,
-            onClickEvent: toggleSelectionMode
+            onClickEvent: async () => { await toggleSelectionMode(); }
         });
 
         const btnSettings = createElement('button', {
             className: 'ypp-btn ypp-btn-secondary ypp-sombra',
             html: `${SVG_ICONS.settings} ${t('settings')}`,
-            onClickEvent: showSettingsUI
+            onClickEvent: async () => { await showSettingsUI(); }
         });
 
         secondRow.appendChild(btnClearAll);
@@ -11101,7 +12511,7 @@ background: var(--ypp-danger);
         const cancelBtn = createElement('button', {
             className: 'ypp-btn ypp-btn-danger ypp-sombra',
             html: `${SVG_ICONS.close} ${t('cancel')}`,
-            onClickEvent: () => toggleSelectionMode()
+            onClickEvent: async () => { await toggleSelectionMode(); }
         });
 
         playlistActions.appendChild(copyBtn);
@@ -11125,7 +12535,7 @@ background: var(--ypp-danger);
         document.body.appendChild(videosContainer);
 
         // Actualizar la lista de videos con los filtros actuales
-        updateVideoList();
+        await updateVideoList();
     }
 
     // ------------------------------------------
@@ -11167,7 +12577,7 @@ background: var(--ypp-danger);
         return `hsl(${hue}, 60%, 70%)`; // Color más intenso para el borde
     }
 
-    function createVideoEntry(videoId, info, playlistKey = null, playlistTitle = null) {
+    async function createVideoEntry(videoId, info, playlistKey = null, playlistTitle = null) {
 
         const isCompleted =
             info.isCompleted ||
@@ -11252,23 +12662,23 @@ background: var(--ypp-danger);
         if (!thumbnailHasVideoId(info.thumb, videoId)) {
             try {
                 if (playlistKey) {
-                    const playlistData = Storage.get(playlistKey);
+                    const playlistData = await Storage.get(playlistKey);
                     const isOld = playlistData?.videos && typeof playlistData.videos === 'object';
                     if (isOld && playlistData.videos[videoId]) {
                         playlistData.videos[videoId].thumb = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;
-                        Storage.set(playlistKey, playlistData);
+                        await Storage.set(playlistKey, playlistData);
                     } else {
-                        const data = Storage.get(videoId);
+                        const data = await Storage.get(videoId);
                         if (data) {
                             data.thumb = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;
-                            Storage.set(videoId, data);
+                            await Storage.set(videoId, data);
                         }
                     }
                 } else {
-                    const data = Storage.get(videoId);
+                    const data = await Storage.get(videoId);
                     if (data) {
                         data.thumb = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;
-                        Storage.set(videoId, data);
+                        await Storage.set(videoId, data);
                     }
                 }
             } catch (_) { }
@@ -11416,7 +12826,7 @@ background: var(--ypp-danger);
                         ? t('changeOrRemoveStartTime', { time: formatTime(normalizeSeconds(info.forceResumeTime)) })
                         : t('setStartTime')
                 },
-                onClickEvent: () => {
+                onClickEvent: async () => {
                     let promptText = info.forceResumeTime
                         ? `${t('enterStartTimeOrEmpty')}:`
                         : `${t('enterStartTime')}:`;
@@ -11448,7 +12858,7 @@ background: var(--ypp-danger);
                     }
 
                     // Determinar si es formato antiguo (playlist anidada) o nuevo (video individual)
-                    const playlistData = Storage.get(playlistKey);
+                    const playlistData = await Storage.get(playlistKey);
                     const isOldFormat = playlistData?.videos && typeof playlistData.videos === 'object';
 
                     if (isOldFormat && playlistKey) {
@@ -11461,11 +12871,11 @@ background: var(--ypp-danger);
                                 delete playlistData.videos[videoId].forceResumeTime;
                                 showFloatingToast(`${SVG_ICONS.unlocked} ${t('fixedTimeRemoved')}`);
                             }
-                            Storage.set(playlistKey, playlistData);
+                            await Storage.set(playlistKey, playlistData);
                         }
                     } else {
                         // Formato nuevo: video es entrada individual (con o sin playlistId)
-                        const data = Storage.get(videoId);
+                        const data = await Storage.get(videoId);
                         if (data) {
                             if (timeSec > 0) {
                                 data.forceResumeTime = timeSec;
@@ -11474,63 +12884,87 @@ background: var(--ypp-danger);
                                 delete data.forceResumeTime;
                                 showFloatingToast(`${SVG_ICONS.unlocked} ${t('fixedTimeRemoved')}`);
                             }
-                            Storage.set(videoId, data);
+                            await Storage.set(videoId, data);
                         }
                     }
-                    updateVideoList();
+                    await updateVideoList();
                 }
             });
             buttonContainer.appendChild(btnForceTime);
+        }
+
+        if (info.lastViewedPlaylistId) {
+            const btnUnlink = createElement('button', {
+                className: 'ypp-btn ypp-btn-small',
+                atribute: {
+                    title: t('removeFromPlaylist')
+                },
+                html: `<div style="position:relative; display:flex; align-items:center;">${SVG_ICONS.folder}<span style="position:absolute; bottom:-4px; right:-4px; color:#ffdddd; background:rgba(255,0,0,0.8); border-radius:50%; width:12px; height:12px; font-size:9px; display:flex; align-items:center; justify-content:center; font-weight:bold;">✕</span></div>`,
+                onClickEvent: async () => {
+                    if (!confirm(t('confirmRemoveFromPlaylist'))) return;
+
+                    const data = await Storage.get(videoId);
+                    if (data) {
+                        data.lastViewedPlaylistId = null;
+                        data.lastViewedPlaylistType = null;
+                        data.lastViewedPlaylistItemId = null;
+                        await Storage.set(videoId, data);
+                        showFloatingToast(`${SVG_ICONS.check} ${t('playlistAssociationRemoved')}`);
+                        await updateVideoList();
+                    }
+                }
+            });
+            buttonContainer.appendChild(btnUnlink);
         }
 
         const btnDelete = createElement('button', {
             className: 'ypp-btn ypp-btn-delete ypp-btn-small',
             atribute: { title: t('deleteEntry') },
             html: SVG_ICONS.trash,
-            onClickEvent: () => {
+            onClickEvent: async () => {
                 const title = info.title || videoId;
                 const itemData = { videoId, info, playlistKey };
 
-                const performDelete = () => {
+                const performDelete = async () => {
                     if (playlistKey) {
-                        const playlist = Storage.get(playlistKey);
+                        const playlist = await Storage.get(playlistKey);
                         if (playlist?.videos && typeof playlist.videos === 'object') {
                             // Formato antiguo: borrar dentro de la playlist
                             if (playlist.videos[videoId]) {
                                 delete playlist.videos[videoId];
                                 Object.keys(playlist.videos).length
-                                    ? Storage.set(playlistKey, playlist)
-                                    : Storage.del(playlistKey);
+                                    ? await Storage.set(playlistKey, playlist)
+                                    : await Storage.del(playlistKey);
                             }
                         } else {
                             // Formato FreeTube: entrada individual por videoId
-                            Storage.del(videoId);
+                            await Storage.del(videoId);
                         }
                     } else {
-                        Storage.del(videoId);
+                        await Storage.del(videoId);
                     }
-                    updateVideoList();
+                    await updateVideoList();
                 };
 
-                const undoDelete = () => {
+                const undoDelete = async () => {
                     if (playlistKey) {
-                        const playlist = Storage.get(playlistKey);
+                        const playlist = await Storage.get(playlistKey);
                         if (playlist?.videos && typeof playlist.videos === 'object') {
                             // Restaurar en formato antiguo
                             const pl = playlist || { lastWatchedVideoId: '', videos: {}, title: '' };
                             pl.videos[videoId] = itemData.info;
-                            Storage.set(playlistKey, pl);
+                            await Storage.set(playlistKey, pl);
                         } else {
                             // Restaurar entrada individual (FreeTube)
-                            Storage.set(videoId, itemData.info);
+                            await Storage.set(videoId, itemData.info);
                         }
                     } else {
-                        Storage.set(videoId, itemData.info);
+                        await Storage.set(videoId, itemData.info);
                     }
-                    updateVideoList();
+                    await updateVideoList();
                 };
 
-                performDelete();
+                await performDelete();
                 showFloatingToast(`${SVG_ICONS.trash} "${title}" ${t('itemDeleted')}`, 5000, {
                     action: {
                         label: t('undo'),
@@ -11552,22 +12986,24 @@ background: var(--ypp-danger);
 
     let clearedData = null; // Para almacenar datos eliminados y poder deshacer
 
-    function clearAllData() {
+    async function clearAllData() {
         if (!confirm(t('clearAllDataConfirm'))) return;
 
         // Guardar datos para posible deshacer
         // No incluir keys de userSettings (contienen configuración/idioma) para evitar dejar la UI inaccesible
-        const allKeys = Storage.keys().filter(k => !k.startsWith('userSettings'));
+        const allKeys = (await Storage.keys()).filter(k => !k.startsWith('userSettings'));
         clearedData = {};
 
-        allKeys.forEach(k => {
-            clearedData[k] = Storage.get(k);
-        });
+        for (const k of allKeys) {
+            clearedData[k] = await Storage.get(k);
+        }
 
         log('clearAllData', '🗑️ Datos a eliminar:', allKeys, clearedData);
 
         // Eliminar todos los datos (excepto userSettings)
-        allKeys.forEach(k => Storage.del(k));
+        for (const k of allKeys) {
+            await Storage.del(k);
+        }
 
         // Mostrar toast con opción de deshacer (usar la propiedad "callback" que espera showFloatingToast)
         showFloatingToast(`${SVG_ICONS.check} ${t('allDataCleared')}`, 10000, {
@@ -11580,10 +13016,10 @@ background: var(--ypp-danger);
         });
 
         // Actualizar UI si es necesario
-        updateVideoList();
+        await updateVideoList();
     }
 
-    function undoClearAll() {
+    async function undoClearAll() {
         if (!clearedData || Object.keys(clearedData).length === 0) {
             showFloatingToast(`${SVG_ICONS.trash} ${t('noDataToRestore')}`);
             return;
@@ -11591,20 +13027,16 @@ background: var(--ypp-danger);
 
         log('undoClearAll', '⏪ Restaurando datos:', clearedData);
 
-        // Restaurar datos
-        Object.entries(clearedData).forEach(([key, value]) => {
-            if (value !== null) {
-                Storage.set(key, value);
-            }
-        });
-
-        showFloatingToast(`${SVG_ICONS.check} ${t('allDataRestored')}`);
+        // Restaurar todos los datos
+        for (const [key, value] of Object.entries(clearedData)) {
+            await Storage.set(key, value);
+        }
 
         // Limpiar referencia
         clearedData = null;
 
         // Actualizar UI
-        updateVideoList();
+        await updateVideoList();
     }
 
     // ------------------------------------------
@@ -11613,12 +13045,12 @@ background: var(--ypp-danger);
 
     // Función para registrar los comandos del menú con traducciones
     function registerMenuCommands() {
-        GM_registerMenuCommand(`⚙️ ${t('settings')}`, () => {
+        GM_registerMenuCommand(`⚙️ ${t('settings')}`, async () => {
             try {
                 if (!document || !document.body) {
                     setTimeout(() => { try { showSettingsUI(); } catch (_) { } }, 0);
                 } else {
-                    showSettingsUI();
+                    await showSettingsUI();
                 }
             } catch (e) { conError('registerMenuCommands', 'Error abriendo Settings UI:', e); }
         });
@@ -12162,9 +13594,11 @@ background: var(--ypp-danger);
 
             cleanupAll();
 
-            // Verificar si YTHelper ya está listo
+            // Verificar si YTHelper ya está listo.
+            // Para Shorts (y previews), no dependemos estrictamente de YTHelper.player.videoElement al inicio,
+            // ya que processVideoFromHelper usará getActiveVideoElement para buscar en el DOM.
             const processIfReady = () => {
-                if (!YTHelper?.player?.videoElement) {
+                if (!YTHelper?.player?.videoElement && currentPageType !== 'shorts') {
                     log('handleNavigation', '⏳ Esperando evento yt-helper-api-ready...');
 
                     // Usar evento del Helper API en lugar de polling
@@ -12424,7 +13858,7 @@ background: var(--ypp-danger);
      * Esta función se ejecuta automáticamente una vez al inicio
      */
     async function migrateToFreeTubeFormat() {
-        const MIGRATION_VERSION = 1; // Incrementar solo si cambia la lógica/estructura de migración
+        const MIGRATION_VERSION = 4; // Incrementar solo si cambia la lógica/estructura de migración
         const MIGRATION_KEY = 'ypp_migration_freetube_format_version';
 
         // Verificar si la migración ya se realizó para esta versión
@@ -12436,12 +13870,139 @@ background: var(--ypp-danger);
 
         log('migrateToFreeTubeFormat', '🔄 Iniciando migración de datos al formato FreeTube...');
 
+        // Mostrar alerta al usuario sobre la migración
+        showFloatingToast({
+            message: t('migratingData', 'Migrando datos guardados desde versión anterior...'),
+            type: 'info',
+            duration: 0, // No auto-desaparecer
+            persistent: true // Reutilizar mismo toast
+        });
+
         let migrated = 0;
         let skipped = 0;
-        const keys = Storage.keys().filter(k => !k.startsWith('userSettings') && !k.startsWith('playlist_meta_') && k !== 'translations_cache_v1');
 
-        for (const key of keys) {
-            const data = Storage.get(key);
+        // PRIMERO: Buscar datos en el sistema antiguo (localStorage)
+        let oldSystemKeys = [];
+        try {
+            // La versión antigua usaba localStorage directamente
+            if (typeof localStorage !== 'undefined') {
+                oldSystemKeys = Object.keys(localStorage).filter(k => k.startsWith('YT_PLAYBACK_PLOX_'));
+            }
+
+            // También intentar con GM_listValues si está disponible
+            if (oldSystemKeys.length === 0 && typeof GM_listValues === 'function') {
+                const gmKeys = GM_listValues();
+                oldSystemKeys = Array.isArray(gmKeys) ? gmKeys : [];
+            }
+        } catch (e) {
+            warn('migrateToFreeTubeFormat', 'Error al obtener claves del sistema antiguo:', e);
+        }
+
+        log('migrateToFreeTubeFormat', `📊 GM_listValues disponible: ${typeof GM_listValues === 'function'}`);
+        log('migrateToFreeTubeFormat', `📊 Claves encontradas: ${oldSystemKeys.length}`);
+        if (oldSystemKeys.length > 0) {
+            log('migrateToFreeTubeFormat', `📊 Primeras 5 claves: ${oldSystemKeys.slice(0, 5).join(', ')}`);
+        }
+
+        // Verificar directamente localStorage también
+        let localStorageKeys = [];
+        if (typeof localStorage !== 'undefined') {
+            localStorageKeys = Object.keys(localStorage).filter(k => k.startsWith('YT_PLAYBACK_PLOX_'));
+            log('migrateToFreeTubeFormat', `📊 Claves localStorage: ${localStorageKeys.length}`);
+            if (localStorageKeys.length > 0) {
+                log('migrateToFreeTubeFormat', `📊 Primeras 5 claves localStorage: ${localStorageKeys.slice(0, 5).join(', ')}`);
+            }
+        }
+
+        // Filtrar claves relevantes del sistema antiguo
+        const oldKeys = oldSystemKeys.filter(k =>
+            !k.includes('userSettings') &&
+            !k.includes('playlist_meta_') &&
+            !k.includes('translations_cache') &&
+            !k.includes('migration_')
+        );
+
+        log('migrateToFreeTubeFormat', `📦 Encontradas ${oldKeys.length} claves en sistema antiguo`);
+
+        // Procesar datos del sistema antiguo
+        for (const key of oldKeys) {
+            let data = null;
+            try {
+                // Leer desde localStorage (la versión antigua usaba localStorage)
+                if (typeof localStorage !== 'undefined') {
+                    const lsData = localStorage.getItem(key);
+                    if (lsData) {
+                        data = JSON.parse(lsData);
+                    }
+                }
+
+                // Fallback a GM_getValue si localStorage no tiene datos
+                if (!data && typeof GM_getValue === 'function') {
+                    data = GM_getValue(key, null);
+                }
+            } catch (e) {
+                warn('migrateToFreeTubeFormat', `Error al leer clave antigua ${key}:`, e);
+            }
+
+            if (!data) continue;
+
+            // Migrar datos individuales (formato antiguo)
+            if (data.videoId || data.timestamp !== undefined) {
+                // Convertir al nuevo formato FreeTube
+                const migratedVideo = {
+                    videoId: data.videoId || key.replace('YT_PLAYBACK_PLOX_', ''),
+                    timestamp: data.timestamp,
+                    lastUpdated: data.lastUpdated || data.savedAt || Date.now(),
+                    videoType: data.videoType || 'regular',
+                    isCompleted: data.isCompleted || false,
+                    duration: data.duration,
+                    title: data.title,
+                    author: data.author,
+                    thumb: data.thumb,
+                    viewsNumber: data.viewsNumber,
+                    savedAt: data.savedAt,
+                    authorId: data.authorId,
+                    published: data.published,
+                    description: data.description,
+                    isLive: data.isLive,
+                    lastViewedPlaylistId: data.lastViewedPlaylistId || null,
+                    lastViewedPlaylistType: data.lastViewedPlaylistType || '',
+                    lastViewedPlaylistItemId: data.lastViewedPlaylistItemId || null,
+                    forceResumeTime: data.forceResumeTime
+                };
+
+                await Storage.set(migratedVideo.videoId, migratedVideo);
+
+                // Eliminar del sistema antiguo
+                try {
+                    GM_setValue(key, null);
+                    if (typeof localStorage !== 'undefined') {
+                        localStorage.removeItem(key); // Usar la clave completa, no modificarla
+                    }
+                } catch (e) {
+                    warn('migrateToFreeTubeFormat', `Error al eliminar clave antigua ${key}:`, e);
+                }
+
+                migrated++;
+                log('migrateToFreeTubeFormat', `✅ Video ${migratedVideo.videoId} migrado desde sistema antiguo`);
+
+                // Actualizar progreso cada 50 videos migrados
+                if (migrated % 50 === 0) {
+                    showFloatingToast({
+                        message: t('migratingDataProgress', `Migrando datos... ${migrated} videos procesados`),
+                        type: 'info',
+                        duration: 2000,
+                        persistent: true
+                    });
+                }
+            }
+        }
+
+        // SEGUNDO: Procesar datos que ya estén en el nuevo sistema (por si acaso)
+        const newSystemKeys = (await Storage.keys()).filter(k => !k.startsWith('userSettings') && !k.startsWith('playlist_meta_') && k !== 'translations_cache_v1');
+
+        for (const key of newSystemKeys) {
+            const data = await Storage.get(key);
             if (!data) continue;
 
             // Si tiene la estructura de playlist anidada (formato antiguo)
@@ -12453,7 +14014,7 @@ background: var(--ypp-danger);
 
                 // Crear metadata de la playlist
                 const playlistMetaKey = `playlist_meta_${playlistId}`;
-                Storage.set(playlistMetaKey, {
+                await Storage.set(playlistMetaKey, {
                     playlistId: playlistId,
                     title: playlistTitle,
                     lastWatchedVideoId: data.lastWatchedVideoId || null,
@@ -12487,14 +14048,14 @@ background: var(--ypp-danger);
                         forceResumeTime: videoData.forceResumeTime
                     };
 
-                    Storage.set(videoId, migratedVideo);
+                    await Storage.set(videoId, migratedVideo);
                     migrated++;
                     log('migrateToFreeTubeFormat', `✅ Video ${videoId} migrado`);
                     if ((++inner % 50) === 0) { await new Promise(r => setTimeout(r, 0)); }
                 }
 
                 // Eliminar la entrada antigua de playlist
-                Storage.del(key);
+                await Storage.del(key);
                 log('migrateToFreeTubeFormat', `✅ Playlist ${playlistId} migrada completamente`);
             } else if (data.videoId || data.timestamp !== undefined) {
                 // Ya está en formato correcto (o cercano), verificar que tenga campos FreeTube
@@ -12507,7 +14068,7 @@ background: var(--ypp-danger);
                         lastViewedPlaylistType: '',
                         lastViewedPlaylistItemId: null
                     };
-                    Storage.set(key, updated);
+                    await Storage.set(key, updated);
                     migrated++;
                 }
                 skipped++;
@@ -12518,6 +14079,22 @@ background: var(--ypp-danger);
         await GM_setValue(MIGRATION_KEY, MIGRATION_VERSION);
 
         log('migrateToFreeTubeFormat', `✅ Migración completada: ${migrated} videos migrados, ${skipped} ya estaban en formato correcto`);
+
+        // Mostrar mensaje final al usuario
+        if (migrated > 0) {
+            showFloatingToast({
+                message: t('migrationComplete', `✅ Migración completada: ${migrated} videos migrados correctamente`),
+                type: 'success',
+                duration: 5000
+            });
+        } else {
+            showFloatingToast({
+                message: t('migrationNoData', '✅ No se encontraron datos para migrar'),
+                type: 'info',
+                duration: 3000
+            });
+        }
+
         return { migrated, skipped };
     }
 
@@ -12690,6 +14267,14 @@ background: var(--ypp-danger);
                 }
             } catch (error) {
                 conError('initializeGlobal', '❌ Error al establecer idioma:', error);
+            }
+
+            // --- Inicializar StorageAsync (migración a IndexedDB) ---
+            try {
+                await StorageAsync.initialize();
+                info('initializeGlobal', '✅ StorageAsync inicializado');
+            } catch (err) {
+                conError('initializeGlobal', '❌ Error al inicializar StorageAsync:', err);
             }
 
             // --- Normalizar almacenamiento ---

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -111,9 +111,10 @@
 // @description:es-419  Guarda y reanuda automáticamente el progreso de reproducción de videos en YouTube sin necesidad de iniciar sesión.
 // @homepage     https://github.com/Alplox/Youtube-Playback-Plox
 // @supportURL   https://github.com/Alplox/Youtube-Playback-Plox/issues
-// @version      0.0.7-2
+// @version      0.0.7-3
 // @author       Alplox
 // @match        https://www.youtube.com/*
+// @exclude      https://www.youtube.com/live_chat*
 // @icon         https://raw.githubusercontent.com/Alplox/StartpagePlox/refs/heads/main/assets/favicon/favicon.ico
 // @grant        GM_getValue
 // @grant        GM_setValue
@@ -124,7 +125,7 @@
 // @license      MIT
 // @downloadURL  https://raw.githubusercontent.com/Alplox/Youtube-Playback-Plox/refs/heads/main/youtube-playback-plox.user.js
 // @updateURL    https://raw.githubusercontent.com/Alplox/Youtube-Playback-Plox/refs/heads/main/youtube-playback-plox.meta.js
-// @require      https://update.greasyfork.org/scripts/549881/1684270/YouTube%20Helper%20API.js
+// @require      https://update.greasyfork.org/scripts/549881/1708128/YouTube%20Helper%20API.js
 // ==/UserScript==
 
 // ------------------------------------------
@@ -136,7 +137,7 @@
 
     // Sistema de niveles: silent(0), error(1), warn(2), info(3), debug(4)
     const LEVELS = { silent: 0, error: 1, warn: 2, info: 3, debug: 4 };
-    let currentLevel = LEVELS.silent; // Cambiar a 'debug' para ver todo, o 'warn'/'error' para menos
+    let currentLevel = LEVELS.debug; // Cambiar a 'debug' para ver todo, o 'warn'/'error' para menos
 
     const styleFor = (kind) => {
         switch (kind) {
@@ -2049,6 +2050,11 @@ background: var(--ypp-danger);
             .ytp-scrubber-button {
                 background: var(--ytp-progress-color) !important;
             }
+
+            .ytp-live .ytp-time-contents {
+                display: flex !important;
+                align-items: center;
+            }
         `;
 
         try {
@@ -2644,20 +2650,20 @@ background: var(--ypp-danger);
     * @param {number} retries - Número de reintentos (opcional, por defecto 0).
     * @returns {Promise} - Promesa que se resuelve cuando YouTube Helper API está listo.
     */
-    function waitForHelper(retries = 0) {
+    function waitForHelper(retries = 1) {
         return new Promise((resolve, reject) => {
             const MAX_RETRIES = 10;
             const RETRY_INTERVAL = 1000;
 
-            const helper = window.youtubeHelperApi;
+            const helper = (typeof youtubeHelperApi !== 'undefined') ? youtubeHelperApi : null;
 
             if (helper) {
                 // Si ya está inicializado completamente
-                if (helper.player?.api) return resolve(helper);
+                if (helper?.player?.api) return resolve(helper);
 
                 // Si existe pero aún no se inicializó
-                helper.eventTarget.addEventListener('yt-helper-api-ready', (e) => {
-                    resolve(e.detail);
+                helper.eventTarget.addEventListener('yt-helper-api-ready', () => {
+                    resolve(helper);
                 }, { once: true });
                 return;
             }
@@ -2667,7 +2673,7 @@ background: var(--ypp-danger);
                 warn('init', `[YTHelper] No disponible, reintentando... (${retries + 1}/${MAX_RETRIES})`);
                 setTimeout(() => resolve(waitForHelper(retries + 1)), RETRY_INTERVAL);
             } else {
-                reject(new Error("YouTube Helper API no disponible tras varios intentos"));
+                reject(new Error('YouTube Helper API no disponible tras varios intentos'));
             }
         });
     }
@@ -4475,52 +4481,165 @@ background: var(--ypp-danger);
     // MARK: 📺 Get Video Info
     // ------------------------------------------
 
-    // Cache por video
+    /**
+     * Cache de conteos de vistas por ID de video.
+     *
+     * La clave es el `videoId` y el valor puede ser:
+     * - un número,
+     * - un string formateado,
+     * - o cualquier representación del conteo que use.
+     *
+     * @type {Map<string, string | number>}
+     */
     const viewCountCache = new Map();
-    var watchMetaCache = new Map();
-    var WATCH_META_TTL = 600000;
-    function fetchWatchMeta(videoId) {
-        return new Promise(function (resolve) {
+
+    /**
+     * @type {Map<string, { data: WatchMeta, time: number }>}
+     */
+    const watchMetaCache = new Map();
+
+    /** Tiempo máximo que se mantiene en caché (10 minutos) */
+    const WATCH_META_TTL = 600_000;
+
+    /**
+     * @typedef {Object} WatchMeta
+     * @property {string} [title]        - Título del video.
+     * @property {string} [author]       - Nombre del canal.
+     * @property {string} [authorId]     - ID del canal.
+     * @property {string} [viewsNumber]  - Cantidad de vistas con separador local.
+     * @property {string} [description]  - Descripción del video.
+     */
+
+    /**
+     * Obtiene metadatos del video directamente desde la página de YouTube.
+     * Hace una petición a `youtube.com/watch?v=<ID>` y extrae el JSON
+     * incrustado `ytInitialPlayerResponse`.
+     *
+     * Si ocurre cualquier error (request, respuesta, parsing, etc.)
+     * siempre se resuelve con `{}`.
+     *
+     * @param {string} videoId - ID del video de YouTube.
+     * @returns {Promise<WatchMeta>} Metadatos extraídos del video.
+     * 
+     * @example
+     * fetchWatchMeta('dQw4w9WgXcQ').then((meta) => {
+     *     console.log(meta);
+     * });
+     * 
+     */
+    const fetchWatchMeta = (videoId) => {
+        return new Promise((resolve) => {
             try {
                 GM_xmlhttpRequest({
-                    method: 'GET',
-                    url: 'https://www.youtube.com/watch?v=' + encodeURIComponent(videoId),
-                    onload: function (response) {
-                        var text = response.responseText || '';
-                        var data = {};
+                    method: "GET",
+                    url: `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`,
+
+                    onload: (response) => {
+                        const text = response.responseText ?? "";
+                        const data = {};
+
                         try {
-                            var m = text.match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/s);
-                            if (m && m[1]) {
-                                var json = JSON.parse(m[1]);
-                                var vd = json && json.videoDetails || null;
-                                var mf = json && json.microformat && json.microformat.playerMicroformatRenderer || null;
-                                if (vd && vd.title != null) data.title = vd.title;
-                                if (vd && vd.author != null) data.author = vd.author;
-                                if (vd && vd.channelId != null) data.authorId = vd.channelId;
-                                if (vd && vd.viewCount != null) {
-                                    try { data.viewsNumber = Number(vd.viewCount).toLocaleString(); } catch (_) { data.viewsNumber = '' + vd.viewCount; }
+                            // Extrae el JSON de la página
+                            const match = text.match(/ytInitialPlayerResponse\s*=\s*(\{.*?\});/s);
+
+                            if (match?.[1]) {
+                                const json = JSON.parse(match[1]);
+
+                                const videoDetails = json?.videoDetails ?? null;
+                                const microformat =
+                                    json?.microformat?.playerMicroformatRenderer ?? null;
+
+                                if (videoDetails?.title) data.title = videoDetails.title;
+                                if (videoDetails?.author) data.author = videoDetails.author;
+                                if (videoDetails?.channelId) data.authorId = videoDetails.channelId;
+
+                                if (videoDetails?.viewCount != null) {
+                                    try {
+                                        data.viewsNumber = Number(videoDetails.viewCount).toLocaleString();
+                                    } catch {
+                                        data.viewsNumber = String(videoDetails.viewCount);
+                                    }
                                 }
-                                if (mf && mf.description && mf.description.simpleText != null) data.description = mf.description.simpleText.trim();
+
+                                const description = microformat?.description?.simpleText;
+                                if (description) data.description = description.trim();
+                                warn('fetchwatchmeta', data)
                             }
-                        } catch (_) { }
+                        } catch {
+                            // Ignore JSON parse errors
+                        }
+
                         resolve(data);
                     },
-                    onerror: function () { resolve({}); },
-                    ontimeout: function () { resolve({}); }
+
+                    onerror: () => resolve({}),
+                    ontimeout: () => resolve({}),
                 });
-            } catch (_) { resolve({}); }
+            } catch {
+                resolve({});
+            }
         });
-    }
-    function getWatchMetaCached(videoId) {
+    };
+
+    /**
+     * Obtiene metadatos desde la caché o los descarga si están expirados.
+     *
+     * @param {string} videoId
+     * @returns {Promise<WatchMeta>}
+     */
+    const getWatchMetaCached = async (videoId) => {
         try {
-            var c = watchMetaCache.get(videoId);
-            if (c && (Date.now() - c.time) < WATCH_META_TTL) return Promise.resolve(c.data);
-        } catch (_) { }
-        return fetchWatchMeta(videoId).then(function (d) { try { watchMetaCache.set(videoId, { data: d, time: Date.now() }); } catch (_) { } return d; });
-    }
+            const cached = watchMetaCache.get(videoId);
+
+            if (cached && (Date.now() - cached.time) < WATCH_META_TTL) {
+                return cached.data;
+            }
+        } catch { }
+
+        const data = await fetchWatchMeta(videoId);
+
+        try {
+            watchMetaCache.set(videoId, {
+                data,
+                time: Date.now(),
+            });
+        } catch { }
+
+        return data;
+    };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     async function getVideoInfo(player, videoId) {
         const now = Date.now();
+
+        warn('getVideoInfo', player.outerHTML + ' ' + videoId)
+
+        // Contexto de la página
+        const ptV = getYouTubePageType();
 
         // Título y autor
         let title = getVideoTittle(player);
@@ -4535,7 +4654,6 @@ background: var(--ypp-danger);
             YTHelper?.video?.publishDate?.getTime() ||
             (YTHelper?.video?.rawPublishDate ? new Date(YTHelper.video.rawPublishDate).getTime() : null);
 
-
         let description =
             YTHelper?.video?.rawDescription?.trim() ??
             document.querySelector('#inline-expander div#snippet.ytd-text-inline-expander yt-attributed-string')?.textContent.trim() ??
@@ -4546,20 +4664,25 @@ background: var(--ypp-danger);
         // Views (evitar contaminación en Shorts cuando no es miniplayer)
         let viewsNumber;
         try {
-            const ptV = getYouTubePageType();
+
+
             let isMiniOnShortsV = false;
             if (ptV === 'shorts') {
                 try {
                     const mp = document.querySelector('#movie_player');
                     const mpVid = mp?.getVideoData?.()?.video_id;
                     if (mpVid && mpVid === videoId) isMiniOnShortsV = true;
+                    warn('viewsnumber mpVid', mpVid)
                 } catch (_) { }
             }
             if (ptV === 'shorts' && !isMiniOnShortsV) {
                 viewsNumber = null;
+                warn('viewsnumber !isMiniOnShortsV', viewsNumber)
             } else if (YTHelper?.video?.viewCount) {
+                warn('viewsnumber YTHelper', YTHelper.video.viewCount)
                 viewsNumber = Number(YTHelper.video.viewCount).toLocaleString();
             } else if (window.ytInitialPlayerResponse?.videoDetails?.viewCount != null) {
+                warn('viewsnumber ytInitialPlayerRespons', Number(window.ytInitialPlayerResponse.videoDetails.viewCount).toLocaleString())
                 viewsNumber = Number(window.ytInitialPlayerResponse.videoDetails.viewCount).toLocaleString();
             } else {
                 viewsNumber =
@@ -4568,6 +4691,7 @@ background: var(--ypp-danger);
                     document.querySelector('ytd-watch-info-text div#tooltip.tp-yt-paper-tooltip')?.textContent?.match(/[\d.,\s]+/)?.[0].trim() ||
                     document.querySelector('yt-formatted-string.view-count')?.textContent?.match(/[\d.,\s]+/)?.[0].trim() ||
                     t('notAvailable');
+                warn('viewsnumber ultimo', viewsNumber)
             }
         } catch (_) {
             viewsNumber = t('notAvailable');
@@ -4591,18 +4715,20 @@ background: var(--ypp-danger);
         let duration = normalizeSeconds(getVideoDuration(player, videoEl));
         log('getVideoInfo', ' 🕕 Duración tras normalizeSeconds = ', duration);
 
-        const pt = getYouTubePageType();
+
         let authorId;
         let isMiniOnShorts = false;
         try {
-            if (pt === 'shorts') {
+            if (ptV === 'shorts') {
                 const mpChk = document.querySelector('#movie_player');
                 const mpVid = mpChk?.getVideoData?.()?.video_id;
+
                 if (mpVid && mpVid === videoId) isMiniOnShorts = true;
             }
         } catch (_) { }
-        if (pt === 'shorts' && !isMiniOnShorts) {
-            // Shorts normales: primero metapanel/overlay del Short ACTIVO
+
+        if (ptV === 'shorts' && !isMiniOnShorts) {
+            // Shorts normales (sin miniplayer): primero metapanel/overlay del Short ACTIVO
             authorId = extractShortsChannelId() ||
                 document.querySelector('#shorts-player a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
                 document.querySelector('ytd-reel-player-header-renderer a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
@@ -4612,12 +4738,15 @@ background: var(--ypp-danger);
                 document.querySelector('link[itemprop="url"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
                 null;
 
+            warn('authorId 11111', YTHelper?.video.id)
+
             // Fallback seguro: usar videoDetails.channelId si pertenece al mismo Short
             if (!authorId) {
                 try {
                     const vd = window.ytInitialPlayerResponse?.videoDetails;
                     if (vd && vd.videoId === videoId && typeof vd.channelId === 'string' && vd.channelId) {
                         authorId = vd.channelId;
+                        conError('auto 1er fallback', authorId)
                     }
                 } catch (_) { }
             }
@@ -4627,7 +4756,7 @@ background: var(--ypp-danger);
                 try {
                     const helperVideo = YTHelper?.video;
                     const helperVid =
-                        helperVideo && (helperVideo.id || helperVideo.videoId || helperVideo.video_id);
+                        helperVideo && (helperVideo.id || helperVideo.videoId);
                     const helperChannelId = helperVideo && helperVideo.channelId;
                     if (
                         helperChannelId &&
@@ -4661,7 +4790,7 @@ background: var(--ypp-danger);
                     if (metaForShort && metaForShort.viewsNumber) viewsNumber = metaForShort.viewsNumber;
                 }
             } catch (_) { }
-        } else if (pt === 'shorts' && isMiniOnShorts) {
+        } else if (ptV === 'shorts' && isMiniOnShorts) {
             // Shorts + miniplayer: NO usar window.ytInitialPlayerResponse (pertenece al Short)
             // 1) Intentar enlaces dentro de #movie_player
             authorId =
@@ -4681,21 +4810,26 @@ background: var(--ypp-danger);
         } else {
             // Páginas normales (watch, embed, home, etc.)
             authorId =
-                window.ytInitialPlayerResponse?.videoDetails?.channelId ||
-                document.querySelector('#upload-info a.yt-simple-endpoint')?.href?.split('/channel/')[1] ||
-                document.querySelector('a.ytp-ce-channel-title.ytp-ce-link')?.href?.split('/channel/')[1] ||
+                YTHelper?.video?.channelId ||
+                document.querySelector('a[href^="/channel/"]')
+                    .getAttribute("href") // "/channel/UCYfdidRxbB8Qhf0Nx7ioOYw/videos"
+                    .split("/")[2] || // "UCYfdidRxbB8Qhf0Nx7ioOYw" 
+
+                //window.ytInitialPlayerResponse?.videoDetails?.channelId ||
+                //document.querySelector('#upload-info a.yt-simple-endpoint')?.href?.split('/channel/')[1] ||
+                //document.querySelector('a.ytp-ce-channel-title.ytp-ce-link')?.href?.split('/channel/')[1] ||
                 document.querySelector('#items yt-button-shape a')?.href?.split('/channel/')[1]?.split('/')[0] ||
                 document.querySelector('#infocard-channel-button yt-button-shape a')?.href?.split('/channel/')[1]?.split('/')[0] ||
                 t('unknown');
         }
 
         try {
-            const pt2 = getYouTubePageType();
-            if (pt2 !== 'watch') {
+
+            if (ptV !== 'watch') {
                 let isMiniContext = false;
                 try {
                     const mpIdNow = document.querySelector('#movie_player')?.getVideoData?.()?.video_id;
-                    if (pt2 === 'shorts' && mpIdNow && mpIdNow === videoId) isMiniContext = true;
+                    if (ptV === 'shorts' && mpIdNow && mpIdNow === videoId) isMiniContext = true;
                 } catch (_) { }
                 const meta = await getWatchMetaCached(videoId);
                 const isGeneric = (s) => !s || ['YouTube', 'Loading...', 'Untitled'].includes(('' + s).trim());
@@ -4708,7 +4842,7 @@ background: var(--ypp-danger);
                         if (meta.description) description = meta.description;
                     } else {
                         // En Shorts (no-miniplayer), no adoptar título/autor/authorId/descripcion desde meta para evitar contaminación
-                        if (pt2 !== 'shorts') {
+                        if (ptV !== 'shorts') {
                             if (isGeneric(title) && meta.title) title = meta.title;
                             if ((!author || author === t('unknown')) && meta.author) author = meta.author;
                             if ((!authorId || authorId === t('unknown')) && meta.authorId) authorId = meta.authorId;
@@ -4724,8 +4858,7 @@ background: var(--ypp-danger);
         } catch (_) { }
 
         try {
-            const ptFinal = getYouTubePageType();
-            if (ptFinal === 'shorts' && !isMiniOnShorts) {
+            if (ptV === 'shorts' && !isMiniOnShorts) {
                 if (!title || title === t('unknown')) {
                     try {
                         const sTitle2 = extractShortsTitle();
@@ -4756,7 +4889,42 @@ background: var(--ypp-danger);
         // Valor por defecto legible si no se pudo determinar
         if (!viewsNumber) viewsNumber = t('notAvailable');
 
-        log('getVideoInfo', 'Info:', { title, author, viewsNumber, duration, videoId, authorId, published })
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        log('getVideoInfo', 'Info:', {
+            title,
+            author,
+            viewsNumber,
+            savedAt: now,
+            duration,
+            authorId,
+            videoId,
+            published,
+            description,
+            isLive
+        })
         return {
             title,
             author,
@@ -4771,6 +4939,40 @@ background: var(--ypp-danger);
             isLive
         };
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     // ------------------------------------------
     // MARK: 📺 get Video Duration
@@ -5055,7 +5257,7 @@ background: var(--ypp-danger);
             // 3. Fallback: Verificar meta tag específico de live broadcast (con validación adicional)
             const isLiveBroadcastMeta = document.querySelector('meta[itemprop="isLiveBroadcast"]');
             const isLiveBroadcast = isLiveBroadcastMeta?.content === 'True';
-            log('isLiveVideo', `Meta isLiveBroadcast: ${isLiveBroadcastMeta?.content}, es True: ${isLiveBroadcast}`);
+            log('isLiveBroadcast', `Meta isLiveBroadcast: ${isLiveBroadcastMeta?.content}, es True: ${isLiveBroadcast}`);
 
             if (isLiveBroadcast) {
                 // SIEMPRE validar meta tag con otros indicadores para evitar falsos positivos
@@ -5820,11 +6022,11 @@ background: var(--ypp-danger);
             videoData.thumb = `https://i.ytimg.com/vi/${video_id}/maxresdefault.jpg`;
 
             try {
-                const channelUrl = videoData.authorId ? `https://www.youtube.com/channel/${videoData.authorId}` : '';
+                const channelUrl = videoData.authorId !== `${t('unknow')}` ? `https://www.youtube.com/channel/${videoData.authorId}` : '';
                 log('updateStatus', 'Canal final para guardar', {
                     author: videoData.author,
                     authorId: videoData.authorId,
-                    channelUrl: channelUrl || '(none)'
+                    channelUrl: channelUrl
                 });
             } catch (_) { }
 
@@ -6031,6 +6233,9 @@ background: var(--ypp-danger);
         try {
             setTimeout(async () => {
                 try {
+                    warn('helper.player', YTHelper.player.playerObject)
+                    warn('helper.apiProxy', YTHelper.apiProxy.getPlayerResponse())
+                    warn('player', player)
                     const freshPlayer = YTHelper?.player?.playerObject || player;
                     const freshEl = await getActiveVideoElement();
                     if (freshPlayer && (freshEl || videoEl)) {
@@ -6267,7 +6472,7 @@ background: var(--ypp-danger);
         }
 
         // No programar limpieza automática para mensajes seek si el video está pausado
-        const isSeekMessage = !!message.includes('svgPlayOrPauseIcon')
+        const isSeekMessage = !!message.includes('svgPlayOrPauseIcon');
         const activeVideoEl = currentVideoEl || getActiveVideoElement();
         const isVideoPaused = activeVideoEl?.paused || false;
         log('updatePlaybackBarMessage', `🔍 Estado: videoPaused=${isVideoPaused}, isSeekMessage=${isSeekMessage}, currentVideoEl=${!!currentVideoEl}`);
@@ -6284,8 +6489,13 @@ background: var(--ypp-danger);
 
     function clearPlaybackBarMessage() {
         if (timeDisplay) {
-            setInnerHTML(timeDisplay, '');
-            timeDisplay.classList.add('ypp-d-none');
+            // Dejar siempre un botón/base visible para abrir la lista de guardados
+            try {
+                setInnerHTML(timeDisplay, SVG_ICONS.save || '');
+            } catch (_) {
+                setInnerHTML(timeDisplay, '');
+            }
+            timeDisplay.classList.remove('ypp-d-none');
         }
 
         // Limpiar timeout si existe
@@ -7286,78 +7496,106 @@ background: var(--ypp-danger);
         }
         log('processVideo', `URL del video guardada para miniplayer: ${lastVideoUrl}`);
 
-        let plId = urlData?.list;
-        // Intentar obtener playlistId desde el contenedor de la tarjeta actual (home/search/channel) para asociar correctamente Mix (RD...)
-        if (!plId && (pageType === 'home' || pageType === 'search' || pageType === 'channel')) {
-            try {
-                const elCtx = (currentVideoEl || videoEl || activeVideoCheck);
-                const card = elCtx?.closest?.('ytd-rich-item-renderer, ytd-video-renderer, ytd-compact-video-renderer, ytd-playlist-panel-video-renderer, ytd-grid-video-renderer');
-                if (card) {
-                    let aSel = null;
-                    try { if (videoIdDetected) aSel = card.querySelector(`a[href*="/watch?v=${videoIdDetected}"][href*="list="]`); } catch (_) { }
-                    if (!aSel) {
-                        try { aSel = card.querySelector('a[href*="list="]'); } catch (_) { }
-                    }
-                    if (aSel) {
-                        const uCard = new URL(aSel.href, location.origin);
-                        const lCard = uCard.searchParams.get('list');
-                        if (lCard) plId = lCard;
-                        log('processVideo', `📌 plId obtenido desde card actual: ${plId || '(none)'}`);
-                    }
-                }
-            } catch (_) { }
-        }
-        if (!plId) {
-            try {
-                if (pageType === 'home' || pageType === 'search' || pageType === 'channel') {
-                    const a = document.querySelector('#anchored-panel a[href*="list="]') ||
-                        document.querySelector('#movie_player a[href*="list="]') ||
-                        document.querySelector('.ytp-miniplayer-ui a[href*="list="]');
-                    if (a) {
-                        const u = new URL(a.href, location.origin);
-                        const l = u.searchParams.get('list');
-                        if (l) plId = l;
-                    }
-                }
-            } catch (_) { }
-        }
-
-        if (!plId && (pageType === 'home' || pageType === 'search' || pageType === 'channel')) {
-            try { if (!plId && lastPlaylistId) plId = lastPlaylistId; } catch (_) { }
-            if (!plId) {
+        const resolvePlaylistIdForProcess = () => {
+            const pickListParam = (maybeUrl) => {
+                if (!maybeUrl) return null;
                 try {
-                    if (lastVideoUrl) {
-                        const u3 = new URL(lastVideoUrl, location.origin);
-                        const l3 = u3.searchParams.get('list');
-                        if (l3) plId = l3;
+                    const parsed = new URL(maybeUrl, location.origin);
+                    return parsed.searchParams.get('list');
+                } catch (_) {
+                    return null;
+                }
+            };
+
+            let candidate = pickListParam(urlForVideoId);
+            const isHomeish = pageType === 'home' || pageType === 'search' || pageType === 'channel';
+            const contextElement = currentVideoEl || videoEl || activeVideoCheck;
+
+            if (!candidate && isHomeish) {
+                try {
+                    const card = contextElement?.closest?.('ytd-rich-item-renderer, ytd-video-renderer, ytd-compact-video-renderer, ytd-playlist-panel-video-renderer, ytd-grid-video-renderer');
+                    if (card) {
+                        let anchor = null;
+                        try {
+                            if (videoIdDetected) {
+                                anchor = card.querySelector(`a[href*="/watch?v=${videoIdDetected}"][href*="list="]`);
+                            }
+                        } catch (_) { }
+                        if (!anchor) {
+                            try { anchor = card.querySelector('a[href*="list="]'); } catch (_) { }
+                        }
+                        if (anchor) {
+                            const uCard = new URL(anchor.href, location.origin);
+                            const lCard = uCard.searchParams.get('list');
+                            if (lCard) {
+                                candidate = lCard;
+                                log('processVideo', `📌 plId obtenido desde card actual: ${candidate}`);
+                            }
+                        }
                     }
                 } catch (_) { }
             }
-        }
-        try {
-            const isHomeish = pageType === 'home' || pageType === 'search' || pageType === 'channel';
-            if (isHomeish && lastPlaylistId && /^RD/.test(lastPlaylistId) && plId && !/^RD/.test(plId)) {
-                plId = lastPlaylistId;
-            }
-            if (isHomeish && !plId && lastPlaylistId && /^RD/.test(lastPlaylistId)) {
-                plId = lastPlaylistId;
-            }
-        } catch (_) { }
-        try {
-            if (plId) {
-                const elForStability = (currentVideoEl || videoEl || activeVideoCheck);
-                const contForStability = elForStability?.closest?.('#movie_player');
-                const ptForStability = getYouTubePageType();
-                const isStableContext = (ptForStability === 'watch' || ptForStability === 'embed') || !!contForStability;
-                if (isStableContext) lastPlaylistId = plId;
-            }
-        } catch (_) { }
 
-        try {
-            if ((pageType === 'home' || pageType === 'search' || pageType === 'channel') && videoIdDetected) {
-                lastVideoUrl = `https://www.youtube.com/watch?v=${videoIdDetected}${plId ? `&list=${plId}` : ''}`;
+            if (!candidate && isHomeish) {
+                try {
+                    const selectors = [
+                        '#anchored-panel a[href*="list="]',
+                        '#movie_player a[href*="list="]',
+                        '.ytp-miniplayer-ui a[href*="list="]'
+                    ];
+                    for (const selector of selectors) {
+                        const anchor = document.querySelector(selector);
+                        if (anchor) {
+                            const u = new URL(anchor.href, location.origin);
+                            const l = u.searchParams.get('list');
+                            if (l) {
+                                candidate = l;
+                                break;
+                            }
+                        }
+                    }
+                } catch (_) { }
             }
-        } catch (_) { }
+
+            if (!candidate && isHomeish && lastPlaylistId) {
+                candidate = lastPlaylistId;
+            }
+
+            if (!candidate && isHomeish && lastVideoUrl) {
+                try {
+                    const u3 = new URL(lastVideoUrl, location.origin);
+                    const l3 = u3.searchParams.get('list');
+                    if (l3) candidate = l3;
+                } catch (_) { }
+            }
+
+            if (isHomeish && lastPlaylistId && /^RD/.test(lastPlaylistId)) {
+                if (candidate && !/^RD/.test(candidate)) {
+                    candidate = lastPlaylistId;
+                } else if (!candidate) {
+                    candidate = lastPlaylistId;
+                }
+            }
+
+            try {
+                if (candidate) {
+                    const contForStability = contextElement?.closest?.('#movie_player');
+                    const ptForStability = getYouTubePageType();
+                    const isStableContext = (ptForStability === 'watch' || ptForStability === 'embed') || !!contForStability;
+                    if (isStableContext) lastPlaylistId = candidate;
+                }
+            } catch (_) { }
+
+            if (isHomeish && videoIdDetected) {
+                try {
+                    lastVideoUrl = `https://www.youtube.com/watch?v=${videoIdDetected}${candidate ? `&list=${candidate}` : ''}`;
+                } catch (_) { }
+            }
+
+            return candidate;
+        };
+
+        let plId = resolvePlaylistIdForProcess();
 
         log('processVideo', `URL del reproductor: ${window.location.href} | Video ID del reproductor: ${videoIdDetected}`);
 
@@ -7869,7 +8107,7 @@ background: var(--ypp-danger);
                                         if (l) mpPlId2 = l;
                                     }
                                 } catch (_) { }
-                                if (!mpPlId2) {
+                                /* if (!mpPlId2) {
                                     try {
                                         const a = document.querySelector('#anchored-panel a[href*="list="]') || document.querySelector('#movie_player a[href*="list="]');
                                         if (a) {
@@ -7878,7 +8116,7 @@ background: var(--ypp-danger);
                                             if (l2) mpPlId2 = l2;
                                         }
                                     } catch (_) { }
-                                }
+                                } */
                             }
                             updateStatus(mpPlayer2, mpEl2, 'watch', mpPlId2, mpId3).then(r => {
                                 if (r && r.success) { try { lastSaveTimesByVideoId[mpId3] = Date.now(); } catch (_) { } }
@@ -8399,7 +8637,7 @@ background: var(--ypp-danger);
     }
 
     function updateVideoList() {
-        const keys = Storage.keys().filter(k => !k.startsWith('userSettings') && !k.startsWith('playlist_meta_') && k !== 'translations_cache_v1');
+        const keys = Storage.keys().filter(k => !k.startsWith('userSettings') && !k.startsWith('userFilters') && !k.startsWith('playlist_meta_') && k !== 'translations_cache_v1');
         setInnerHTML(listContainer, ''); // Limpiar contenido previo
 
         // Cargar metadata de playlists para referencia

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -351,7 +351,12 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "confirmRemoveFromPlaylist": "Are you sure you want to remove this video from the playlist? It will be kept as an individual video.",
             "playlistAssociationRemoved": "Playlist association removed",
             "loading": "Loading",
-            "rendered": "rendered"
+            "rendered": "rendered",
+            "previews": "Previews",
+            "migratingData": "Migrating saved data from previous version...",
+            "migratingDataProgress": "Migrating data... {count} items processed",
+            "migrationComplete": "Migration complete: {migrated} videos migrated successfully",
+            "migrationNoData": "No data found to migrate"
         },
         "es-ES": {
             "settings": "Configuración",
@@ -462,7 +467,12 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "confirmRemoveFromPlaylist": "¿Estás seguro de que quieres quitar este video de la playlist? Se mantendrá como video individual.",
             "playlistAssociationRemoved": "Asociación de playlist eliminada",
             "loading": "Cargando",
-            "rendered": "renderizados"
+            "rendered": "renderizados",
+            "previews": "Previsualizaciones",
+            "migratingData": "Migrando datos guardados desde versión anterior...",
+            "migratingDataProgress": "Migrando datos... {count} entradas procesadas",
+            "migrationComplete": "Migración completada: {migrated} videos migrados correctamente",
+            "migrationNoData": "No se encontraron datos para migrar"
         },
         "fr": {
             "settings": "Paramètres",
@@ -572,7 +582,12 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "confirmRemoveFromPlaylist": "Êtes-vous sûr de vouloir retirer cette vidéo de la playlist ? Elle sera conservée comme vidéo individuelle.",
             "playlistAssociationRemoved": "Association de playlist supprimée",
             "loading": "Chargement",
-            "rendered": "rendus"
+            "rendered": "rendus",
+            "previews": "Aperçus",
+            "migratingData": "Migration des données de la version précédente...",
+            "migratingDataProgress": "Migration des données... {count} éléments traités",
+            "migrationComplete": "Migration terminée : {migrated} vidéos migrées avec succès",
+            "migrationNoData": "Aucune donnée trouvée pour migrer"
         }
     };
 
@@ -728,17 +743,36 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
     let currentLanguage = CONFIG.defaultSettings.language; // Idioma predeterminado
 
     // Función para obtener el texto traducido
-    function t(key, params = {}) {
+    function t(key, params = {}, defaultText = null) {
+        let actualDefaultText = defaultText;
+        let actualParams = params;
+
+        // Soporte para valor por defecto como segundo argumento: t('key', 'Default Text')
+        if (typeof params === 'string') {
+            actualDefaultText = params;
+            actualParams = {};
+        }
+
+        // Si params no es objeto, asegurarlo
+        if (typeof actualParams !== 'object' || actualParams === null) {
+            actualParams = {};
+        }
+
+        // Si no se pasó defaultText explícito, usar la key como fallback
+        if (!actualDefaultText) {
+            actualDefaultText = key;
+        }
+
         if (!TRANSLATIONS[currentLanguage] || !TRANSLATIONS[currentLanguage][key]) {
             // Si no hay traducción, intentar con el idioma por defecto (ej: en-US)
             const fallbackLang = CONFIG.defaultSettings.language;
             if (TRANSLATIONS[fallbackLang] && TRANSLATIONS[fallbackLang][key]) {
-                return replaceParams(TRANSLATIONS[fallbackLang][key], params);
+                return replaceParams(TRANSLATIONS[fallbackLang][key], actualParams);
             }
-            // Si no hay ni en el idioma por defecto, devolver la clave
-            return key;
+            // Si no hay ni en el idioma por defecto, devolver el valor por defecto
+            return replaceParams(actualDefaultText, actualParams);
         }
-        return replaceParams(TRANSLATIONS[currentLanguage][key], params);
+        return replaceParams(TRANSLATIONS[currentLanguage][key], actualParams);
     }
 
     // Función para reemplazar parámetros en las traducciones
@@ -1986,7 +2020,7 @@ background: var(--ypp-danger);
     * Aplica degradado de colores a la barra de progreso del reproductor de YouTube usando CSS
     * @param {number} currentTime - Tiempo actual del video en segundos
     * @param {number} duration - Duración total del video en segundos
-    * @param {string} type - Tipo de video ('shorts' o 'watch')
+    * @param {string} type - Tipo de video ('shorts', 'video' o 'watch')
     */
     function updateProgressBarGradient(currentTime, duration, type = 'watch') {
         try {
@@ -2299,6 +2333,39 @@ background: var(--ypp-danger);
         /**
          * Inicializa la capa asíncrona: detecta IndexedDB, migra datos si es necesario y llena caché.
          */
+        /**
+         * Normaliza una clave removiendo el prefijo del script si lo tiene.
+         * Las claves en IndexedDB se almacenan SIN prefijo para coherencia
+         * con el nuevo sistema Storage que no agrega prefijos.
+         * @param {string} key - Clave original (puede tener prefijo o no)
+         * @returns {string} Clave sin prefijo
+         */
+        function stripStoragePrefix(key) {
+            if (typeof key === 'string' && key.startsWith(CONFIG.storagePrefix)) {
+                return key.slice(CONFIG.storagePrefix.length);
+            }
+            return key;
+        }
+
+        /**
+         * Determina si una clave pertenece al script (tiene prefijo o es una clave interna conocida).
+         * Evita migrar claves ajenas de localStorage o GM que no pertenecen al script.
+         * @param {string} key - Clave a verificar
+         * @returns {boolean} true si la clave pertenece al script
+         */
+        function isScriptKey(key) {
+            if (typeof key !== 'string') return false;
+            // Claves con prefijo del script
+            if (key.startsWith(CONFIG.storagePrefix)) return true;
+            // Claves internas de migración/normalización
+            if (key.startsWith('ypp_')) return true;
+            return false;
+        }
+
+        /**
+         * Inicializa la capa asíncrona: detecta IndexedDB, migra datos si es necesario y llena caché.
+         * Solo migra claves con prefijo YT_PLAYBACK_PLOX_ y las almacena en IndexedDB sin prefijo.
+         */
         async function initialize() {
             if (readyPromise) return readyPromise;
             readyPromise = (async () => {
@@ -2308,11 +2375,12 @@ background: var(--ypp-danger);
                     const migrated = localStorage.getItem(STORAGE_MIGRATION_STATE_KEY) === '1';
                     let legacySnapshot = [];
                     if (!migrated && IndexedDBAdapter.isSupported) {
-                        // Recolectar snapshot de localStorage/GM directamente para evitar recursión
+                        // Recolectar snapshot de localStorage/GM filtrando solo claves del script
                         let allKeys = [];
                         try {
                             if (typeof GM_listValues !== 'undefined') {
-                                allKeys = await GM_listValues();
+                                const gmRaw = await GM_listValues();
+                                allKeys = Array.isArray(gmRaw) ? gmRaw : [];
                             } else if (typeof localStorage !== 'undefined') {
                                 allKeys = Object.keys(localStorage);
                             }
@@ -2320,21 +2388,26 @@ background: var(--ypp-danger);
                             logger.warn('Error al obtener claves para migración:', err);
                         }
 
-                        for (const key of allKeys || []) {
-                            if (STORAGE_META_KEYS.has(key)) continue;
+                        // Filtrar: solo claves del script, excluyendo metaclaves
+                        const filteredKeys = (allKeys || []).filter(k => isScriptKey(k) && !STORAGE_META_KEYS.has(k));
+                        logger.info(`Migración: ${filteredKeys.length} claves del script encontradas (de ${allKeys.length} totales)`);
+
+                        for (const rawKey of filteredKeys) {
+                            // Strip prefix para coherencia con nuevo Storage sin prefijos
+                            const normalizedKey = stripStoragePrefix(rawKey);
                             let value = null;
                             try {
                                 if (typeof GM_getValue !== 'undefined') {
-                                    value = await GM_getValue(key);
+                                    value = await GM_getValue(rawKey);
                                 } else if (typeof localStorage !== 'undefined') {
-                                    const item = localStorage.getItem(key);
+                                    const item = localStorage.getItem(rawKey);
                                     if (item) value = JSON.parse(item);
                                 }
                             } catch (err) {
-                                logger.warn(`Error al leer clave ${key}:`, err);
+                                logger.warn(`Error al leer clave ${rawKey}:`, err);
                             }
                             if (value !== null) {
-                                legacySnapshot.push({ key, value: JSON.stringify(value) });
+                                legacySnapshot.push({ key: normalizedKey, value: JSON.stringify(value) });
                             }
                         }
                     }
@@ -2463,7 +2536,7 @@ background: var(--ypp-danger);
 
     const IndexedDBAdapter = (() => {
         const DB_NAME = 'YTPlaybackPloxDB';
-        const STORE_NAME = 'keyvalue';
+        const STORE_NAME = 'savedVideos';
         const DB_VERSION = 1;
         const isSupported = (() => {
             try {
@@ -4295,7 +4368,7 @@ background: var(--ypp-danger);
             duration: freeTubeData.lengthSeconds,
             timestamp: freeTubeData.watchProgress,
             lastUpdated: freeTubeData.timeWatched,
-            videoType: freeTubeData.type === 'short' ? 'shorts' : 'watch',
+            videoType: normalizeVideoType(freeTubeData.type === 'short' ? 'shorts' : 'video'),
             isCompleted: isCompleted,
             published: freeTubeData.published,
             description: freeTubeData.description,
@@ -8937,7 +9010,7 @@ background: var(--ypp-danger);
                         // Si aún no hay playlist, verificar si el plId actual pertenece a este video
                         if (!urlPlaylistId && plId) {
                             // CRÍTICO: Verificar si es un anuncio - los anuncios NO deben heredar playlists
-                            const isAd = isAdBlockedFor('watch') || isAdBlockedFor('shorts');
+                            const isAd = isAdBlockedFor('video') || isAdBlockedFor('shorts');
                             if (isAd) {
                                 log('updateStatus', `🚫 Anuncio detectado, no heredando playlist ${plId}`);
                                 urlPlaylistId = null;
@@ -9229,7 +9302,7 @@ background: var(--ypp-danger);
 
         try {
             const d = getVideoDuration(player, videoEl);
-            const videoType = type === 'short' ? 'shorts' : 'watch';
+            const videoType = type === 'short' ? 'shorts' : 'video';
             updateProgressBarGradient(timeToSeek, d, videoType);
         } catch (_) { }
         /*
@@ -10076,8 +10149,9 @@ background: var(--ypp-danger);
 
         // Bloquear notificación de progreso si hay tiempo fijo o si hay un mensaje seek activo y video está pausado
         if (context === 'progress') {
-            // Opción A: si estamos en Shorts y el guardado proviene del miniplayer (watch), no mostrar notificación
-            if (currentPageType === 'shorts' && options?.videoType === 'watch') {
+            // Opción A: si estamos en Shorts y el guardado proviene del miniplayer (watch/video), no mostrar notificación
+            const vType = options?.videoType;
+            if (currentPageType === 'shorts' && (vType === 'watch' || vType === 'video')) {
                 return;
             }
             const videoId = YTHelper?.video.id || extractOrNormalizeVideoId(location.href)?.id;
@@ -10499,7 +10573,7 @@ background: var(--ypp-danger);
 
         try {
             const pt0 = getYouTubePageType();
-            if (pt0 !== 'shorts' && isAdBlockedFor('watch')) {
+            if (pt0 !== 'shorts' && isAdBlockedFor('video')) {
                 log('processVideo', '⏸️  ABORTANDO processVideo - Anuncio (watch) activo');
                 return;
             }
@@ -11592,7 +11666,7 @@ background: var(--ypp-danger);
                     let mpId3 = null;
                     try { mpId3 = mpC?.getVideoData?.()?.video_id || null; } catch (_) { }
                     const urlIdNow2 = extractOrNormalizeVideoId(window.location.href)?.id || null;
-                    if (mpEl2 && !mpEl2.paused && mpId3 && mpId3 !== boundVideoId && !isAdBlockedFor('watch')) {
+                    if (mpEl2 && !mpEl2.paused && mpId3 && mpId3 !== boundVideoId && !isAdBlockedFor('video')) {
                         const lastSavedMp = (ctx?.lastSaveTimesByVideoId?.[mpId3] ?? lastSaveTimesByVideoId[mpId3] ?? 0);
                         if (nowTs2 - lastSavedMp >= minInterval2) {
                             const mpPlayer2 = mpC && typeof mpC.getDuration === 'function' ? mpC : player;
@@ -11619,7 +11693,7 @@ background: var(--ypp-danger);
                                     } catch (_) { }
                                 } */
                             }
-                            updateStatus(mpPlayer2, mpEl2, 'watch', mpPlId2, mpId3).then(r => {
+                            updateStatus(mpPlayer2, mpEl2, 'video', mpPlId2, mpId3).then(r => {
                                 if (r && r.success) {
                                     const tsOk = Date.now();
                                     try { lastSaveTimesByVideoId[mpId3] = tsOk; } catch (_) { }
@@ -12129,7 +12203,7 @@ background: var(--ypp-danger);
         const select = createElement('select', {
             className: 'ypp-filter-select', id: 'filter-selector', html: `
         <option value="all" ${currentValue === 'all' ? 'selected' : ''}>🔎 ${t('all')}</option>
-        <option value="watch" ${currentValue === 'watch' ? 'selected' : ''}>▶️ ${t('videos')}</option>
+        <option value="video" ${currentValue === 'video' ? 'selected' : ''}>▶️ ${t('videos')}</option>
         <option value="shorts" ${currentValue === 'shorts' ? 'selected' : ''}>📱 ${t('shorts')}</option>
         <option value="preview" ${currentValue === 'preview' ? 'selected' : ''}>👁️ ${t('previews')}</option>
         <option value="live" ${currentValue === 'live' ? 'selected' : ''}>🔴 ${t('liveStreams')}</option>
@@ -12194,6 +12268,7 @@ background: var(--ypp-danger);
     let currentOrderBy, currentFilterBy, currentSearchQuery;
     /** @type {VirtualScroller|null} Instancia del scroller virtual para la lista de videos */
     let virtualScroller = null;
+    let storageUsageRefreshIntervalId = null;
     /** @type {Array|null} Cache de items preparados para evitar re-procesar en cada render */
     let preparedItemsCache = null;
     /** @type {Map<string, string>} Cache global de títulos por ID para uso en createVideoEntry */
@@ -12393,8 +12468,8 @@ background: var(--ypp-danger);
             if (currentFilterBy === 'playlist') return item.type === 'playlist-video';
             if (currentFilterBy === 'preview') return (vType && vType.startsWith('preview'));
 
-            if (currentFilterBy === 'watch') {
-                return vType === 'watch' || vType === 'video' || !vType;
+            if (currentFilterBy === 'video') {
+                return vType === 'video' || vType === 'watch' || !vType; // fallback for watch legacy if any
             }
 
             if (currentFilterBy === 'shorts') return vType === 'shorts';
@@ -12444,8 +12519,11 @@ background: var(--ypp-danger);
         setInnerHTML(statsBar, `
             <span>${filteredItems.length} ${t('videos')}</span>
             <span id="ypp-render-stats"></span>
+            <span id="ypp-storage-usage"></span>
         `);
         listContainer.appendChild(statsBar);
+
+        try { await updateStorageUsageIndicator(); } catch (_) { }
 
         // Crear contenedor para el scroller virtual
         const scrollerContainer = createElement('div', {
@@ -12551,8 +12629,51 @@ background: var(--ypp-danger);
             listContainer.remove();
             listContainer = null;
         }
+
+        if (storageUsageRefreshIntervalId) {
+            clearInterval(storageUsageRefreshIntervalId);
+            storageUsageRefreshIntervalId = null;
+        }
         document.body.style.overflow = '';
     }
+
+    /**
+     * Formatea una cantidad de bytes en unidades humanas.
+     * @param {number} bytes
+     * @returns {string}
+     */
+    const formatBytes = (bytes) => {
+        const value = Number(bytes);
+        if (!Number.isFinite(value) || value <= 0) return '0 B';
+        const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        const exponent = Math.min(Math.floor(Math.log(value) / Math.log(1024)), units.length - 1);
+        const scaled = value / (1024 ** exponent);
+        const decimals = exponent === 0 ? 0 : (scaled < 10 ? 2 : 1);
+        return `${scaled.toFixed(decimals)} ${units[exponent]}`;
+    };
+
+    /**
+     * Actualiza el indicador de uso/cuota del almacenamiento (origin storage, incluye IndexedDB).
+     * @returns {Promise<void>}
+     */
+    const updateStorageUsageIndicator = async () => {
+        const el = document.getElementById('ypp-storage-usage');
+        if (!el) return;
+
+        const estimateFn = navigator?.storage?.estimate;
+        if (typeof estimateFn !== 'function') {
+            el.textContent = '';
+            return;
+        }
+
+        const { usage, quota } = await estimateFn.call(navigator.storage);
+        if (!Number.isFinite(usage) || !Number.isFinite(quota) || quota <= 0) {
+            el.textContent = '';
+            return;
+        }
+
+        el.textContent = `${formatBytes(usage)} / ${formatBytes(quota)}`;
+    };
 
     // ------------------------------------------
     // MARK: 🔘 Floating Button
@@ -12639,6 +12760,15 @@ background: var(--ypp-danger);
         videosContainer.appendChild(filtersContainer);
 
         videosContainer.appendChild(listContainer);
+
+        try {
+            await updateStorageUsageIndicator();
+            if (!storageUsageRefreshIntervalId) {
+                storageUsageRefreshIntervalId = setInterval(() => {
+                    updateStorageUsageIndicator().catch(() => { });
+                }, 30_000);
+            }
+        } catch (_) { }
 
         const footer = createElement('div', { className: 'ypp-footer' });
 
@@ -14090,11 +14220,42 @@ background: var(--ypp-danger);
     // ------------------------------------------
 
     /**
-     * Migra datos del formato antiguo (playlists anidadas) al nuevo formato FreeTube
-     * Esta función se ejecuta automáticamente una vez al inicio
+     * Normaliza un valor de videoType para corregir inconsistencias entre versiones.
+     * Convierte valores legacy ('watch', 'regular', 'short') al esquema actual.
+     * @param {string|undefined} rawType - Tipo original del video
+     * @returns {string} Tipo normalizado: 'video', 'shorts', 'live', 'preview_watch', 'preview_shorts'
+     */
+    function normalizeVideoType(rawType) {
+        if (!rawType || typeof rawType !== 'string') return 'video';
+        const type = rawType.trim().toLowerCase();
+        // Mapa de conversión de tipos legacy → actuales
+        const LEGACY_TYPE_MAP = {
+            'watch': 'video',
+            'regular': 'video',
+            'normal': 'video',
+            'short': 'shorts',
+        };
+        if (LEGACY_TYPE_MAP[type]) return LEGACY_TYPE_MAP[type];
+        // Tipos válidos actuales: devolver tal cual
+        const VALID_TYPES = new Set(['video', 'shorts', 'live', 'preview_watch', 'preview_shorts']);
+        if (VALID_TYPES.has(type)) return type;
+        // Fallback seguro
+        return 'video';
+    }
+
+    /**
+     * Migra datos del formato antiguo (playlists anidadas) al nuevo formato FreeTube.
+     * Esta función se ejecuta automáticamente una vez al inicio.
+     *
+     * Fase 1: Busca claves legacy remanentes en localStorage/GM que no fueron migradas
+     *         por StorageAsync.initialize() (edge case) y las mueve a Storage (IndexedDB).
+     * Fase 2: Procesa todas las claves ya en IndexedDB/Storage para normalizar su
+     *         esquema: desanidar playlists, agregar campos FreeTube, y normalizar videoType.
+     *
+     * @returns {Promise<{migrated: number, skipped: number}>}
      */
     async function migrateToFreeTubeFormat() {
-        const MIGRATION_VERSION = 4; // Incrementar solo si cambia la lógica/estructura de migración
+        const MIGRATION_VERSION = 5; // Incrementado: normalización de videoType y mejora de coherencia
         const MIGRATION_KEY = 'ypp_migration_freetube_format_version';
 
         // Verificar si la migración ya se realizó para esta versión
@@ -14104,135 +14265,93 @@ background: var(--ypp-danger);
             return { migrated: 0, skipped: 0 };
         }
 
-        log('migrateToFreeTubeFormat', '🔄 Iniciando migración de datos al formato FreeTube...');
+        log('migrateToFreeTubeFormat', `🔄 Iniciando migración v${MIGRATION_VERSION} (última: v${lastMigrationVersion})...`);
 
         // Mostrar alerta al usuario sobre la migración
-        showFloatingToast({
-            message: t('migratingData', 'Migrando datos guardados desde versión anterior...'),
-            type: 'info',
-            duration: 0, // No auto-desaparecer
-            persistent: true // Reutilizar mismo toast
-        });
+        showFloatingToast(
+            t('migratingData', 'Migrando datos guardados desde versión anterior...'),
+            0, // No auto-desaparecer
+            { persistent: true } // Reutilizar mismo toast
+        );
 
         let migrated = 0;
         let skipped = 0;
 
-        // PRIMERO: Buscar datos en el sistema antiguo (localStorage)
-        let oldSystemKeys = [];
+        // ─────────────────────────────────────────────────────────────
+        // FASE 1: Rescatar claves legacy remanentes de localStorage/GM
+        // ─────────────────────────────────────────────────────────────
+        // StorageAsync.initialize() ya migró la mayoría de claves a IndexedDB,
+        // pero puede haber remanentes (e.g. error parcial, claves escritas après).
+        let legacyRescued = 0;
         try {
-            // La versión antigua usaba localStorage directamente
+            let legacyKeys = [];
             if (typeof localStorage !== 'undefined') {
-                oldSystemKeys = Object.keys(localStorage).filter(k => k.startsWith('YT_PLAYBACK_PLOX_'));
+                legacyKeys = Object.keys(localStorage).filter(k => k.startsWith('YT_PLAYBACK_PLOX_'));
+            }
+            if (legacyKeys.length === 0 && typeof GM_listValues === 'function') {
+                const gmKeys = await GM_listValues();
+                legacyKeys = (Array.isArray(gmKeys) ? gmKeys : []).filter(k =>
+                    typeof k === 'string' && k.startsWith('YT_PLAYBACK_PLOX_')
+                );
             }
 
-            // También intentar con GM_listValues si está disponible
-            if (oldSystemKeys.length === 0 && typeof GM_listValues === 'function') {
-                const gmKeys = GM_listValues();
-                oldSystemKeys = Array.isArray(gmKeys) ? gmKeys : [];
-            }
-        } catch (e) {
-            warn('migrateToFreeTubeFormat', 'Error al obtener claves del sistema antiguo:', e);
-        }
+            // Filtrar claves no relevantes
+            const relevantLegacyKeys = legacyKeys.filter(k =>
+                !k.includes('userSettings') &&
+                !k.includes('translations_cache') &&
+                !k.includes('migration_') &&
+                !k.includes('__idb_migrated__') &&
+                !k.includes('__test__')
+            );
 
-        log('migrateToFreeTubeFormat', `📊 GM_listValues disponible: ${typeof GM_listValues === 'function'}`);
-        log('migrateToFreeTubeFormat', `📊 Claves encontradas: ${oldSystemKeys.length}`);
-        if (oldSystemKeys.length > 0) {
-            log('migrateToFreeTubeFormat', `📊 Primeras 5 claves: ${oldSystemKeys.slice(0, 5).join(', ')}`);
-        }
+            log('migrateToFreeTubeFormat', `📊 Claves legacy remanentes: ${relevantLegacyKeys.length}`);
 
-        // Verificar directamente localStorage también
-        let localStorageKeys = [];
-        if (typeof localStorage !== 'undefined') {
-            localStorageKeys = Object.keys(localStorage).filter(k => k.startsWith('YT_PLAYBACK_PLOX_'));
-            log('migrateToFreeTubeFormat', `📊 Claves localStorage: ${localStorageKeys.length}`);
-            if (localStorageKeys.length > 0) {
-                log('migrateToFreeTubeFormat', `📊 Primeras 5 claves localStorage: ${localStorageKeys.slice(0, 5).join(', ')}`);
-            }
-        }
+            for (const rawKey of relevantLegacyKeys) {
+                const cleanKey = rawKey.startsWith('YT_PLAYBACK_PLOX_')
+                    ? rawKey.slice('YT_PLAYBACK_PLOX_'.length)
+                    : rawKey;
 
-        // Filtrar claves relevantes del sistema antiguo
-        const oldKeys = oldSystemKeys.filter(k =>
-            !k.includes('userSettings') &&
-            !k.includes('playlist_meta_') &&
-            !k.includes('translations_cache') &&
-            !k.includes('migration_')
-        );
+                // Solo rescatar si no existe ya en IndexedDB
+                const existing = await Storage.get(cleanKey);
+                if (existing) continue;
 
-        log('migrateToFreeTubeFormat', `📦 Encontradas ${oldKeys.length} claves en sistema antiguo`);
-
-        // Procesar datos del sistema antiguo
-        for (const key of oldKeys) {
-            let data = null;
-            try {
-                // Leer desde localStorage (la versión antigua usaba localStorage)
-                if (typeof localStorage !== 'undefined') {
-                    const lsData = localStorage.getItem(key);
-                    if (lsData) {
-                        data = JSON.parse(lsData);
-                    }
-                }
-
-                // Fallback a GM_getValue si localStorage no tiene datos
-                if (!data && typeof GM_getValue === 'function') {
-                    data = GM_getValue(key, null);
-                }
-            } catch (e) {
-                warn('migrateToFreeTubeFormat', `Error al leer clave antigua ${key}:`, e);
-            }
-
-            if (!data) continue;
-
-            // Migrar datos individuales (formato antiguo)
-            if (data.videoId || data.timestamp !== undefined) {
-                // Convertir al nuevo formato FreeTube
-                const migratedVideo = {
-                    videoId: data.videoId || key.replace('YT_PLAYBACK_PLOX_', ''),
-                    timestamp: data.timestamp,
-                    lastUpdated: data.lastUpdated || data.savedAt || Date.now(),
-                    videoType: data.videoType || 'regular',
-                    isCompleted: data.isCompleted || false,
-                    duration: data.duration,
-                    title: data.title,
-                    author: data.author,
-                    thumb: data.thumb,
-                    viewsNumber: data.viewsNumber,
-                    savedAt: data.savedAt,
-                    authorId: data.authorId,
-                    published: data.published,
-                    description: data.description,
-                    isLive: data.isLive,
-                    lastViewedPlaylistId: data.lastViewedPlaylistId || null,
-                    lastViewedPlaylistType: data.lastViewedPlaylistType || '',
-                    lastViewedPlaylistItemId: data.lastViewedPlaylistItemId || null,
-                    forceResumeTime: data.forceResumeTime
-                };
-
-                await Storage.set(migratedVideo.videoId, migratedVideo);
-
-                // Eliminar del sistema antiguo
+                let data = null;
                 try {
-                    GM_setValue(key, null);
                     if (typeof localStorage !== 'undefined') {
-                        localStorage.removeItem(key); // Usar la clave completa, no modificarla
+                        const lsData = localStorage.getItem(rawKey);
+                        if (lsData) data = JSON.parse(lsData);
+                    }
+                    if (!data && typeof GM_getValue === 'function') {
+                        data = await GM_getValue(rawKey, null);
                     }
                 } catch (e) {
-                    warn('migrateToFreeTubeFormat', `Error al eliminar clave antigua ${key}:`, e);
+                    warn('migrateToFreeTubeFormat', `Error al leer clave legacy ${rawKey}:`, e);
                 }
 
-                migrated++;
-                log('migrateToFreeTubeFormat', `✅ Video ${migratedVideo.videoId} migrado desde sistema antiguo`);
+                if (!data) continue;
 
-                // Actualizar progreso cada 50 videos migrados
-                if (migrated % 50 === 0) {
-                    showFloatingToast({
-                        message: t('migratingDataProgress', `Migrando datos... ${migrated} videos procesados`),
-                        type: 'info',
-                        duration: 2000,
-                        persistent: true
-                    });
+                await Storage.set(cleanKey, data);
+                legacyRescued++;
+
+                // Limpiar la clave legacy del sistema antiguo
+                try {
+                    if (typeof GM_setValue === 'function') GM_setValue(rawKey, null);
+                    if (typeof localStorage !== 'undefined') localStorage.removeItem(rawKey);
+                } catch (e) {
+                    warn('migrateToFreeTubeFormat', `Error al eliminar clave legacy ${rawKey}:`, e);
                 }
             }
+
+            if (legacyRescued > 0) {
+                log('migrateToFreeTubeFormat', `✅ Rescatadas ${legacyRescued} claves legacy remanentes`);
+            }
+        } catch (e) {
+            warn('migrateToFreeTubeFormat', 'Error en fase 1 (rescate legacy):', e);
         }
+
+        // ──────────────────────────────────────────────────────────────────────────
+        // FASE 2: Normalizar esquema de todas las entradas ya en IndexedDB/Storage
+        // ──────────────────────────────────────────────────────────────────────────
 
         /**
          * Valida de forma conservadora un título de playlist.
@@ -14251,61 +14370,28 @@ background: var(--ypp-danger);
             return true;
         };
 
-        // Migrar metadata legacy de playlists (si existe) y limpiar claves antiguas
-        const legacyPlaylistMetaKeys = oldSystemKeys.filter((k) => k.startsWith('YT_PLAYBACK_PLOX_playlist_meta_'));
-        for (const legacyKey of legacyPlaylistMetaKeys) {
-            let legacyMeta = null;
-            try {
-                if (typeof localStorage !== 'undefined') {
-                    const lsData = localStorage.getItem(legacyKey);
-                    if (lsData) legacyMeta = JSON.parse(lsData);
-                }
+        // Obtener todas las claves del sistema actual (ya en IndexedDB)
+        const allKeys = (await Storage.keys()).filter(k =>
+            !k.startsWith('userSettings') &&
+            k !== 'translations_cache_v1'
+        );
 
-                if (!legacyMeta && typeof GM_getValue === 'function') {
-                    legacyMeta = GM_getValue(legacyKey, null);
-                }
-            } catch (e) {
-                warn('migrateToFreeTubeFormat', `Error al leer playlist_meta legacy ${legacyKey}:`, e);
-            }
+        log('migrateToFreeTubeFormat', `📦 Procesando ${allKeys.length} claves en Storage`);
 
-            const playlistId = legacyMeta?.playlistId || legacyKey.replace('YT_PLAYBACK_PLOX_playlist_meta_', '');
-            if (!playlistId) continue;
-
-            try {
-                const playlistMetaKey = `playlist_meta_${playlistId}`;
-                const existing = await Storage.get(playlistMetaKey);
-
-                const merged = {
-                    playlistId,
-                    title: (isValidPlaylistTitle(existing?.title) ? existing.title : (isValidPlaylistTitle(legacyMeta?.title) ? legacyMeta.title : (existing?.title || legacyMeta?.title || ''))),
-                    lastWatchedVideoId: existing?.lastWatchedVideoId || legacyMeta?.lastWatchedVideoId || null,
-                    lastUpdated: Math.max(
-                        Number(existing?.lastUpdated || 0),
-                        Number(legacyMeta?.lastUpdated || 0),
-                        Date.now()
-                    )
-                };
-
-                await Storage.set(playlistMetaKey, merged);
-
-                // Eliminar del sistema antiguo
-                try {
-                    GM_setValue(legacyKey, null);
-                    if (typeof localStorage !== 'undefined') {
-                        localStorage.removeItem(legacyKey);
-                    }
-                } catch (e) {
-                    warn('migrateToFreeTubeFormat', `Error al eliminar playlist_meta legacy ${legacyKey}:`, e);
-                }
-            } catch (e) {
-                warn('migrateToFreeTubeFormat', `Error al migrar playlist_meta legacy ${legacyKey}:`, e);
+        // Separar claves por tipo para procesarlas en orden
+        const playlistMetaKeys = [];
+        const dataKeys = [];
+        for (const key of allKeys) {
+            if (key.startsWith('playlist_meta_')) {
+                playlistMetaKeys.push(key);
+            } else {
+                dataKeys.push(key);
             }
         }
 
-        // SEGUNDO: Procesar datos que ya estén en el nuevo sistema (por si acaso)
-        const newSystemKeys = (await Storage.keys()).filter(k => !k.startsWith('userSettings') && !k.startsWith('playlist_meta_') && k !== 'translations_cache_v1');
-
-        for (const key of newSystemKeys) {
+        // Procesar datos de video
+        let batchCount = 0;
+        for (const key of dataKeys) {
             const data = await Storage.get(key);
             if (!data) continue;
 
@@ -14328,13 +14414,12 @@ background: var(--ypp-danger);
                 // Migrar cada video de la playlist
                 let inner = 0;
                 for (const [videoId, videoData] of Object.entries(data.videos)) {
-                    // Crear entrada de video en formato FreeTube
                     const migratedVideo = {
                         videoId: videoId,
                         timestamp: videoData.timestamp,
-                        lastUpdated: videoData.lastUpdated || videoData.savedAt,
-                        videoType: videoData.videoType,
-                        isCompleted: videoData.isCompleted,
+                        lastUpdated: videoData.lastUpdated || videoData.savedAt || Date.now(),
+                        videoType: normalizeVideoType(videoData.videoType),
+                        isCompleted: videoData.isCompleted || false,
                         duration: videoData.duration,
                         title: videoData.title,
                         author: videoData.author,
@@ -14348,13 +14433,11 @@ background: var(--ypp-danger);
                         lastViewedPlaylistId: playlistId,
                         lastViewedPlaylistType: 'channel',
                         lastViewedPlaylistItemId: null,
-                        // Preservar campos opcionales si existen
                         forceResumeTime: videoData.forceResumeTime
                     };
 
                     await Storage.set(videoId, migratedVideo);
                     migrated++;
-                    log('migrateToFreeTubeFormat', `✅ Video ${videoId} migrado`);
                     if ((++inner % 50) === 0) { await new Promise(r => setTimeout(r, 0)); }
                 }
 
@@ -14362,41 +14445,72 @@ background: var(--ypp-danger);
                 await Storage.del(key);
                 log('migrateToFreeTubeFormat', `✅ Playlist ${playlistId} migrada completamente`);
             } else if (data.videoId || data.timestamp !== undefined) {
-                // Ya está en formato correcto (o cercano), verificar que tenga campos FreeTube
-                if (!data.lastViewedPlaylistId && !data.lastViewedPlaylistType) {
-                    // Agregar campos FreeTube faltantes
+                // Video individual: normalizar videoType y asegurar campos FreeTube
+                const currentType = normalizeVideoType(data.videoType);
+                const needsTypeNormalization = currentType !== data.videoType;
+                const needsFreeTubeFields = !data.lastViewedPlaylistId && !data.lastViewedPlaylistType && data.lastViewedPlaylistId !== null;
+
+                if (needsTypeNormalization || needsFreeTubeFields) {
                     const updated = {
                         ...data,
                         videoId: data.videoId || key,
-                        lastViewedPlaylistId: null,
-                        lastViewedPlaylistType: '',
-                        lastViewedPlaylistItemId: null
+                        videoType: currentType,
+                        lastViewedPlaylistId: data.lastViewedPlaylistId ?? null,
+                        lastViewedPlaylistType: data.lastViewedPlaylistType ?? '',
+                        lastViewedPlaylistItemId: data.lastViewedPlaylistItemId ?? null
                     };
                     await Storage.set(key, updated);
                     migrated++;
+                    log('migrateToFreeTubeFormat', `🔧 Video ${key} normalizado: videoType ${data.videoType || '(none)'} → ${currentType}`);
+                } else {
+                    skipped++;
                 }
-                skipped++;
+            }
+
+            // Progreso cada 50 entradas
+            if ((++batchCount % 50) === 0) {
+                showFloatingToast(
+                    t('migratingDataProgress', { count: batchCount }),
+                    2000,
+                    { persistent: true }
+                );
+                await new Promise(r => setTimeout(r, 0));
+            }
+        }
+
+        // Validar playlist_meta existentes (normalizar títulos inválidos)
+        for (const metaKey of playlistMetaKeys) {
+            try {
+                const meta = await Storage.get(metaKey);
+                if (!meta) continue;
+
+                // Verificar si el título necesita validación
+                if (meta.title && !isValidPlaylistTitle(meta.title)) {
+                    const updated = { ...meta, title: '' };
+                    await Storage.set(metaKey, updated);
+                    log('migrateToFreeTubeFormat', `🔧 Playlist meta ${metaKey}: título inválido limpiado`);
+                }
+            } catch (e) {
+                warn('migrateToFreeTubeFormat', `Error al validar playlist_meta ${metaKey}:`, e);
             }
         }
 
         // Marcar la migración como completada para esta versión
         await GM_setValue(MIGRATION_KEY, MIGRATION_VERSION);
 
-        log('migrateToFreeTubeFormat', `✅ Migración completada: ${migrated} videos migrados, ${skipped} ya estaban en formato correcto`);
+        log('migrateToFreeTubeFormat', `✅ Migración v${MIGRATION_VERSION} completada: ${migrated} migrados, ${skipped} ya correctos, ${legacyRescued} rescatados de legacy`);
 
         // Mostrar mensaje final al usuario
         if (migrated > 0) {
-            showFloatingToast({
-                message: t('migrationComplete', `✅ Migración completada: ${migrated} videos migrados correctamente`),
-                type: 'success',
-                duration: 5000
-            });
+            showFloatingToast(
+                t('migrationComplete', { migrated: migrated }),
+                5000
+            );
         } else {
-            showFloatingToast({
-                message: t('migrationNoData', '✅ No se encontraron datos para migrar'),
-                type: 'info',
-                duration: 3000
-            });
+            showFloatingToast(
+                t('migrationNoData'),
+                3000
+            );
         }
 
         return { migrated, skipped };

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -218,7 +218,7 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
     // URL del archivo de traducciones
     const TRANSLATIONS_URL = 'https://raw.githubusercontent.com/Alplox/Youtube-Playback-Plox/refs/heads/main/translations.json';
     const TRANSLATIONS_URL_BACKUP = 'https://cdn.jsdelivr.net/gh/Alplox/Youtube-Playback-Plox@refs/heads/main/translations.json';
-    const TRANSLATIONS_EXPECTED_VERSION = '0.0.7-2';
+    const TRANSLATIONS_EXPECTED_VERSION = '0.0.7-3';
 
     // Variables globales para las traducciones
     let TRANSLATIONS = {};

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -2312,7 +2312,7 @@ background: var(--ypp-danger);
                         let allKeys = [];
                         try {
                             if (typeof GM_listValues !== 'undefined') {
-                                allKeys = GM_listValues();
+                                allKeys = await GM_listValues();
                             } else if (typeof localStorage !== 'undefined') {
                                 allKeys = Object.keys(localStorage);
                             }
@@ -2325,7 +2325,7 @@ background: var(--ypp-danger);
                             let value = null;
                             try {
                                 if (typeof GM_getValue !== 'undefined') {
-                                    value = GM_getValue(key);
+                                    value = await GM_getValue(key);
                                 } else if (typeof localStorage !== 'undefined') {
                                     const item = localStorage.getItem(key);
                                     if (item) value = JSON.parse(item);
@@ -2509,19 +2509,38 @@ background: var(--ypp-danger);
             return dbPromise;
         }
 
+        /**
+         * Ejecuta una operación en el object store de IndexedDB.
+         * Captura el resultado del IDBRequest vía onsuccess (no tx.oncomplete)
+         * para compatibilidad con Chrome/Edge (Blink limpia IDBRequest.result
+         * después de oncomplete, a diferencia de Firefox/Gecko).
+         * @param {'readonly'|'readwrite'} mode - Modo de la transacción
+         * @param {(store: IDBObjectStore) => IDBRequest} executor - Función que ejecuta la operación
+         * @returns {Promise<any>} Resultado de la operación
+         */
         function runInStore(mode, executor) {
-            return openDatabase().then((db) => new Promise((resolve, reject) => {
-                try {
-                    const tx = db.transaction(STORE_NAME, mode);
-                    const store = tx.objectStore(STORE_NAME);
-                    const result = executor(store);
-                    tx.oncomplete = () => resolve(result?.result ?? undefined);
-                    tx.onerror = () => reject(tx.error);
-                    tx.onabort = () => reject(tx.error);
-                } catch (error) {
-                    reject(error);
-                }
-            }));
+            return openDatabase().then((db) => {
+                return new Promise((resolve, reject) => {
+                    try {
+                        const tx = db.transaction(STORE_NAME, mode);
+                        const store = tx.objectStore(STORE_NAME);
+                        const request = executor(store);
+                        // Capturar resultado en onsuccess del IDBRequest,
+                        // donde .result está garantizado en todos los navegadores
+                        let capturedResult;
+                        if (request && typeof request.addEventListener === 'function') {
+                            request.onsuccess = () => {
+                                capturedResult = request.result;
+                            };
+                        }
+                        tx.oncomplete = () => resolve(capturedResult);
+                        tx.onerror = () => reject(tx.error);
+                        tx.onabort = () => reject(tx.error);
+                    } catch (error) {
+                        reject(error);
+                    }
+                });
+            });
         }
 
         function enqueue(operation) {
@@ -3523,7 +3542,7 @@ background: var(--ypp-danger);
      * Sistema de virtualización para listas grandes.
      * Solo renderiza los items visibles en el viewport más un buffer,
      * reduciendo dramáticamente el número de nodos DOM.
-     * 
+     *
      * @example
      * const scroller = new VirtualScroller({
      *     container: listContainer,
@@ -10779,7 +10798,7 @@ background: var(--ypp-danger);
                 log('processVideo', `🔄 Usando lastPlaylistId como fallback (no miniplayer): ${lastPlaylistId}`);
                 candidate = lastPlaylistId;
             }
- 
+
             if (!candidate && isHomeish && lastVideoUrl) {
                 try {
                     const u3 = new URL(lastVideoUrl, location.origin);
@@ -12177,6 +12196,8 @@ background: var(--ypp-danger);
     let virtualScroller = null;
     /** @type {Array|null} Cache de items preparados para evitar re-procesar en cada render */
     let preparedItemsCache = null;
+    /** @type {Map<string, string>} Cache global de títulos por ID para uso en createVideoEntry */
+    let modalVideoTitleById = new Map();
 
     async function fixThumbnailsInStorage() {
         const keys = (await Storage.keys?.() || []).filter(k => !k.startsWith('userSettings') && !k.startsWith('userFilters') && !k.startsWith('playlist_meta_'));
@@ -12247,6 +12268,12 @@ background: var(--ypp-danger);
     async function updateVideoList() {
         if (!listContainer) return;
 
+        // Destruir scroller anterior si existe
+        if (virtualScroller) {
+            virtualScroller.destroy();
+            virtualScroller = null;
+        }
+
         // Mostrar indicador de carga
         setInnerHTML(listContainer, '');
         const loadingIndicator = createElement('div', {
@@ -12254,12 +12281,6 @@ background: var(--ypp-danger);
             text: `⏳ ${t('loading')}...`
         });
         listContainer.appendChild(loadingIndicator);
-
-        // Destruir scroller anterior si existe
-        if (virtualScroller) {
-            virtualScroller.destroy();
-            virtualScroller = null;
-        }
 
         const keys = (await Storage.keys()).filter(k =>
             !k.startsWith('userSettings') &&
@@ -14210,6 +14231,74 @@ background: var(--ypp-danger);
                         persistent: true
                     });
                 }
+            }
+        }
+
+        /**
+         * Valida de forma conservadora un título de playlist.
+         * No debe usar validateTitle() porque esa función compara contra document.title (video actual).
+         * @param {unknown} candidateTitle
+         * @returns {boolean}
+         */
+        const isValidPlaylistTitle = (candidateTitle) => {
+            if (typeof candidateTitle !== 'string') return false;
+            const title = candidateTitle.trim();
+            if (!title) return false;
+            if (title.length < 2 || title.length > 200) return false;
+            if (typeof isPlaceholder === 'function' && isPlaceholder(title)) return false;
+            const normalized = title.toLowerCase();
+            if (['youtube', 'loading...', 'untitled', 'null', 'undefined'].includes(normalized)) return false;
+            return true;
+        };
+
+        // Migrar metadata legacy de playlists (si existe) y limpiar claves antiguas
+        const legacyPlaylistMetaKeys = oldSystemKeys.filter((k) => k.startsWith('YT_PLAYBACK_PLOX_playlist_meta_'));
+        for (const legacyKey of legacyPlaylistMetaKeys) {
+            let legacyMeta = null;
+            try {
+                if (typeof localStorage !== 'undefined') {
+                    const lsData = localStorage.getItem(legacyKey);
+                    if (lsData) legacyMeta = JSON.parse(lsData);
+                }
+
+                if (!legacyMeta && typeof GM_getValue === 'function') {
+                    legacyMeta = GM_getValue(legacyKey, null);
+                }
+            } catch (e) {
+                warn('migrateToFreeTubeFormat', `Error al leer playlist_meta legacy ${legacyKey}:`, e);
+            }
+
+            const playlistId = legacyMeta?.playlistId || legacyKey.replace('YT_PLAYBACK_PLOX_playlist_meta_', '');
+            if (!playlistId) continue;
+
+            try {
+                const playlistMetaKey = `playlist_meta_${playlistId}`;
+                const existing = await Storage.get(playlistMetaKey);
+
+                const merged = {
+                    playlistId,
+                    title: (isValidPlaylistTitle(existing?.title) ? existing.title : (isValidPlaylistTitle(legacyMeta?.title) ? legacyMeta.title : (existing?.title || legacyMeta?.title || ''))),
+                    lastWatchedVideoId: existing?.lastWatchedVideoId || legacyMeta?.lastWatchedVideoId || null,
+                    lastUpdated: Math.max(
+                        Number(existing?.lastUpdated || 0),
+                        Number(legacyMeta?.lastUpdated || 0),
+                        Date.now()
+                    )
+                };
+
+                await Storage.set(playlistMetaKey, merged);
+
+                // Eliminar del sistema antiguo
+                try {
+                    GM_setValue(legacyKey, null);
+                    if (typeof localStorage !== 'undefined') {
+                        localStorage.removeItem(legacyKey);
+                    }
+                } catch (e) {
+                    warn('migrateToFreeTubeFormat', `Error al eliminar playlist_meta legacy ${legacyKey}:`, e);
+                }
+            } catch (e) {
+                warn('migrateToFreeTubeFormat', `Error al migrar playlist_meta legacy ${legacyKey}:`, e);
             }
         }
 

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -139,7 +139,7 @@
 
     // Sistema de niveles: silent(0), error(1), warn(2), info(3), debug(4)
     const LEVELS = { silent: 0, error: 1, warn: 2, info: 3, debug: 4 };
-    let currentLevel = LEVELS.warn; // Cambiar a 'debug' para ver todo, o 'warn'/'error' para menos
+    let currentLevel = LEVELS.silent; // Cambiar a 'debug' para ver todo, o 'warn'/'error' para menos
 
     const styleFor = (kind) => {
         switch (kind) {
@@ -1045,6 +1045,22 @@ html[dark], body.dark-theme {
     background: var(--ypp-success-dark);
   }
 }
+
+
+/* .ytp-time-current,
+.ytp-time-separator,
+.ytp-time-duration {
+  display: none !important;
+    visibility: hidden !important;
+} */
+
+.ytp-live .ytp-time-current,
+.ytp-live .ytp-time-separator,
+.ytp-live .ytp-time-duration {
+  display: none !important;
+  visibility: visible !important;
+}
+
 
 /* Estilo específico para mensajes en Shorts - integrado en el player */
 .ypp-shorts-time-display {
@@ -2200,10 +2216,117 @@ background: var(--ypp-danger);
             .ytp-scrubber-button {
                 background: var(--ytp-progress-color) !important;
             }
-
-            .ytp-live .ytp-time-contents {
+            /* Soporte para el rediseño Moderno (Delhi) */
+            .ytp-delhi-modern .ytp-time-wrapper:not(.ytp-miniplayer-ui *) {
+                min-width: 0;
+                position: relative;
                 display: flex !important;
+                height: var(--yt-delhi-pill-height, 48px);
+                border-radius: 28px;
+                padding: 0 16px;
+                -webkit-backdrop-filter: var(--yt-frosted-glass-backdrop-filter-override, blur(16px));
+                backdrop-filter: var(--yt-frosted-glass-backdrop-filter-override, blur(16px));
+                background: var(--yt-spec-overlay-background-medium-light, rgba(0,0,0,.3));
+                text-shadow: 0 0 2px #000;
                 align-items: center;
+                gap: 8px;
+                cursor: default;
+                /* No interceptar clicks que no son nuestros */
+                pointer-events: auto;
+            }
+
+            /* Corregir orden en el rediseño Delhi: el botón del script debe ir al final */
+            .ytp-delhi-modern .ytp-time-wrapper .ytp-time-current,
+            .ytp-delhi-modern .ytp-time-wrapper .ytp-time-separator,
+            .ytp-delhi-modern .ytp-time-wrapper .ytp-time-duration {
+                order: 1;
+                /* El tiempo debe estar visible para que YouTube calcule bien los offsets de click */
+                display: inline-block !important;
+            }
+
+            .ytp-delhi-modern .ytp-time-wrapper .ytp-live-badge,
+            .ytp-delhi-modern .ytp-time-wrapper .live-badge {
+                order: 2 !important;
+                margin-left: 4px;
+                /* Asegurar que el badge sea clickeable */
+                pointer-events: auto !important;
+                cursor: pointer !important;
+            }
+
+            /* puede descuadrar "punto rojo" de boton en vivo */
+            /*
+            .ytp-delhi-modern .ytp-time-wrapper .ytp-live-badge.ytp-live-badge-is-livehead,
+            .ytp-delhi-modern .ytp-time-wrapper .live-badge.ytp-live-badge-is-livehead {
+                display: flex !important;
+            } */
+
+            /* Livestream real (clase agregada por el script) */
+            .ypp-is-livestream .ytp-time-contents,
+            .ypp-is-livestream .ytp-time-current,
+            .ypp-is-livestream .ytp-time-separator,
+            .ypp-is-livestream .ytp-time-duration {
+                display: none !important;
+            }
+
+            .ypp-is-livestream .ytp-live-badge.ytp-live-badge-is-livehead {
+                display: inline-flex !important;
+                align-items: center !important;
+            }
+
+            .ypp-is-livestream .ytp-live-badge.ytp-live-badge-is-livehead::before {
+                position: relative !important;
+                top: 0 !important;
+                transform: none !important;
+            }
+
+            .ypp-is-livestream .ytp-live-badge.ytp-live-badge-is-livehead[disabled]::before {
+                display: inline-block !important;
+                vertical-align: middle !important;
+                top: -1px !important;
+            }
+
+            .ypp-is-livestream .ypp-time-display {
+                max-height: 24px !important;
+                line-height: normal !important;
+                padding: 2px 8px !important;
+                border-radius: 12px !important;
+                overflow: visible !important;
+                white-space: nowrap !important;
+            }
+
+            .ytp-delhi-modern .ytp-time-wrapper .ypp-time-display {
+                order: 3 !important;
+                margin-left: 4px !important;
+                white-space: nowrap;
+                pointer-events: auto;
+                align-self: center !important;
+                height: auto !important;
+                min-height: 0 !important;
+                max-height: 24px !important;
+                line-height: 20px !important;
+                padding: 2px 8px !important;
+                border-radius: 999px !important;
+                box-sizing: border-box !important;
+                display: inline-flex !important;
+                align-items: center !important;
+                overflow: hidden !important;
+            }
+
+            /* Estilos generales para el botón del script en la barra */
+            .ypp-time-display {
+                cursor: pointer;
+                font-weight: bold;
+                color: #fff;
+                padding: 2px 6px;
+                border-radius: 4px;
+                background: rgba(255, 255, 255, 0.1);
+                transition: background 0.2s;
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+            }
+            .ypp-time-display:hover {
+                background: rgba(255, 255, 255, 0.2);
             }
         `;
 
@@ -2316,7 +2439,7 @@ background: var(--ypp-danger);
         '_test_',
         'idb_migrated'
     ]);
-    const STORAGE_MIGRATION_STATE_KEY = `${CONFIG.storagePrefix}idb_migrated`;
+    const STORAGE_MIGRATION_STATE_KEY = `${CONFIG.storagePrefix} idb_migrated`;
     const storageCache = new Map();
 
     // Nueva capa asíncrona de almacenamiento (IndexedDB primario + caché en memoria + fallback)
@@ -2392,7 +2515,7 @@ background: var(--ypp-danger);
 
                         // Filtrar: solo claves del script, excluyendo metaclaves
                         const filteredKeys = (allKeys || []).filter(k => isScriptKey(k) && !STORAGE_META_KEYS.has(k));
-                        logger.info(`Migración: ${filteredKeys.length} claves del script encontradas (de ${allKeys.length} totales)`);
+                        logger.info(`Migración: ${filteredKeys.length} claves del script encontradas(de ${allKeys.length} totales)`);
 
                         for (const rawKey of filteredKeys) {
                             // Strip prefix para coherencia con nuevo Storage sin prefijos
@@ -2406,7 +2529,7 @@ background: var(--ypp-danger);
                                     if (item) value = JSON.parse(item);
                                 }
                             } catch (err) {
-                                logger.warn(`Error al leer clave ${rawKey}:`, err);
+                                logger.warn(`Error al leer clave ${rawKey}: `, err);
                             }
                             if (value !== null) {
                                 legacySnapshot.push({ key: normalizedKey, value: JSON.stringify(value) });
@@ -2457,7 +2580,7 @@ background: var(--ypp-danger);
                         return JSON.parse(raw);
                     }
                 } catch (err) {
-                    logger.warn(`Error al leer ${key} desde IndexedDB:`, err);
+                    logger.warn(`Error al leer ${key} desde IndexedDB: `, err);
                 }
             }
             return null;
@@ -2474,7 +2597,7 @@ background: var(--ypp-danger);
                 try {
                     await IndexedDBAdapter.put(key, serialized);
                 } catch (err) {
-                    logger.warn(`Error al escribir ${key} en IndexedDB, usando fallback:`, err);
+                    logger.warn(`Error al escribir ${key} en IndexedDB, usando fallback: `, err);
                     // Lanzar el error para que el manejador superior lo capture
                     throw err;
                 }
@@ -2491,7 +2614,7 @@ background: var(--ypp-danger);
                 try {
                     await IndexedDBAdapter.del(key);
                 } catch (err) {
-                    logger.warn(`Error al eliminar ${key} en IndexedDB:`, err);
+                    logger.warn(`Error al eliminar ${key} en IndexedDB: `, err);
                 }
             }
         }
@@ -2782,7 +2905,7 @@ background: var(--ypp-danger);
                     parsed = raw;
                 } else if (typeof raw === 'string' && raw.trim()) {
                     parsed = JSON.parse(raw);
-                }  
+                }
 
                 return { ...CONFIG.defaultSettings, ...parsed };
             } catch (error) {
@@ -3228,15 +3351,15 @@ background: var(--ypp-danger);
 
                 // Logging detallado del estado detectado
                 const coexistenceInfo = PlayerStateManager.getCoexistenceInfo();
-                log('PlayerStateCache', `🔍 Estado actualizado: ${coexistenceInfo}`);
+                log('PlayerStateCache', `🔍 Estado actualizado: ${coexistenceInfo} `);
                 if (cachedState.hasMiniPlayer) {
-                    log('PlayerStateCache', `📱 Miniplayer detectado: ${cachedState.miniPlayerVideoId}`);
+                    log('PlayerStateCache', `📱 Miniplayer detectado: ${cachedState.miniPlayerVideoId} `);
                 }
                 if (cachedState.hasShortsPlayer) {
-                    log('PlayerStateCache', `📹 Shorts detectado: ${cachedState.activeShortsVideoId}`);
+                    log('PlayerStateCache', `📹 Shorts detectado: ${cachedState.activeShortsVideoId} `);
                 }
                 if (cachedState.hasWatchPlayer) {
-                    log('PlayerStateCache', `📺 Watch detectado: ${cachedState.activeWatchVideoId}`);
+                    log('PlayerStateCache', `📺 Watch detectado: ${cachedState.activeWatchVideoId} `);
                 }
             }
             return cachedState;
@@ -3329,8 +3452,8 @@ background: var(--ypp-danger);
         const secs = Math.floor(seconds % 60);
 
         return hours > 0
-            ? `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
-            : `${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+            ? `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')} `
+            : `${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')} `;
     };
 
     /**
@@ -4440,7 +4563,7 @@ background: var(--ypp-danger);
                     const internal = Object.assign({}, videoObj, { videoId: videoObj.videoId || vidKey });
                     const formatted = toFreeTubeFormat(internal);
                     freeTubeData.push(formatted);
-                    if (internal.videoType === 'short' || internal.videoType === 'preview_shorts') shortCount++;
+                    if (internal.videoType === 'shorts' || internal.videoType === 'preview_shorts') shortCount++;
                     else videoCount++;
                 });
             } else {
@@ -4448,7 +4571,7 @@ background: var(--ypp-danger);
                 const internal = Object.assign({}, data, { videoId: data.videoId || key });
                 const formatted = toFreeTubeFormat(internal);
                 freeTubeData.push(formatted);
-                if (internal.videoType === 'short' || internal.videoType === 'preview_shorts') {
+                if (internal.videoType === 'shorts' || internal.videoType === 'preview_shorts') {
                     shortCount++;
                     log('exportToFreeTubeFormat', `Short detectado: ${formatted.videoId} | videoType: ${internal.videoType}`);
                 } else {
@@ -4799,24 +4922,28 @@ background: var(--ypp-danger);
             }
         } catch (_) { }
 
-        // Prioridad 5: Si estamos en watch page, NUNCA debe ser preview
-        if (pageType === 'watch') {
-            log('detectContentType', `✅ Tipo detectado: VIDEO (watch page)`);
-            return 'video';
-        }
-
-        // Prioridad 6: Si es una preview (inline preview en home/search/channel)
-        // IMPORTANTE: Solo si estamos en un contexto real de preview inline
+        // Prioridad 5: Si es una preview (inline preview en home/search/channel)
+        // IMPORTANTE: Si currentType indica preview_*, debe ganar incluso si el DOM
+        // fue refloweado (sticky fallback) y el video ya no está dentro del contenedor
+        // de preview en este tick.
         if (typeof currentType === 'string' && currentType.startsWith('preview_')) {
             try {
                 const isActualPreview = videoElement?.closest?.('#inline-preview-player, .ytp-inline-preview-ui, ytd-thumbnail-overlay-inline-playback-renderer');
                 if (isActualPreview) {
                     log('detectContentType', `✅ Tipo detectado: PREVIEW (${currentType})`);
-                    return 'preview';
                 } else {
-                    log('detectContentType', `⚠️ currentType sugiere preview pero no hay contexto DOM de preview. Tratando como video regular.`);
+                    log('detectContentType', `ℹ️ currentType indica preview (${currentType}) pero no hay contexto DOM de preview (posible reflow sticky). Forzando PREVIEW.`);
                 }
-            } catch (_) { }
+            } catch (_) {
+                log('detectContentType', `ℹ️ currentType indica preview (${currentType}) y hubo error de inspección DOM. Forzando PREVIEW.`);
+            }
+            return 'preview';
+        }
+
+        // Prioridad 6: Si estamos en watch page, NUNCA debe ser preview
+        if (pageType === 'watch') {
+            log('detectContentType', `✅ Tipo detectado: VIDEO (watch page)`);
+            return 'video';
         }
 
         // Default: Es un video regular
@@ -4961,13 +5088,19 @@ background: var(--ypp-danger);
         const now = Date.now();
         const isFinished = duration > 0 && (currentTime / duration) * 100 >= (cachedSettings?.staticFinishPercent || CONFIG.defaultSettings.staticFinishPercent);
 
+        const resolvedVideoType = (() => {
+            const previousType = sourceData?.videoType;
+            if (previousType === 'video' || previousType === 'shorts' || previousType === 'live') return previousType;
+            return previewType;
+        })();
+
         // Preservar datos previos para previews
         const videoData = {
             ...(sourceData || {}),
             videoId,
             timestamp: currentTime,
             lastUpdated: now,
-            videoType: previewType,
+            videoType: resolvedVideoType,
             isCompleted: isFinished,
             duration: isFinite(duration) ? duration : (sourceData?.duration || 0),
             ...videoInfo,
@@ -5043,13 +5176,22 @@ background: var(--ypp-danger);
     function saveVideoDataByType(videoId, currentTime, duration, videoInfo, pageType, containerType, videoElement, isLiveType, currentType, playlistId = null) {
         log('saveVideoDataByType', `🎯 Iniciando guardado para video ${videoId} via VideoTypeHandler`);
 
+        // En páginas dedicadas, nunca debemos tratar el contenido como preview aunque
+        // currentType haya quedado "pegado" desde el homepage (sticky/reflow).
+        // Esto asegura reclasificación inmediata: preview_* -> video/shorts al navegar.
+        const normalizedCurrentType = (() => {
+            if (pageType === 'watch' && typeof currentType === 'string' && currentType.startsWith('preview_')) return 'watch';
+            if (pageType === 'shorts' && typeof currentType === 'string' && currentType.startsWith('preview_')) return 'shorts';
+            return currentType;
+        })();
+
         // Detectar el tipo de contenido
-        const contentType = detectContentType(pageType, containerType, videoElement, isLiveType, currentType);
+        const contentType = detectContentType(pageType, containerType, videoElement, isLiveType, normalizedCurrentType);
         log('saveVideoDataByType', `📊 Tipo detectado: ${contentType}`);
 
         // Determinar subtipo para previews
-        const previewSubtype = (typeof currentType === 'string' && currentType.startsWith('preview_'))
-            ? currentType
+        const previewSubtype = (typeof normalizedCurrentType === 'string' && normalizedCurrentType.startsWith('preview_'))
+            ? normalizedCurrentType
             : 'preview_watch';
 
         // Delegar todo al VideoTypeHandler
@@ -9401,8 +9543,36 @@ background: var(--ypp-danger);
 
     // Inicializa la visualización de tiempo en la barra de reproducción
     function initTimeDisplay() {
-        const timeContainer = document.querySelector('.ytp-time-contents');
-        log('initTimeDisplay', 'timeContainer encontrado:', timeContainer);
+        // Intentar encontrar el contenedor de contenidos de tiempo
+        let timeContainer = document.querySelector('.ytp-time-contents');
+
+        // Soporte para el rediseño "Delhi" (2024+): el contenedor es un pill wrapper (.ytp-time-wrapper)
+        // Usamos el wrapper como contenedor directo para que el botón del script sea un hermano
+        // de los elementos internos (tiempo, badge de vivo) y así poder usar flexbox order.
+        const delhiWrapper = document.querySelector('.ytp-delhi-modern .ytp-time-wrapper');
+        if (delhiWrapper) {
+            // En el rediseño Delhi, preferimos inyectar directamente en el wrapper si es posible
+            timeContainer = delhiWrapper;
+        }
+
+        try {
+            const wrapper = delhiWrapper || timeContainer?.closest?.('.ytp-time-wrapper') || timeContainer?.parentElement || document.querySelector('.ytp-time-wrapper');
+            const isLiveHead = !!wrapper?.querySelector?.('.ytp-live-badge-is-livehead');
+            if (wrapper?.classList) wrapper.classList.toggle('ypp-is-livestream', isLiveHead);
+
+            // Limpieza defensiva: si no es livehead, asegurarnos de no dejar clases residuales en wrappers antiguos
+            if (!isLiveHead) {
+                for (const el of document.querySelectorAll('.ytp-time-wrapper.ypp-is-livestream')) {
+                    try {
+                        if (!el.querySelector?.('.ytp-live-badge-is-livehead')) el.classList.remove('ypp-is-livestream');
+                    } catch (_) {
+                    }
+                }
+            }
+        } catch (_) {
+        }
+
+        log('initTimeDisplay', 'timeContainer seleccionado:', timeContainer);
 
         // Verificar si timeDisplay existe pero fue removido del DOM (ej: después de un anuncio)
         if (timeDisplay && !document.contains(timeDisplay)) {
@@ -9411,15 +9581,23 @@ background: var(--ypp-danger);
         }
 
         if (!timeContainer || timeDisplay) return;
+
         timeDisplay = createElement('span', {
+            id: 'ypp-time-display-indicator',
             className: 'ypp-time-display ypp-d-none',
             onClickEvent: showSavedVideosList,
             atribute: { title: `${t('savedVideos')}` }
         });
-        timeContainer.appendChild(timeDisplay);
+
+        // En Delhi UI, asegurarnos de que quede al final (después de badge de vivo)
+        if (delhiWrapper) {
+            delhiWrapper.insertAdjacentElement('beforeend', timeDisplay);
+        } else {
+            timeContainer.appendChild(timeDisplay);
+        }
+
         log('initTimeDisplay', 'Creada visualización de tiempo en la barra de reproducción');
     }
-
     /**
      * Determina si un elemento está visible en el layout (no display:none/visibility:hidden, con tamaño > 0)
      * @param {HTMLElement} el
@@ -14776,7 +14954,7 @@ background: var(--ypp-danger);
                 // Actualizar siempre cachedSettings.language con el idioma detectado/seleccionado
                 cachedSettings = cachedSettings || { ...CONFIG.defaultSettings };
                 cachedSettings.language = langToUse;
-                
+
                 // Guardar preferencia si era primera carga o si el idioma cambió
                 if (!hadLanguageInStorage || (loadedSettings?.language !== langToUse)) {
                     await Settings.set(cachedSettings);

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -2772,11 +2772,51 @@ background: var(--ypp-danger);
         async get() {
             try {
                 const raw = await GM_getValue(CONFIG.userSettingsKey, null);
-                const parsed = raw ? JSON.parse(raw) : {};
+                // const parsed = raw ? JSON.parse(raw) : {};
+
+                /** @type {Record<string, any>} **/
+                let parsed = {};
+
+                if (raw && typeof raw === 'object') {
+                    // Algunos managers o migraciones pueden guardar/retornar un objeto directamente.
+                    parsed = raw;
+                } else if (typeof raw === 'string' && raw.trim()) {
+                    parsed = JSON.parse(raw);
+                }  
+
                 return { ...CONFIG.defaultSettings, ...parsed };
             } catch (error) {
                 conError('Settings', 'Error al cargar configuración del usuario:', error);
                 return { ...CONFIG.defaultSettings };
+            }
+        },
+
+        /**
+         * Obtiene la configuración del usuario e incluye metadatos sobre qué claves estaban presentes
+         * en el storage (antes de mezclar defaults).
+         * usar idioma del navegador solo si el usuario nunca eligió idioma.
+         * @returns {Promise<{settings: Object, hadLanguageInStorage: boolean}>}
+         */
+        async getWithMeta() {
+            try {
+                const raw = await GM_getValue(CONFIG.userSettingsKey, null);
+
+                /** @type {Record<string, any>} */
+                let parsed = {};
+
+                if (raw && typeof raw === 'object') {
+                    parsed = raw;
+                } else if (typeof raw === 'string' && raw.trim()) {
+                    parsed = JSON.parse(raw);
+                }
+
+                return {
+                    settings: { ...CONFIG.defaultSettings, ...parsed },
+                    hadLanguageInStorage: Object.prototype.hasOwnProperty.call(parsed || {}, 'language')
+                };
+            } catch (error) {
+                conError('Settings', 'Error al cargar configuración del usuario (meta):', error);
+                return { settings: { ...CONFIG.defaultSettings }, hadLanguageInStorage: false };
             }
         },
 
@@ -10084,8 +10124,7 @@ background: var(--ypp-danger);
         saveShortsCheckbox.checked = settings.saveShorts;
         saveLiveStreamsCheckbox.checked = settings.saveLiveStreams;
         saveMiniplayerVideosCheckbox.checked = settings.saveMiniplayerVideos !== false;
-        const inlineEl = document.getElementById('saveInlinePreviews');
-        if (inlineEl) inlineEl.checked = settings.saveInlinePreviews === true;
+        saveInlinePreviewsCheckbox.checked = settings.saveInlinePreviews === true;
 
         // Añadir al DOM
         document.body.appendChild(overlay);
@@ -14679,16 +14718,19 @@ background: var(--ypp-danger);
 
             // --- Cargar traducciones ---
             try {
-                const [externalTranslations, loadedSettings] = await Promise.all([
+                const [externalTranslations, loadedSettingsMeta] = await Promise.all([
                     loadTranslations().catch((err) => {
                         conError('initializeGlobal', '❌ Error al cargar traducciones:', err);
                         return null;
                     }),
-                    Settings.get().catch((err) => {
+                    Settings.getWithMeta().catch((err) => {
                         conError('initializeGlobal', '❌ Error al cargar settings:', err);
-                        return { ...CONFIG.defaultSettings };
+                        return { settings: { ...CONFIG.defaultSettings }, hadLanguageInStorage: false };
                     })
                 ]);
+
+                const loadedSettings = loadedSettingsMeta?.settings || { ...CONFIG.defaultSettings };
+                hadLanguageInStorage = !!loadedSettingsMeta?.hadLanguageInStorage;
 
                 if (externalTranslations && Object.keys(externalTranslations).length > 0) {
                     info('initializeGlobal', ' Traducciones externas cargadas correctamente');
@@ -14701,7 +14743,6 @@ background: var(--ypp-danger);
                     LANGUAGE_FLAGS = FALLBACK_FLAGS;
                     TRANSLATIONS = FALLBACK_TRANSLATIONS;
                 }
-                hadLanguageInStorage = Object.prototype.hasOwnProperty.call(loadedSettings || {}, 'language');
                 cachedSettings = { ...CONFIG.defaultSettings, ...(loadedSettings || {}) };
                 info('initializeGlobal', 'Settings cargados:', cachedSettings);
             } catch (error) {

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -118,6 +118,8 @@
 // @icon         https://raw.githubusercontent.com/Alplox/StartpagePlox/refs/heads/main/assets/favicon/favicon.ico
 // @grant        GM_getValue
 // @grant        GM_setValue
+// @grant        GM_deleteValue
+// @grant        GM_listValues
 // @grant        GM_registerMenuCommand
 // @grant        GM_xmlhttpRequest
 // @run-at       document-end
@@ -354,8 +356,8 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "rendered": "rendered",
             "previews": "Previews",
             "migratingData": "Migrating saved data from previous version...",
-            "migratingDataProgress": "Migrating data... {count} items processed",
-            "migrationComplete": "Migration complete: {migrated} videos migrated successfully",
+            "migratingDataProgress": "Migrating data... {count} entries processed",
+            "migrationComplete": "Migration completed: {migrated} videos successfully migrated",
             "migrationNoData": "No data found to migrate"
         },
         "es-ES": {
@@ -584,10 +586,10 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "loading": "Chargement",
             "rendered": "rendus",
             "previews": "Aperçus",
-            "migratingData": "Migration des données de la version précédente...",
+            "migratingData": "Migration des données enregistrées depuis la version précédente...",
             "migratingDataProgress": "Migration des données... {count} éléments traités",
             "migrationComplete": "Migration terminée : {migrated} vidéos migrées avec succès",
-            "migrationNoData": "Aucune donnée trouvée pour migrer"
+            "migrationNoData": "Aucune donnée trouvée à migrer"
         }
     };
 
@@ -2311,10 +2313,10 @@ background: var(--ypp-danger);
     // Metaclaves para control de migración y configuración
     const STORAGE_META_KEYS = new Set([
         'INDEX_v1',
-        '__test__',
-        '__idb_migrated__'
+        '_test_',
+        'idb_migrated'
     ]);
-    const STORAGE_MIGRATION_STATE_KEY = `${CONFIG.storagePrefix}__idb_migrated__`;
+    const STORAGE_MIGRATION_STATE_KEY = `${CONFIG.storagePrefix}idb_migrated`;
     const storageCache = new Map();
 
     // Nueva capa asíncrona de almacenamiento (IndexedDB primario + caché en memoria + fallback)
@@ -5108,7 +5110,7 @@ background: var(--ypp-danger);
     * //  - Crea nuevas claves con el formato correcto y migra los datos
     */
     async function normalizeYouTubeStorageKeys() {
-        const NORMALIZE_VERSION = 1; // Incrementar si cambia la lógica de normalización
+        const NORMALIZE_VERSION = 2; // Incrementar si cambia la lógica de normalización
         const NORMALIZE_KEY = 'ypp_normalize_storage_keys_version';
 
         // Evitar re-ejecución si ya se aplicó esta versión
@@ -12275,16 +12277,45 @@ background: var(--ypp-danger);
     let modalVideoTitleById = new Map();
 
     async function fixThumbnailsInStorage() {
-        const keys = (await Storage.keys?.() || []).filter(k => !k.startsWith('userSettings') && !k.startsWith('userFilters') && !k.startsWith('playlist_meta_'));
+        const keys = (await Storage.keys?.() || []).filter(k =>
+            !k.startsWith('userSettings') &&
+            !k.startsWith('userFilters') &&
+            !k.startsWith('playlist_meta_') &&
+            !k.startsWith('ypp_')
+        );
         for (const key of keys) {
             const data = await Storage.get(key);
             if (!data) continue;
+            if (typeof data !== 'object') {
+                if (key.startsWith('ypp_')) continue;
+                // Entrada corrupta/legacy inesperada (e.g. number/bool/string). Evitar crash al intentar asignar propiedades.
+                try {
+                    const preview = (() => {
+                        try {
+                            if (typeof data === 'string') return data.slice(0, 120);
+                            if (typeof data === 'number' || typeof data === 'boolean') return String(data);
+                            if (data === null) return 'null';
+                            return Object.prototype.toString.call(data);
+                        } catch (_) {
+                            return '[unprintable]';
+                        }
+                    })();
+                    warn('fixThumbnailsInStorage', `Entrada inválida en Storage (se eliminará). key="${key}", type=${typeof data}, preview=${preview}`);
+                } catch (_) { }
+                try {
+                    await Storage.del(key);
+                } catch (_) { }
+                continue;
+            }
             if (data.videos && typeof data.videos === 'object') {
                 let modified = false;
                 for (const [vid, info] of Object.entries(data.videos)) {
                     const vId = info?.videoId || vid;
                     if (!thumbnailHasVideoId(info?.thumb, vId)) {
-                        if (data.videos[vid]) data.videos[vid].thumb = `https://i.ytimg.com/vi/${vId}/maxresdefault.jpg`;
+                        if (data.videos[vid] && typeof data.videos[vid] === 'object') {
+                            data.videos[vid].thumb = `https://i.ytimg.com/vi/${vId}/maxresdefault.jpg`;
+                            modified = true;
+                        }
                         modified = true;
                     }
                 }
@@ -14255,8 +14286,29 @@ background: var(--ypp-danger);
      * @returns {Promise<{migrated: number, skipped: number}>}
      */
     async function migrateToFreeTubeFormat() {
-        const MIGRATION_VERSION = 5; // Incrementado: normalización de videoType y mejora de coherencia
+        const MIGRATION_VERSION = 2; // Incrementar solo si cambia la lógica/estructura de migración
         const MIGRATION_KEY = 'ypp_migration_freetube_format_version';
+
+        /**
+         * Elimina una clave GM de forma compatible entre managers.
+         * En Violentmonkey, GM_setValue(key, null) NO borra la clave; deja el valor null.
+         * @param {string} key
+         * @returns {Promise<void>}
+         */
+        const deleteGMValueSafe = async (key) => {
+            try {
+                if (typeof GM_deleteValue === 'function') {
+                    await GM_deleteValue(key);
+                    return;
+                }
+            } catch (_) { /* noop */ }
+
+            try {
+                if (typeof GM_setValue === 'function') {
+                    await GM_setValue(key, null);
+                }
+            } catch (_) { /* noop */ }
+        };
 
         // Verificar si la migración ya se realizó para esta versión
         const lastMigrationVersion = await GM_getValue(MIGRATION_KEY, 0);
@@ -14300,8 +14352,8 @@ background: var(--ypp-danger);
                 !k.includes('userSettings') &&
                 !k.includes('translations_cache') &&
                 !k.includes('migration_') &&
-                !k.includes('__idb_migrated__') &&
-                !k.includes('__test__')
+                !k.includes('idb_migrated') &&
+                !k.includes('_test_')
             );
 
             log('migrateToFreeTubeFormat', `📊 Claves legacy remanentes: ${relevantLegacyKeys.length}`);
@@ -14335,7 +14387,7 @@ background: var(--ypp-danger);
 
                 // Limpiar la clave legacy del sistema antiguo
                 try {
-                    if (typeof GM_setValue === 'function') GM_setValue(rawKey, null);
+                    await deleteGMValueSafe(rawKey);
                     if (typeof localStorage !== 'undefined') localStorage.removeItem(rawKey);
                 } catch (e) {
                     warn('migrateToFreeTubeFormat', `Error al eliminar clave legacy ${rawKey}:`, e);

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -345,6 +345,7 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "linkCopied": "Link copied to clipboard",
             "selectAtLeastOne": "Select at least one video",
             "tooManyVideos": "Too many videos selected (max 200)",
+            "miniplayerVideos": "Miniplayer videos",
             "inlinePreviews": "Inline previews (Home)",
             "removeFromPlaylist": "Remove from playlist",
             "confirmRemoveFromPlaylist": "Are you sure you want to remove this video from the playlist? It will be kept as an individual video.",
@@ -455,6 +456,7 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "linkCopied": "Enlace copiado al portapapeles",
             "selectAtLeastOne": "Selecciona al menos un video",
             "tooManyVideos": "Demasiados videos seleccionados (máx 200)",
+            "miniplayerVideos": "Videos en miniplayer",
             "inlinePreviews": "Previsualizaciones en inicio (Home)",
             "removeFromPlaylist": "Quitar de la playlist",
             "confirmRemoveFromPlaylist": "¿Estás seguro de que quieres quitar este video de la playlist? Se mantendrá como video individual.",
@@ -564,6 +566,7 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             "linkCopied": "Lien copié dans le presse-papiers",
             "selectAtLeastOne": "Sélectionnez au moins une vidéo",
             "tooManyVideos": "Trop de vidéos sélectionnées (max 200)",
+            "miniplayerVideos": "Vidéos en miniplayer",
             "inlinePreviews": "Aperçus intégrés (Accueil)",
             "removeFromPlaylist": "Retirer de la playlist",
             "confirmRemoveFromPlaylist": "Êtes-vous sûr de vouloir retirer cette vidéo de la playlist ? Elle sera conservée comme vidéo individuelle.",
@@ -704,6 +707,7 @@ const { log, info, warn, error: conError } = window.MyScriptLogger;
             enableProgressBarGradient: true, // Por defecto, habilitar degradado de colores en barra de progreso
             staticFinishPercent: 95, // Porcentaje desde el final para considerar video como completado (95% = 5% antes del final)
             saveInlinePreviews: false, // Guardar previsualizaciones inline (Homepage) desactivado por defecto
+            saveMiniplayerVideos: true, // Guardar videos en miniplayer (default: activo)
         },
 
         /** Clave para guardar filtros del usuario en GM_* */
@@ -4465,22 +4469,25 @@ background: var(--ypp-danger);
          */
         const isEnabled = (type, options = {}) => {
             try {
+                const settingsSnapshot = cachedSettings || CONFIG.defaultSettings;
+                const context = options.context || null;
                 switch (type) {
                     case ContentTypes.VIDEO:
-                        return cachedSettings?.saveRegularVideos !== false;
+                        if (context?.isMiniplayer && settingsSnapshot.saveMiniplayerVideos === false) return false;
+                        return settingsSnapshot.saveRegularVideos !== false;
                     case ContentTypes.SHORTS:
-                        return cachedSettings?.saveShorts !== false;
+                        return settingsSnapshot.saveShorts !== false;
                     case ContentTypes.LIVE:
-                        return cachedSettings?.saveLiveStreams !== false;
+                        return settingsSnapshot.saveLiveStreams !== false;
                     case ContentTypes.PREVIEW:
                         // Previews requieren configuración explícita
-                        if (cachedSettings?.saveInlinePreviews !== true) return false;
+                        if (settingsSnapshot.saveInlinePreviews !== true) return false;
                         // Validar subtipo
                         const subtype = options.previewSubtype || 'preview_watch';
                         if (subtype === 'preview_shorts') {
-                            return cachedSettings?.saveShorts !== false;
+                            return settingsSnapshot.saveShorts !== false;
                         }
-                        return cachedSettings?.saveRegularVideos !== false;
+                        return settingsSnapshot.saveRegularVideos !== false;
                     default:
                         return true;
                 }
@@ -4566,6 +4573,7 @@ background: var(--ypp-danger);
          */
         const save = (type, params) => {
             const { videoId, currentTime, duration, videoInfo, playlistId, previewSubtype, videoElement } = params;
+            const context = videoElement ? getContextInfo(videoElement) : null;
 
             // Validación de contexto para prevenir contaminación
             if (videoElement) {
@@ -4577,7 +4585,7 @@ background: var(--ypp-danger);
             }
 
             // Verificar si está habilitado
-            if (!isEnabled(type, { previewSubtype })) {
+            if (!isEnabled(type, { previewSubtype, context })) {
                 log('VideoTypeHandler', `🛑 Tipo ${type} deshabilitado por configuración`);
                 return { success: false, reason: `${type}_disabled_by_settings` };
             }
@@ -5197,6 +5205,8 @@ background: var(--ypp-danger);
     //   - Prioriza videos que estén reproduciéndose vs simplemente visibles
     //   - Respeta configuración del usuario (saveShorts, saveRegularVideos, etc)
     async function getActiveVideoElement() {
+        const settingsSnapshot = cachedSettings || CONFIG.defaultSettings;
+        const allowMiniplayerSaving = settingsSnapshot.saveMiniplayerVideos !== false && settingsSnapshot.saveRegularVideos !== false;
         // ======================================================================
         // OPCIÓN 1: YOUTUBE HELPER API (Más confiable y rápido)
         // ======================================================================
@@ -5225,7 +5235,7 @@ background: var(--ypp-danger);
                         const miniplayerEl = document.querySelector('#movie_player video.html5-main-video');
                         // Si miniplayer está reproduciendo Y saveShorts está deshabilitado,
                         // forzar búsqueda en DOM para que rejección temprana de updateStatus() lo capture
-                        if (miniplayerEl && !miniplayerEl.paused && cachedSettings?.saveShorts === false) {
+                        if (miniplayerEl && !miniplayerEl.paused && settingsSnapshot.saveShorts === false && allowMiniplayerSaving) {
                             log('getActiveVideoElement', '⏭ Miniplayer activo y saveShorts deshabilitado, buscando en DOM');
                             throw new Error('Force DOM search');
                         }
@@ -5487,17 +5497,20 @@ background: var(--ypp-danger);
         //   - Cualquiera: Fallback si nada de lo anterior
         const pickByPriority = (list) => {
             // Prioridad 1: Miniplayer (usuario lo destacó flotante)
-            const mp = list.find(v =>
-                v.closest('.ytp-miniplayer-ui') ||
-                v.closest('#miniplayer') ||
-                v.closest('ytd-miniplayer')
-            );
-            if (mp) return mp;
+            if (allowMiniplayerSaving) {
+                const mp = list.find(v =>
+                    v.closest('.ytp-miniplayer-ui') ||
+                    v.closest('#miniplayer') ||
+                    v.closest('ytd-miniplayer')
+                );
+                if (mp) return mp;
+            }
 
             // Prioridad 2: Main player (movie_player en página watch)
             const main = list.find(v =>
-                v.closest('#movie_player') ||
-                v.closest('.html5-video-player')
+                (!allowMiniplayerSaving && (v.closest('.ytp-miniplayer-ui') || v.closest('#miniplayer') || v.closest('ytd-miniplayer')))
+                    ? false
+                    : (v.closest('#movie_player') || v.closest('.html5-video-player'))
             );
             if (main) return main;
 
@@ -5509,8 +5522,11 @@ background: var(--ypp-danger);
             );
             if (shorts) return shorts;
 
-            // Fallback: El primero de la lista
-            return list[0];
+            // Fallback: El primero válido (respetando miniplayer deshabilitado)
+            const fallback = allowMiniplayerSaving
+                ? list[0]
+                : list.find(v => !(v.closest('.ytp-miniplayer-ui') || v.closest('#miniplayer') || v.closest('ytd-miniplayer')));
+            return fallback || null;
         };
 
         // ======================================================================
@@ -5524,13 +5540,13 @@ background: var(--ypp-danger);
         // luego vuelve a la página anterior. Queremos grabar el video principal, no el short.
         let preferMiniplayer = false;
         try {
-            preferMiniplayer = (getYouTubePageType() === 'shorts') && (cachedSettings?.saveShorts === false);
+            preferMiniplayer = allowMiniplayerSaving && (getYouTubePageType() === 'shorts') && (settingsSnapshot.saveShorts === false);
         } catch (_) { }
 
         // Opuesto: Si están HABILITADOS los Shorts, preferir Shorts sobre miniplayer
         let preferShorts = false;
         try {
-            preferShorts = (getYouTubePageType() === 'shorts') && (cachedSettings?.saveShorts !== false);
+            preferShorts = (getYouTubePageType() === 'shorts') && (settingsSnapshot.saveShorts !== false);
         } catch (_) { }
 
         // ======================================================================
@@ -5566,8 +5582,10 @@ background: var(--ypp-danger);
 
             // Default: usar la función de prioridad estándar
             const chosen = pickByPriority(playingVideos);
-            log('getActiveVideoElement', 'Seleccionado por reproducción activa');
-            return chosen;
+            if (chosen) {
+                log('getActiveVideoElement', 'Seleccionado por reproducción activa');
+                return chosen;
+            }
         }
 
         // Segunda opción: Si no hay reproducción activa, revisar por VISIBILIDAD
@@ -5601,7 +5619,7 @@ background: var(--ypp-danger);
         // (miniplayer > main > shorts > cualquiera)
         const chosen = pickByPriority(visibleVideos);
         log('getActiveVideoElement', `Seleccionado por prioridad de visibilidad`);
-        return chosen;
+        return chosen || null;
     }
 
     // ------------------------------------------
@@ -5633,11 +5651,14 @@ background: var(--ypp-danger);
         }
 
         try {
+            const settingsSnapshot = cachedSettings || CONFIG.defaultSettings;
+            const allowMiniplayerSaving = settingsSnapshot.saveMiniplayerVideos !== false && settingsSnapshot.saveRegularVideos !== false;
             // Detectar miniplayer
             const miniplayerContainer = videoElement.closest('.ytp-miniplayer-ui, #miniplayer, ytd-miniplayer');
             if (miniplayerContainer) {
                 result.type = 'miniplayer';
                 result.container = miniplayerContainer;
+                result.shouldProcess = allowMiniplayerSaving;
                 return result;
             }
 
@@ -5646,7 +5667,7 @@ background: var(--ypp-danger);
             if (shortsContainer) {
                 result.type = 'shorts';
                 result.container = shortsContainer;
-                result.shouldProcess = cachedSettings?.saveShorts !== false;
+                result.shouldProcess = settingsSnapshot.saveShorts !== false;
                 return result;
             }
 
@@ -5655,7 +5676,7 @@ background: var(--ypp-danger);
             if (pageType === 'shorts' && videoElement.src && videoElement.src.includes('blob:')) {
                 result.type = 'shorts';
                 result.container = videoElement.closest('div') || videoElement.parentElement;
-                result.shouldProcess = cachedSettings?.saveShorts !== false;
+                result.shouldProcess = settingsSnapshot.saveShorts !== false;
                 log('determineVideoContext', `🔍 Shorts detectado por URL y reproducción activa: ${videoElement.src.substring(0, 50)}...`);
                 return result;
             }
@@ -8139,6 +8160,7 @@ background: var(--ypp-danger);
         // Obtener el ID desde URL
         const homeVideoCheck = await getActiveVideoElement();
         let url;
+        let urlSource = 'location';
 
 
 
@@ -8173,6 +8195,7 @@ background: var(--ypp-danger);
                             const urlVideoId = extractOrNormalizeVideoId(fullUrl)?.id;
                             if (urlVideoId === expectedVideoId) {
                                 url = fullUrl;
+                                urlSource = 'miniplayer_anchor';
                                 log('updateStatus', `📌 URL verificada del miniplayer usada: ${url}`);
                                 break;
                             }
@@ -8184,6 +8207,7 @@ background: var(--ypp-danger);
                         const lastUrlVideoId = extractOrNormalizeVideoId(lastVideoUrl)?.id;
                         if (lastUrlVideoId === expectedVideoId) {
                             url = lastVideoUrl;
+                            urlSource = 'lastVideoUrl';
                             log('updateStatus', `📌 lastVideoUrl verificada usada: ${url}`);
                         } else {
                             // No usar URL que no pertenece al video actual
@@ -8204,16 +8228,60 @@ background: var(--ypp-danger);
 
         const urlDataNow = extractOrNormalizeVideoId(url);
         const urlIdNow = urlDataNow?.id || null;
+        const currentPlaylistVideoId = expectedVideoId || urlIdNow;
+
+        /**
+         * Verifica si un URL de playlist pertenece al video esperado.
+         * @param {string} href - URL del anchor o candidate
+         * @param {string|null} targetVideoId - Video ID esperado
+         * @returns {boolean} True si el URL apunta al video esperado
+         */
+        const isPlaylistUrlForVideo = (href, targetVideoId) => {
+            if (!href || !targetVideoId) return false;
+            try {
+                const parsed = new URL(href, location.origin);
+                const vParam = parsed.searchParams.get('v') || '';
+                const path = parsed.pathname || '';
+                return vParam === targetVideoId || path.includes(`/shorts/${targetVideoId}`);
+            } catch (_) {
+                return false;
+            }
+        };
+
+        /**
+         * Obtiene el playlistId del último click si corresponde al video actual.
+         * @param {string|null} targetVideoId - Video ID esperado
+         * @returns {string|null} Playlist ID si el click es válido
+         */
+        const getClickedPlaylistIdForVideo = (targetVideoId) => {
+            if (!targetVideoId || lastClickedVideoId !== targetVideoId || !lastClickedVideoLink) return null;
+            try {
+                const clickedUrl = new URL(lastClickedVideoLink, location.origin);
+                const clickedPlaylistId = clickedUrl.searchParams.get('list');
+                if (clickedPlaylistId && isPlaylistUrlForVideo(clickedUrl.href, targetVideoId)) {
+                    return clickedPlaylistId;
+                }
+            } catch (_) { }
+            return null;
+        };
+
+        const clickedPlaylistIdForVideo = getClickedPlaylistIdForVideo(currentPlaylistVideoId);
 
         // Fuente del playlist en este ciclo
         let playlistSource = null; // 'url' | 'anchor' | 'fallback' | null
 
         // Para miniplayer con URL verificada, usar directamente el playlist ID de la URL
         const playerState = PlayerStateCache.getCurrentState();
-        if (playerState.hasMiniPlayer && urlDataNow?.list) {
+        const isUrlPlaylistMatch = !!(currentPlaylistVideoId && urlDataNow?.list && urlDataNow?.id === currentPlaylistVideoId);
+        const canTrustUrlPlaylist = urlSource !== 'lastVideoUrl' && isUrlPlaylistMatch;
+        if (playerState.hasMiniPlayer && canTrustUrlPlaylist) {
             plId = urlDataNow.list;
             playlistSource = 'url';
             log('updateStatus', `📌 Usando playlist ID de URL verificada para miniplayer: ${plId}`);
+        }
+
+        if (clickedPlaylistIdForVideo && plId && !playlistSource && plId === clickedPlaylistIdForVideo) {
+            playlistSource = 'click';
         }
 
         let contId = null; // Identificador del contenedor (movie_player | shorts-player | null)
@@ -8234,12 +8302,18 @@ background: var(--ypp-danger);
                             if (a) {
                                 const ua = new URL(a.href, location.origin);
                                 const la = ua.searchParams.get('list');
-                                if (la) { p = la; pSource = 'mp_anchor'; }
+                                if (la && isPlaylistUrlForVideo(a.href, currentPlaylistVideoId)) {
+                                    p = la;
+                                    pSource = 'mp_anchor';
+                                } else if (la) {
+                                    log('updateStatus', `⚠️ Ignored miniplayer playlist anchor (video mismatch): ${a.href}`);
+                                }
                             }
                         } catch (_) { }
                     }
-                    if (!p) {
-                        try { if (lastPlaylistId) { p = lastPlaylistId; pSource = 'fallback'; } } catch (_) { }
+                    if (!p && clickedPlaylistIdForVideo) {
+                        p = clickedPlaylistIdForVideo;
+                        pSource = 'click';
                     }
                 } else {
                     // Contenido Shorts en su propio contenedor: solo evidencia explícita (URL o UI de Shorts)
@@ -8268,7 +8342,7 @@ background: var(--ypp-danger);
 
                 plId = p || null;
                 // Actualizar lastPlaylistId solo si la fuente es explícita (url o anchor), nunca en fallback
-                try { if ((pSource === 'url' || pSource === 'anchor') && plId) { lastPlaylistId = plId; } } catch (_) { }
+                try { if ((pSource === 'url' || pSource === 'anchor' || pSource === 'click') && plId) { lastPlaylistId = plId; } } catch (_) { }
                 playlistSource = pSource;
             } else {
                 // Si plId ya viene como parámetro (desde processVideo), usarlo
@@ -8296,18 +8370,25 @@ background: var(--ypp-danger);
                             if (a) {
                                 const ua = new URL(a.href, location.origin);
                                 const la = ua.searchParams.get('list');
-                                if (la) { p = la; pSrc = 'anchor'; }
+                                if (la && isPlaylistUrlForVideo(a.href, currentPlaylistVideoId)) {
+                                    p = la;
+                                    pSrc = 'anchor';
+                                } else if (la) {
+                                    log('updateStatus', `⚠️ Ignored playlist anchor (video mismatch): ${a.href}`);
+                                }
                             }
                         } catch (_) { }
                     }
-                    if (!p) {
-                        try { if (lastPlaylistId) p = lastPlaylistId; } catch (_) { }
+                    if (!p && clickedPlaylistIdForVideo) {
+                        p = clickedPlaylistIdForVideo;
+                        pSrc = 'click';
                     }
                     if (p) {
                         plId = p;
                         if (pSrc) playlistSource = pSrc;
                     }
-                    try { if (plId) lastPlaylistId = plId; } catch (_) { }
+                    const isExplicitSource = playlistSource === 'url' || playlistSource === 'anchor' || playlistSource === 'click';
+                    try { if (plId && isExplicitSource) lastPlaylistId = plId; } catch (_) { }
                 } else {
                     // plId ya viene del parámetro, solo actualizar lastPlaylistId si es estable
                     const isStableContext = (pageTypeNow === 'watch' || pageTypeNow === 'embed');
@@ -8318,8 +8399,10 @@ background: var(--ypp-danger);
                 const isHomeishNow = pageTypeNow === 'home' || pageTypeNow === 'search' || pageTypeNow === 'channel';
                 // Solo sobrescribir plId si el actual NO es un Mix automático (RD)
                 // Los Mixes automáticos (RD) deben ser respetados y guardados como playlists válidas
-                if (isHomeishNow && lastPlaylistId && /^RD/.test(lastPlaylistId) && plId && !/^RD/.test(plId)) {
+                const canApplyMixOverride = !!(clickedPlaylistIdForVideo && lastPlaylistId === clickedPlaylistIdForVideo && /^RD/.test(lastPlaylistId));
+                if (isHomeishNow && canApplyMixOverride && plId && !/^RD/.test(plId)) {
                     plId = lastPlaylistId;
+                    if (!playlistSource) playlistSource = 'click';
                 }
             }
         } catch (_) { }
@@ -9744,6 +9827,11 @@ background: var(--ypp-danger);
         saveLiveStreamsLabel.appendChild(saveLiveStreamsCheckbox);
         saveLiveStreamsLabel.appendChild(createElement('span', { text: t('liveStreams') }));
 
+        const saveMiniplayerVideosLabel = createElement('label', { className: 'ypp-label-save-type' });
+        const saveMiniplayerVideosCheckbox = createElement('input', { atribute: { type: 'checkbox', id: 'saveMiniplayerVideos' } });
+        saveMiniplayerVideosLabel.appendChild(saveMiniplayerVideosCheckbox);
+        saveMiniplayerVideosLabel.appendChild(createElement('span', { text: t('miniplayerVideos') }));
+
         const saveInlinePreviewsLabel = createElement('label', { className: 'ypp-label-save-type' });
         const saveInlinePreviewsCheckbox = createElement('input', { atribute: { type: 'checkbox', id: 'saveInlinePreviews' } });
         saveInlinePreviewsLabel.appendChild(saveInlinePreviewsCheckbox);
@@ -9759,6 +9847,7 @@ background: var(--ypp-danger);
         containerSavingOptions.appendChild(saveRegularVideosLabel);
         containerSavingOptions.appendChild(saveShortsLabel);
         containerSavingOptions.appendChild(saveLiveStreamsLabel);
+        containerSavingOptions.appendChild(saveMiniplayerVideosLabel);
         containerSavingOptions.appendChild(saveInlinePreviewsLabel);
 
         savingOptions.appendChild(containerSavingOptions)
@@ -9787,6 +9876,7 @@ background: var(--ypp-danger);
                     saveRegularVideos: document.getElementById('saveRegularVideos').checked,
                     saveShorts: document.getElementById('saveShorts').checked,
                     saveLiveStreams: document.getElementById('saveLiveStreams').checked,
+                    saveMiniplayerVideos: document.getElementById('saveMiniplayerVideos').checked,
                     saveInlinePreviews: document.getElementById('saveInlinePreviews').checked,
                     language: languageSelect.value,
                     alertStyle: alertStyleSelect.value,
@@ -9829,6 +9919,7 @@ background: var(--ypp-danger);
         saveRegularVideosCheckbox.checked = settings.saveRegularVideos;
         saveShortsCheckbox.checked = settings.saveShorts;
         saveLiveStreamsCheckbox.checked = settings.saveLiveStreams;
+        saveMiniplayerVideosCheckbox.checked = settings.saveMiniplayerVideos !== false;
         const inlineEl = document.getElementById('saveInlinePreviews');
         if (inlineEl) inlineEl.checked = settings.saveInlinePreviews === true;
 
@@ -10376,6 +10467,9 @@ background: var(--ypp-danger);
 
         // Determinar contexto del video (miniplayer, shorts, watch, preview, etc.)
         const videoContext = determineVideoContext(videoEl);
+        const settingsSnapshot = cachedSettings || CONFIG.defaultSettings;
+        const isMiniplayerContext = videoContext.type === 'miniplayer';
+        const allowMiniplayerSaving = settingsSnapshot.saveMiniplayerVideos !== false && settingsSnapshot.saveRegularVideos !== false;
         log('processVideo', `📍 Contexto del video: type=${videoContext.type}, container=${videoContext.container?.tagName || 'N/A'}, shouldProcess=${videoContext.shouldProcess}`);
 
         // Validar si el video debe procesarse según su contexto
@@ -10746,6 +10840,9 @@ background: var(--ypp-danger);
                 log('processVideo', `🔄 Tipo cambiado a 'live' porque se detectó video en vivo`);
             }
             try {
+                if (isMiniplayerContext && allowMiniplayerSaving) {
+                    type = 'watch';
+                }
                 const cont2 = activeVideoEl?.closest?.('#movie_player, #shorts-player');
                 const shortsDisabled = (() => { try { return cachedSettings?.saveShorts === false; } catch (_) { return false; } })();
                 const mpPresent = (() => { try { return !!(document.querySelector('#movie_player')); } catch (_) { return false; } })();
@@ -10764,7 +10861,9 @@ background: var(--ypp-danger);
                 const el = (currentVideoEl || videoEl || activeVideoEl);
                 const cont = el?.closest?.('#movie_player, #shorts-player');
                 const isHomeish = (type !== 'watch' && type !== 'shorts' && type !== 'embed' && type !== 'live');
-                if (isHomeish && (cont?.id !== 'movie_player')) {
+                if (isMiniplayerContext && allowMiniplayerSaving) {
+                    logicalType = 'watch';
+                } else if (isHomeish && (cont?.id !== 'movie_player')) {
                     const isShortish = !!(el?.closest?.('ytd-reel-video-renderer, ytd-shorts, #shorts-player'));
                     logicalType = isShortish ? 'preview_shorts' : 'preview_watch';
                 } else if (type === 'home' && (cont?.id === 'movie_player')) {
@@ -10797,7 +10896,7 @@ background: var(--ypp-danger);
                 // Permitir procesamiento si hay un miniplayer presente aun estando en Shorts
                 const cont = activeVideoEl?.closest?.('#movie_player, #shorts-player');
                 const mp = document.querySelector('#movie_player');
-                allowByMiniplayer = (!!cont && (cont.id === 'movie_player')) || !!mp;
+                allowByMiniplayer = allowMiniplayerSaving && ((!!cont && (cont.id === 'movie_player')) || isMiniplayerContext || !!mp);
             } catch (_) { }
             // Usar configuración segura (defaults si aún no carga settings) para prevenir crash en carga inicial
             const safeSettings = cachedSettings || CONFIG.defaultSettings;
@@ -12234,10 +12333,14 @@ background: var(--ypp-danger);
 
         for (const item of filteredItems) {
             if (item.type === 'playlist-video' && item.playlistKey && item.playlistKey !== lastPlaylistKey) {
+                const basePlaylistTitle = item.playlistTitle || item.playlistKey;
+                const headerTitle = (item.playlistKey?.startsWith('RD') && basePlaylistTitle === item.playlistKey)
+                    ? `Mix - ${item.info?.title || 'Playlist automática'}`
+                    : basePlaylistTitle;
                 virtualItems.push({
                     type: 'playlist-header',
                     playlistKey: item.playlistKey,
-                    playlistTitle: item.playlistTitle || item.playlistKey,
+                    playlistTitle: headerTitle,
                     firstVideoId: item.videoId // Guardar ID para enlaces de Mixes
                 });
                 lastPlaylistKey = item.playlistKey;

--- a/youtube-playback-plox.user.js
+++ b/youtube-playback-plox.user.js
@@ -2352,7 +2352,7 @@ background: var(--ypp-danger);
     // Ad Monitor
     let isAdPlaying = false;    // Estado global de anuncios (para compartir entre módulos)
     let isScriptPaused = false; // Variable global para controlar pausa total del script
-    // let lastAdEndTime = 0; // Timestamp de cuando terminó el último anuncio
+    let lastAdEndTime = 0; // Timestamp de cuando terminó el último anuncio
     // Estados de anuncios por tipo
     let isAdShortsPlaying = false; // Anuncio activo en Shorts
     let isAdWatchPlaying = false;  // Anuncio activo en reproductor principal (watch/embed/miniplayer)
@@ -2368,6 +2368,407 @@ background: var(--ypp-danger);
             return !!isAdPlaying || !!isScriptPaused;
         }
     };
+
+    /**
+     * Obtiene el id del contenedor de reproductor asociado a un elemento (movie_player o shorts-player).
+     * @param {HTMLElement|null|undefined} el Elemento de video o nodo dentro del contenedor.
+     * @returns {'movie_player'|'shorts-player'|null} Id del contenedor o null.
+     */
+    const getPlayerContainerId = (el) => {
+        try {
+            const cont = el?.closest?.('#movie_player, #shorts-player');
+            const id = cont?.id || null;
+            return (id === 'movie_player' || id === 'shorts-player') ? id : null;
+        } catch (_) {
+            return null;
+        }
+    };
+
+    /**
+     * Contexto por contenedor para evitar contaminación de estados cuando coexisten players (miniplayer + shorts).
+     * @returns {ReturnType<typeof createPlayerContextManager>}
+     */
+    const createPlayerContextManager = () => {
+        /** @type {Map<'movie_player'|'shorts-player', any>} */
+        const contexts = new Map();
+
+        /**
+         * Crea o devuelve un contexto por contenedor.
+         * @param {'movie_player'|'shorts-player'} containerId
+         */
+        const get = (containerId) => {
+            if (contexts.has(containerId)) return contexts.get(containerId);
+            const ctx = {
+                containerId,
+                videoEl: null,
+                player: null,
+                videoId: null,
+                logicalType: null,
+                playlistId: null,
+                timeupdateHandler: null,
+                timeupdateRebindIntervalId: null,
+                progressPollIntervalId: null,
+                secondaryProgressPollIntervalId: null,
+                lastTimeUpdateTick: 0,
+                lastSaveTime: 0,
+                lastSaveTimesByVideoId: Object.create(null),
+                isResuming: false,
+                lastResumeId: null,
+            };
+            contexts.set(containerId, ctx);
+            return ctx;
+        };
+
+        /**
+         * Devuelve un contexto asociado a un elemento; fallback a movie_player si no se puede detectar.
+         * @param {HTMLElement|null|undefined} el
+         */
+        const forElement = (el) => {
+            const id = getPlayerContainerId(el) || 'movie_player';
+            return get(id);
+        };
+
+        /**
+         * Limpia timers/listeners de un contexto.
+         * @param {'movie_player'|'shorts-player'} containerId
+         * @param {{preserveVideoEl?: boolean}} [opts]
+         */
+        const cleanup = (containerId, opts = {}) => {
+            const ctx = contexts.get(containerId);
+            if (!ctx) return;
+            try { if (ctx.timeupdateRebindIntervalId) clearInterval(ctx.timeupdateRebindIntervalId); } catch (_) { }
+            try { if (ctx.progressPollIntervalId) clearInterval(ctx.progressPollIntervalId); } catch (_) { }
+            try { if (ctx.secondaryProgressPollIntervalId) clearInterval(ctx.secondaryProgressPollIntervalId); } catch (_) { }
+            ctx.timeupdateRebindIntervalId = null;
+            ctx.progressPollIntervalId = null;
+            ctx.secondaryProgressPollIntervalId = null;
+            ctx.lastTimeUpdateTick = 0;
+            ctx.lastSaveTime = 0;
+            ctx.videoId = null;
+            ctx.logicalType = null;
+            ctx.playlistId = null;
+            ctx.isResuming = false;
+            ctx.lastResumeId = null;
+            if (!opts.preserveVideoEl) {
+                try { if (ctx.videoEl && ctx.timeupdateHandler) ctx.videoEl.removeEventListener('timeupdate', ctx.timeupdateHandler); } catch (_) { }
+                ctx.videoEl = null;
+                ctx.timeupdateHandler = null;
+            }
+        };
+
+        /**
+         * Limpia todos los contextos.
+         * @param {{preserveMoviePlayer?: boolean}} [opts]
+         */
+        const cleanupAll = (opts = {}) => {
+            for (const [id] of contexts) {
+                cleanup(id, { preserveVideoEl: opts.preserveMoviePlayer && id === 'movie_player' });
+            }
+        };
+
+        /**
+         * Obtiene el contexto correcto para un video específico considerando coexistencia.
+         * @param {string} videoId - ID del video
+         * @returns {Object|null} Contexto del player apropiado o null si no se encuentra
+         */
+        const getContextForVideo = (videoId) => {
+            if (!videoId) return null;
+
+            const playerInfo = PlayerStateManager.getPrimaryPlayerForVideo(videoId);
+            if (!playerInfo.containerId) return null;
+
+            return get(playerInfo.containerId);
+        };
+
+        /**
+         * Verifica si hay coexistencia de players y cuál es el estado actual.
+         * @returns {Object} Información sobre el estado de coexistencia
+         */
+        const getCoexistenceState = () => {
+            const playerState = PlayerStateManager.detectActivePlayers();
+            const activeContexts = [];
+
+            // Verificar qué contextos están realmente activos
+            for (const [containerId, ctx] of contexts) {
+                if (ctx.videoId) {
+                    const playerInfo = PlayerStateManager.getPrimaryPlayerForVideo(ctx.videoId, playerState);
+                    activeContexts.push({
+                        containerId,
+                        videoId: ctx.videoId,
+                        logicalType: ctx.logicalType,
+                        isPrimary: playerInfo.containerId === containerId,
+                        playerType: playerInfo.playerType
+                    });
+                }
+            }
+
+            return {
+                playerState,
+                activeContexts,
+                hasCoexistence: playerState.hasMiniPlayer && (playerState.hasShortsPlayer || playerState.hasWatchPlayer),
+                coexistenceInfo: PlayerStateManager.getCoexistenceInfo()
+            };
+        };
+
+        /**
+         * Fuerza la actualización del tipo lógico de un contexto basado en el estado actual.
+         * @param {'movie_player'|'shorts-player'} containerId
+         */
+        const updateLogicalType = (containerId) => {
+            const ctx = contexts.get(containerId);
+            if (!ctx || !ctx.videoId) return;
+
+            const playerInfo = PlayerStateManager.getPrimaryPlayerForVideo(ctx.videoId);
+            ctx.logicalType = playerInfo.playerType;
+        };
+
+        return {
+            get,
+            forElement,
+            cleanup,
+            cleanupAll,
+            contexts,
+            getContextForVideo,
+            getCoexistenceState,
+            updateLogicalType
+        };
+    };
+
+    const PlayerContexts = createPlayerContextManager();
+
+    // MARK: 🎯 Sistema Centralizado de Estados de Player
+    /**
+     * Sistema centralizado para detectar y manejar estados de múltiples players simultáneos.
+     * Reduce redundancia y mejora el manejo de miniplayer + shorts coexistentes.
+     */
+    const createPlayerStateManager = () => {
+        /**
+         * Tipos de player detectados en la página
+         * @typedef {Object} PlayerTypes
+         * @property {boolean} hasMiniPlayer - Hay un miniplayer activo
+         * @property {boolean} hasShortsPlayer - Hay un reproductor de shorts activo
+         * @property {boolean} hasWatchPlayer - Hay un reproductor de watch/embed activo
+         * @property {string|null} miniPlayerVideoId - ID del video en miniplayer
+         * @property {string|null} activeShortsVideoId - ID del video activo en shorts
+         * @property {string|null} activeWatchVideoId - ID del video activo en watch
+         */
+
+        /**
+         * Detecta todos los players activos en la página actual.
+         * @returns {PlayerTypes} Estado completo de los players detectados
+         */
+        const detectActivePlayers = () => {
+            const result = {
+                hasMiniPlayer: false,
+                hasShortsPlayer: false,
+                hasWatchPlayer: false,
+                miniPlayerVideoId: null,
+                activeShortsVideoId: null,
+                activeWatchVideoId: null
+            };
+
+            const pageType = getYouTubePageType();
+
+            try {
+                // Detectar miniplayer - SOLO cuando esté realmente minimizado
+                const miniPlayerEl = document.querySelector('.ytp-miniplayer-ui, #miniplayer, ytd-miniplayer[miniplayer-active]');
+                if (miniPlayerEl) {
+                    const moviePlayer = document.querySelector('#movie_player');
+                    if (moviePlayer) {
+                        const videoData = moviePlayer.getVideoData?.();
+                        if (videoData?.video_id) {
+                            result.hasMiniPlayer = true;
+                            result.miniPlayerVideoId = videoData.video_id;
+                        }
+                    }
+                }
+
+                // Detectar shorts player
+                const shortsPlayer = document.querySelector('#shorts-player, ytd-shorts video.html5-main-video');
+                if (shortsPlayer) {
+                    // Intentar obtener el video ID del shorts activo
+                    const activeShort = document.querySelector('ytd-reel-video-renderer[is-active]');
+                    if (activeShort) {
+                        const videoId = activeShort.getAttribute('video-id') ||
+                            activeShort.querySelector('[video-id]')?.getAttribute('video-id');
+
+                        if (videoId) {
+                            result.hasShortsPlayer = true;
+                            result.activeShortsVideoId = videoId;
+                        }
+                    }
+                }
+
+                // Detectar watch player principal (solo en páginas watch/embed)
+                if (pageType === 'watch' || pageType === 'embed') {
+                    const moviePlayer = document.querySelector('#movie_player');
+                    if (moviePlayer && !result.hasMiniPlayer) { // No contar como watch si ya es miniplayer
+                        const videoData = moviePlayer.getVideoData?.();
+                        if (videoData?.video_id) {
+                            result.hasWatchPlayer = true;
+                            result.activeWatchVideoId = videoData.video_id;
+                        }
+                    }
+                }
+
+            } catch (error) {
+                log('PlayerStateManager', 'Error detectando players activos:', error);
+            }
+
+            return result;
+        };
+
+        /**
+         * Determina cuál es el player principal según el contexto y configuración.
+         * @param {string} videoId - ID del video a evaluar
+         * @param {PlayerTypes} [playerState] - Estado de players (se detecta si no se proporciona)
+         * @returns {Object} Información del player principal
+         */
+        const getPrimaryPlayerForVideo = (videoId, playerState = null) => {
+            if (!playerState) {
+                playerState = detectActivePlayers();
+            }
+
+            const result = {
+                playerType: 'unknown', // 'miniplayer', 'shorts', 'watch', 'unknown'
+                isCoexisting: false, // Si hay múltiples players activos
+                containerId: null, // ID del contenedor para PlayerContexts
+                playerElement: null, // Elemento del player
+                pageType: getYouTubePageType() // Tipo de página actual
+            };
+
+            // Contar players activos
+            const activePlayers = [playerState.hasMiniPlayer, playerState.hasShortsPlayer, playerState.hasWatchPlayer]
+                .filter(Boolean).length;
+            result.isCoexisting = activePlayers > 1;
+
+            // Lógica de prioridad según videoId y contexto de página
+            if (playerState.hasMiniPlayer && playerState.miniPlayerVideoId === videoId) {
+                result.playerType = 'miniplayer';
+                result.containerId = 'movie_player';
+                result.playerElement = document.querySelector('#movie_player');
+            } else if (playerState.hasShortsPlayer && playerState.activeShortsVideoId === videoId) {
+                result.playerType = 'shorts';
+                result.containerId = 'shorts-player';
+                result.playerElement = document.querySelector('#shorts-player, ytd-shorts');
+            } else if (playerState.hasWatchPlayer && playerState.activeWatchVideoId === videoId) {
+                result.playerType = 'watch';
+                result.containerId = 'movie_player';
+                result.playerElement = document.querySelector('#movie_player');
+            } else {
+                // Fallback basado en tipo de página
+                if (result.pageType === 'watch' || result.pageType === 'embed') {
+                    result.playerType = 'watch';
+                    result.containerId = 'movie_player';
+                    result.playerElement = document.querySelector('#movie_player');
+                } else if (result.pageType === 'shorts') {
+                    result.playerType = 'shorts';
+                    result.containerId = 'shorts-player';
+                    result.playerElement = document.querySelector('#shorts-player, ytd-shorts');
+                }
+            }
+
+            return result;
+        };
+
+        /**
+         * Verifica si un video específico está siendo reproducido por el miniplayer.
+         * @param {string} videoId - ID del video a verificar
+         * @returns {boolean} true si el miniplayer está reproduciendo este video
+         */
+        const isVideoInMiniPlayer = (videoId) => {
+            if (!videoId) return false;
+            try {
+                const moviePlayer = document.querySelector('#movie_player');
+                const videoData = moviePlayer?.getVideoData?.();
+                return videoData?.video_id === videoId;
+            } catch (error) {
+                return false;
+            }
+        };
+
+        /**
+         * Obtiene información de coexistencia para logging/debugging.
+         * @returns {string} Descripción del estado actual de players
+         */
+        const getCoexistenceInfo = () => {
+            const state = detectActivePlayers();
+            const activeTypes = [];
+            if (state.hasMiniPlayer) activeTypes.push(`Mini(${state.miniPlayerVideoId?.slice(0, 8)}...)`);
+            if (state.hasShortsPlayer) activeTypes.push(`Shorts(${state.activeShortsVideoId?.slice(0, 8)}...)`);
+            if (state.hasWatchPlayer) activeTypes.push(`Watch(${state.activeWatchVideoId?.slice(0, 8)}...)`);
+
+            return activeTypes.length > 0 ? activeTypes.join(' + ') : 'Ninguno';
+        };
+
+        return {
+            detectActivePlayers,
+            getPrimaryPlayerForVideo,
+            isVideoInMiniPlayer,
+            getCoexistenceInfo
+        };
+    };
+
+    const PlayerStateManager = createPlayerStateManager();
+
+    // MARK: 📊 Caché de Estado de Players
+    /**
+     * Sistema de caché para estado de players - análisis fuera de funciones
+     */
+    const PlayerStateCache = (() => {
+        let cachedState = null;
+        let lastUpdate = 0;
+        const CACHE_DURATION = 1000; // 1 segundo
+
+        /**
+         * Obtiene el estado actual de players, usando caché si está fresco
+         * @returns {PlayerTypes} Estado actual de players
+         */
+        const getCurrentState = () => {
+            const now = Date.now();
+            if (!cachedState || (now - lastUpdate) > CACHE_DURATION) {
+                cachedState = PlayerStateManager.detectActivePlayers();
+                lastUpdate = now;
+
+                // Logging detallado del estado detectado
+                const coexistenceInfo = PlayerStateManager.getCoexistenceInfo();
+                log('PlayerStateCache', `🔍 Estado actualizado: ${coexistenceInfo}`);
+                if (cachedState.hasMiniPlayer) {
+                    log('PlayerStateCache', `📱 Miniplayer detectado: ${cachedState.miniPlayerVideoId}`);
+                }
+                if (cachedState.hasShortsPlayer) {
+                    log('PlayerStateCache', `📹 Shorts detectado: ${cachedState.activeShortsVideoId}`);
+                }
+                if (cachedState.hasWatchPlayer) {
+                    log('PlayerStateCache', `📺 Watch detectado: ${cachedState.activeWatchVideoId}`);
+                }
+            }
+            return cachedState;
+        };
+
+        /**
+         * Fuerza la actualización del caché
+         */
+        const invalidate = () => {
+            cachedState = null;
+            lastUpdate = 0;
+        };
+
+        /**
+         * Obtiene información del player primario para un video específico
+         * @param {string} videoId - ID del video
+         * @returns {Object} Información del player primario
+         */
+        const getPrimaryPlayer = (videoId) => {
+            return PlayerStateManager.getPrimaryPlayerForVideo(videoId, getCurrentState());
+        };
+
+        return {
+            getCurrentState,
+            invalidate,
+            getPrimaryPlayer
+        };
+    })();
 
     // ------------------------------------------
     // MARK: 🔧 Utils
@@ -3355,6 +3756,477 @@ background: var(--ypp-danger);
     }
 
     // ------------------------------------------
+    // MARK: 📺 Content Type Detection & Specialized Saving
+    // ------------------------------------------
+    /**
+     * Módulo para detectar y manejar distintos tipos de contenido de forma especializada.
+     * Detecta el tipo una sola vez al inicio y luego ejecuta la función específica.
+     */
+
+    // ------------------------------------------
+    // MARK: 📺 VideoTypeHandler - Strategy Pattern
+    // ------------------------------------------
+    /**
+     * Módulo estratégico para manejar operaciones por tipo de video.
+     * Centraliza la validación de configuración y delegación de guardado.
+     * 
+     * IMPORTANTE: Mantiene aislamiento de contexto entre miniplayer y shorts
+     * para evitar contaminación de datos cuando ambos coexisten.
+     * 
+     * @namespace VideoTypeHandler
+     */
+    const VideoTypeHandler = (() => {
+        /**
+         * Tipos de contenido soportados
+         * @readonly
+         * @enum {string}
+         */
+        const ContentTypes = Object.freeze({
+            VIDEO: 'video',
+            SHORTS: 'shorts',
+            PREVIEW: 'preview',
+            LIVE: 'live'
+        });
+
+        /**
+         * Verifica si el guardado está habilitado para un tipo específico.
+         * @param {string} type - Tipo de contenido (video, shorts, preview, live)
+         * @param {Object} [options] - Opciones adicionales
+         * @param {string} [options.previewSubtype] - Subtipo para previews (preview_watch, preview_shorts)
+         * @returns {boolean} true si el tipo está habilitado para guardar
+         */
+        const isEnabled = (type, options = {}) => {
+            try {
+                switch (type) {
+                    case ContentTypes.VIDEO:
+                        return cachedSettings?.saveRegularVideos !== false;
+                    case ContentTypes.SHORTS:
+                        return cachedSettings?.saveShorts !== false;
+                    case ContentTypes.LIVE:
+                        return cachedSettings?.saveLiveStreams !== false;
+                    case ContentTypes.PREVIEW:
+                        // Previews requieren configuración explícita
+                        if (cachedSettings?.saveInlinePreviews !== true) return false;
+                        // Validar subtipo
+                        const subtype = options.previewSubtype || 'preview_watch';
+                        if (subtype === 'preview_shorts') {
+                            return cachedSettings?.saveShorts !== false;
+                        }
+                        return cachedSettings?.saveRegularVideos !== false;
+                    default:
+                        return true;
+                }
+            } catch (_) {
+                return true; // En caso de error, permitir el guardado
+            }
+        };
+
+        /**
+         * Obtiene información del contexto actual para evitar contaminación.
+         * Crucial cuando miniplayer y shorts coexisten.
+         * @param {HTMLElement} videoElement - Elemento de video
+         * @returns {Object} Información del contexto
+         */
+        const getContextInfo = (videoElement) => {
+            try {
+                const container = videoElement?.closest?.('#movie_player, #shorts-player');
+                const containerId = container?.id || null;
+
+                return {
+                    containerId,
+                    isShortContext: containerId === 'shorts-player',
+                    isWatchContext: containerId === 'movie_player',
+                    isInlinePreview: !!(
+                        videoElement?.closest?.('#inline-preview-player') ||
+                        videoElement?.closest?.('.ytp-inline-preview-ui') ||
+                        videoElement?.closest?.('ytd-thumbnail-overlay-inline-playback-renderer')
+                    ),
+                    isMiniplayer: !!(
+                        videoElement?.closest?.('#miniplayer') ||
+                        videoElement?.closest?.('.ytp-miniplayer-ui') ||
+                        videoElement?.closest?.('ytd-miniplayer')
+                    )
+                };
+            } catch (_) {
+                return {
+                    containerId: null,
+                    isShortContext: false,
+                    isWatchContext: false,
+                    isInlinePreview: false,
+                    isMiniplayer: false
+                };
+            }
+        };
+
+        /**
+         * Valida que el tipo detectado coincida con el contexto del elemento.
+         * Previene guardar con tipo incorrecto cuando hay coexistencia.
+         * @param {string} detectedType - Tipo detectado
+         * @param {HTMLElement} videoElement - Elemento de video
+         * @returns {Object} Resultado de validación
+         */
+        const validateContext = (detectedType, videoElement) => {
+            const context = getContextInfo(videoElement);
+
+            // Si es shorts-player, el tipo DEBE ser shorts
+            if (context.isShortContext && detectedType !== ContentTypes.SHORTS) {
+                log('VideoTypeHandler', `⚠️ Contexto shorts-player pero tipo=${detectedType}. Corrigiendo a shorts.`);
+                return { valid: true, correctedType: ContentTypes.SHORTS, context };
+            }
+
+            // Si es miniplayer en movie_player, el tipo NO debe ser shorts
+            if (context.isMiniplayer && detectedType === ContentTypes.SHORTS) {
+                log('VideoTypeHandler', `⚠️ Contexto miniplayer pero tipo=shorts. Corrigiendo a video.`);
+                return { valid: true, correctedType: ContentTypes.VIDEO, context };
+            }
+
+            return { valid: true, correctedType: detectedType, context };
+        };
+
+        /**
+         * Guarda el progreso delegando a la función especializada correspondiente.
+         * @param {string} type - Tipo de contenido
+         * @param {Object} params - Parámetros de guardado
+         * @param {string} params.videoId - ID del video
+         * @param {number} params.currentTime - Tiempo actual en segundos
+         * @param {number} params.duration - Duración total del video
+         * @param {Object} params.videoInfo - Información del video
+         * @param {string} [params.playlistId] - ID de playlist (solo para videos regulares)
+         * @param {string} [params.previewSubtype] - Subtipo para previews
+         * @param {HTMLElement} [params.videoElement] - Elemento de video para validación de contexto
+         * @returns {Object} Resultado de la operación { success, reason?, videoId?, timestamp?, type? }
+         */
+        const save = (type, params) => {
+            const { videoId, currentTime, duration, videoInfo, playlistId, previewSubtype, videoElement } = params;
+
+            // Validación de contexto para prevenir contaminación
+            if (videoElement) {
+                const validation = validateContext(type, videoElement);
+                if (validation.correctedType !== type) {
+                    log('VideoTypeHandler', `🔄 Tipo corregido: ${type} → ${validation.correctedType}`);
+                    type = validation.correctedType;
+                }
+            }
+
+            // Verificar si está habilitado
+            if (!isEnabled(type, { previewSubtype })) {
+                log('VideoTypeHandler', `🛑 Tipo ${type} deshabilitado por configuración`);
+                return { success: false, reason: `${type}_disabled_by_settings` };
+            }
+
+            // Delegar al guardado especializado
+            log('VideoTypeHandler', `📼 Delegando guardado: tipo=${type}, videoId=${videoId}`);
+
+            switch (type) {
+                case ContentTypes.VIDEO:
+                    return saveRegularVideo(videoId, currentTime, duration, videoInfo, playlistId);
+                case ContentTypes.SHORTS:
+                    return saveShortsVideo(videoId, currentTime, duration, videoInfo);
+                case ContentTypes.PREVIEW:
+                    return savePreview(videoId, currentTime, duration, videoInfo, previewSubtype || 'preview_watch');
+                case ContentTypes.LIVE:
+                    return saveLivestream(videoId, currentTime, duration, videoInfo);
+                default:
+                    log('VideoTypeHandler', `⚠️ Tipo desconocido: ${type}, usando video por defecto`);
+                    return saveRegularVideo(videoId, currentTime, duration, videoInfo, playlistId);
+            }
+        };
+
+        /**
+         * Determina el tipo de contenido desde parámetros simples.
+         * Wrapper simplificado de detectContentType para uso interno.
+         * @param {Object} params
+         * @param {string} params.pageType - Tipo de página
+         * @param {string} params.containerType - ID del contenedor
+         * @param {HTMLElement} params.videoElement - Elemento de video
+         * @param {boolean} params.isLive - Si es livestream
+         * @param {string} params.currentType - Tipo actual (preview_*, etc)
+         * @returns {string} Tipo de contenido normalizado
+         */
+        const detectType = ({ pageType, containerType, videoElement, isLive, currentType }) => {
+            // Delegamos a detectContentType existente para no duplicar lógica
+            return detectContentType(pageType, containerType, videoElement, isLive, currentType);
+        };
+
+        // API pública
+        return Object.freeze({
+            ContentTypes,
+            isEnabled,
+            getContextInfo,
+            validateContext,
+            save,
+            detectType
+        });
+    })();
+
+    /**
+     * Detecta el tipo de contenido basado en el contexto de reproducción
+     * @param {string} pageType - Tipo de página (home, watch, shorts, etc.)
+     * @param {string} containerType - ID del contenedor (movie_player, shorts-player, etc.)
+     * @param {HTMLElement} videoElement - Elemento de video
+     * @param {boolean} isLiveType - Si es contenido en vivo
+     * @param {string} currentType - Tipo actual detectado (puede ser 'preview_watch', 'preview_shorts', etc.)
+     * @returns {string} Tipo de contenido normalizado: 'video', 'shorts', 'preview', 'live'
+     */
+    function detectContentType(pageType, containerType, videoElement, isLiveType, currentType) {
+        // Prioridad 1: Si es explícitamente un livestream
+        if (isLiveType) {
+            log('detectContentType', `✅ Tipo detectado: LIVE (livestream)`);
+            return 'live';
+        }
+
+        // Prioridad 2: Si estamos en la página de Shorts
+        if (pageType === 'shorts' && containerType === 'shorts-player') {
+            log('detectContentType', `✅ Tipo detectado: SHORTS (página de Shorts)`);
+            return 'shorts';
+        }
+
+        // Prioridad 3: Si es una preview (inline preview en home/search/channel)
+        if (typeof currentType === 'string' && currentType.startsWith('preview_')) {
+            log('detectContentType', `✅ Tipo detectado: PREVIEW (${currentType})`);
+            return 'preview';
+        }
+
+        // Prioridad 4: Si el video está dentro de un contenedor de Shorts (aunque la página no sea Shorts)
+        try {
+            const inShortsContext = videoElement?.closest?.('ytd-reel-video-renderer, ytd-shorts, #shorts-player, .ytp-inline-preview-ui');
+            if (inShortsContext) {
+                log('detectContentType', `✅ Tipo detectado: SHORTS (contexto de Shorts detectado)`);
+                return 'shorts';
+            }
+        } catch (_) { }
+
+        // Prioridad 5: Si es un miniplayer reproduciendo
+        try {
+            const isMiniplayer = videoElement?.closest?.('#miniplayer, .ytp-miniplayer-ui, ytd-miniplayer');
+            if (isMiniplayer) {
+                log('detectContentType', `✅ Tipo detectado: VIDEO (miniplayer)`);
+                return 'video';
+            }
+        } catch (_) { }
+
+        // Default: Es un video regular
+        log('detectContentType', `✅ Tipo detectado: VIDEO (default)`);
+        return 'video';
+    }
+
+    /**
+     * Guarda progreso para un video regular (watch page)
+     * @param {string} videoId - ID del video
+     * @param {number} currentTime - Tiempo actual en segundos
+     * @param {number} duration - Duración total del video
+     * @param {Object} videoInfo - Información del video (title, author, etc.)
+     * @param {string|null} playlistId - ID de la playlist si aplica
+     * @returns {Object} Resultado de la operación
+     */
+    function saveRegularVideo(videoId, currentTime, duration, videoInfo, playlistId) {
+        log('saveRegularVideo', `Guardando video regular ${videoId} en ${currentTime}s`);
+
+        const sourceData = getSavedVideoData(videoId, playlistId);
+        const now = Date.now();
+        const isFinished = duration > 0 && (currentTime / duration) * 100 >= (cachedSettings?.staticFinishPercent || CONFIG.defaultSettings.staticFinishPercent);
+
+        // Si tiene tiempo fijo, no sobreescribir
+        if (sourceData && sourceData.forceResumeTime > 0) {
+            if (isFinished) {
+                log('saveRegularVideo', `Video ${videoId} completado, manteniendo tiempo fijo`);
+                const base = { ...sourceData, isCompleted: true, lastUpdated: now, timestamp: 0 };
+                if (!thumbnailHasVideoId(base.thumb, videoId)) {
+                    base.thumb = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;
+                }
+                Storage.set(videoId, base);
+            }
+            return { success: false, reason: 'fixed_time_no_overwrite' };
+        }
+
+        // Preservar metadata si existe
+        const safeVideoInfo = { ...videoInfo };
+        if (sourceData) {
+            if (!safeVideoInfo.title && sourceData.title) safeVideoInfo.title = sourceData.title;
+            if (!safeVideoInfo.author && sourceData.author) safeVideoInfo.author = sourceData.author;
+            if (!safeVideoInfo.authorId && sourceData.authorId) safeVideoInfo.authorId = sourceData.authorId;
+        }
+
+        const videoData = {
+            videoId,
+            timestamp: currentTime,
+            lastUpdated: now,
+            videoType: 'video',
+            isCompleted: isFinished,
+            duration,
+            ...safeVideoInfo,
+            thumb: `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
+            lastViewedPlaylistId: playlistId || (sourceData?.lastViewedPlaylistId || null),
+            lastViewedPlaylistType: playlistId ? 'channel' : (sourceData?.lastViewedPlaylistType || ''),
+            lastViewedPlaylistItemId: null
+        };
+
+        Storage.set(videoId, videoData);
+        log('saveRegularVideo', `✅ Video regular guardado:`, videoData);
+
+        // Actualizar metadata de playlist si aplica
+        if (playlistId) {
+            const playlistMetaKey = `playlist_meta_${playlistId}`;
+            let playlistMeta = Storage.get(playlistMetaKey) || {
+                playlistId,
+                title: '',
+                lastWatchedVideoId: videoId,
+                lastUpdated: now
+            };
+            playlistMeta.lastWatchedVideoId = videoId;
+            playlistMeta.lastUpdated = now;
+            Storage.set(playlistMetaKey, playlistMeta);
+        }
+
+        return { success: true, videoId, timestamp: videoData.timestamp, type: 'video' };
+    }
+
+    /**
+     * Guarda progreso para Shorts
+     * @param {string} videoId - ID del short
+     * @param {number} currentTime - Tiempo actual
+     * @param {number} duration - Duración total
+     * @param {Object} videoInfo - Información del short
+     * @returns {Object} Resultado de la operación
+     */
+    function saveShortsVideo(videoId, currentTime, duration, videoInfo) {
+        log('saveShortsVideo', `Guardando short ${videoId} en ${currentTime}s`);
+
+        const sourceData = getSavedVideoData(videoId);
+        const now = Date.now();
+        const isFinished = duration > 0 && (currentTime / duration) * 100 >= (cachedSettings?.staticFinishPercent || CONFIG.defaultSettings.staticFinishPercent);
+
+        const videoData = {
+            videoId,
+            timestamp: currentTime,
+            lastUpdated: now,
+            videoType: 'shorts',
+            isCompleted: isFinished,
+            duration,
+            ...videoInfo,
+            thumb: `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
+            lastViewedPlaylistId: null,
+            lastViewedPlaylistType: '',
+            lastViewedPlaylistItemId: null
+        };
+
+        Storage.set(videoId, videoData);
+        log('saveShortsVideo', `✅ Short guardado:`, videoData);
+
+        return { success: true, videoId, timestamp: videoData.timestamp, type: 'shorts' };
+    }
+
+    /**
+     * Guarda progreso para previews (inline playback en home/search)
+     * @param {string} videoId - ID del video en preview
+     * @param {number} currentTime - Tiempo actual
+     * @param {number} duration - Duración total
+     * @param {Object} videoInfo - Información del video
+     * @param {string} previewType - 'preview_watch' o 'preview_shorts'
+     * @returns {Object} Resultado de la operación
+     */
+    function savePreview(videoId, currentTime, duration, videoInfo, previewType) {
+        log('savePreview', `Guardando preview ${previewType} para ${videoId} en ${currentTime}s`);
+
+        const sourceData = getSavedVideoData(videoId);
+        const now = Date.now();
+        const isFinished = duration > 0 && (currentTime / duration) * 100 >= (cachedSettings?.staticFinishPercent || CONFIG.defaultSettings.staticFinishPercent);
+
+        // Preservar datos previos para previews
+        const videoData = {
+            ...(sourceData || {}),
+            videoId,
+            timestamp: currentTime,
+            lastUpdated: now,
+            videoType: previewType,
+            isCompleted: isFinished,
+            duration: isFinite(duration) ? duration : (sourceData?.duration || 0),
+            ...videoInfo,
+            thumb: `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`
+        };
+
+        Storage.set(videoId, videoData);
+        log('savePreview', `✅ Preview guardado:`, videoData);
+
+        return { success: true, videoId, timestamp: videoData.timestamp, type: 'preview' };
+    }
+
+    /**
+     * Guarda progreso para livestreams
+     * @param {string} videoId - ID del livestream
+     * @param {number} currentTime - Tiempo actual
+     * @param {number} duration - Duración (0 para en vivo)
+     * @param {Object} videoInfo - Información del livestream
+     * @returns {Object} Resultado de la operación
+     */
+    function saveLivestream(videoId, currentTime, duration, videoInfo) {
+        log('saveLivestream', `Guardando livestream ${videoId} en ${currentTime}s`);
+
+        const sourceData = getSavedVideoData(videoId);
+        const now = Date.now();
+
+        const videoData = {
+            videoId,
+            timestamp: currentTime,
+            lastUpdated: now,
+            videoType: 'live',
+            isCompleted: false,
+            duration: isFinite(duration) && duration > 0 ? duration : 0,
+            ...videoInfo,
+            thumb: `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
+            lastViewedPlaylistId: null,
+            lastViewedPlaylistType: '',
+            lastViewedPlaylistItemId: null
+        };
+
+        Storage.set(videoId, videoData);
+        log('saveLivestream', `✅ Livestream guardado:`, videoData);
+
+        return { success: true, videoId, timestamp: videoData.timestamp, type: 'live' };
+    }
+
+    /**
+     * Dispatcher principal: detecta el tipo y delega al VideoTypeHandler.
+     * Esta función simplifica el proceso de guardado usando el patrón Strategy.
+     * 
+     * @param {string} videoId - ID del video
+     * @param {number} currentTime - Tiempo actual en segundos
+     * @param {number} duration - Duración total del video
+     * @param {Object} videoInfo - Información del video (title, author, etc.)
+     * @param {string} pageType - Tipo de página (home, watch, shorts, etc.)
+     * @param {string} containerType - ID del contenedor (movie_player, shorts-player)
+     * @param {HTMLElement} videoElement - Elemento de video
+     * @param {boolean} isLiveType - true si es un livestream
+     * @param {string} currentType - Tipo actual (puede ser preview_watch, preview_shorts, etc.)
+     * @param {string|null} [playlistId=null] - ID de playlist si aplica
+     * @returns {Object} Resultado de la operación { success, reason?, videoId?, timestamp?, type? }
+     */
+    function saveVideoDataByType(videoId, currentTime, duration, videoInfo, pageType, containerType, videoElement, isLiveType, currentType, playlistId = null) {
+        log('saveVideoDataByType', `🎯 Iniciando guardado para video ${videoId} via VideoTypeHandler`);
+
+        // Detectar el tipo de contenido
+        const contentType = detectContentType(pageType, containerType, videoElement, isLiveType, currentType);
+        log('saveVideoDataByType', `📊 Tipo detectado: ${contentType}`);
+
+        // Determinar subtipo para previews
+        const previewSubtype = (typeof currentType === 'string' && currentType.startsWith('preview_'))
+            ? currentType
+            : 'preview_watch';
+
+        // Delegar todo al VideoTypeHandler
+        return VideoTypeHandler.save(contentType, {
+            videoId,
+            currentTime,
+            duration,
+            videoInfo,
+            playlistId,
+            previewSubtype,
+            videoElement
+        });
+    }
+
+
+    // ------------------------------------------
     // MARK: 📺 Helpers
     // ------------------------------------------
     // MARK: 📺 Obtiene datos guardados de un video
@@ -3520,122 +4392,222 @@ background: var(--ypp-danger);
     *   - `'channel'` — Página de canal (personalizada, por ID o nombre)
     *   - `'unknown'` — Si no coincide con ninguno de los anteriores
     */
+    let _cachedPageType = null;
+    let _lastPageTypeUrl = null;
+
     function getYouTubePageType() {
+        // Retornar caché si la URL no cambió (optimización: evitar evaluaciones repetidas)
+        if (_lastPageTypeUrl === window.location.href && _cachedPageType !== null) {
+            return _cachedPageType;
+        }
+
         // Obtener la ruta actual de la URL (sin dominio)
         const path = window.location.pathname;
 
-        // Comprobaciones directas de ruta
-        if (path === '/') return 'home';
-        if (path.startsWith('/shorts')) return 'shorts';
-        if (path.startsWith('/watch')) return 'watch';
-        if (path.startsWith('/embed')) return 'embed';
-        if (path.startsWith('/playlist')) return 'playlist';
-        if (path.startsWith('/results')) return 'search';
+        let pageType = 'unknown';
 
-        // Comprobaciones por canal o categoría especial (IDs fijos de YouTube)
-        if (path.endsWith('/UC-9-kyTW8ZkZNDHQJ6FgpwQ')) return 'music';     // Canal oficial de YouTube Music
-        if (path.startsWith('/gaming')) return 'gaming';                    // Sección de Gaming
-        if (path.endsWith('/UCYfdidRxbB8Qhf0Nx7ioOYw')) return 'news';      // Canal de Noticias
-        if (path.endsWith('/UCEgdi0XIXXZ-qJOFPf4JSKw')) return 'sports';    // Canal de Deportes
-        if (path.endsWith('/UCtFRv9O2AHqOZjjynzrv-xg')) return 'learning';  // Canal de Aprendizaje
-
-        // Feeds personales del usuario
-        if (path.endsWith('/feed/you')) return 'you';
-        if (path.endsWith('/feed/history')) return 'history';
-        if (path.endsWith('/feed/subscriptions')) return 'subscriptions';
-
+        // Comprobaciones directas de ruta (ordenadas por frecuencia esperada)
+        if (path === '/') {
+            pageType = 'home';
+        } else if (path.startsWith('/shorts')) {
+            pageType = 'shorts';
+        } else if (path.startsWith('/watch')) {
+            pageType = 'watch';
+        } else if (path.startsWith('/embed')) {
+            pageType = 'embed';
+        } else if (path.startsWith('/playlist')) {
+            pageType = 'playlist';
+        } else if (path.startsWith('/results')) {
+            pageType = 'search';
+        }
         // Detección de videos en vivo o enlaces con "/live"
         // Ejemplo: https://www.youtube.com/@NASA/live
         // Para raros casos, ya que Youtube usa "/watch" igual para directos.
-        if (path.includes('/live')) return 'live';
-
+        else if (path.includes('/live')) {
+            pageType = 'live';
+        }
+        // Sección de Gaming
+        else if (path.startsWith('/gaming')) {
+            pageType = 'gaming';
+        }
+        // Comprobaciones por canal o categoría especial (IDs fijos de YouTube)
+        else if (path.endsWith('/UC-9-kyTW8ZkZNDHQJ6FgpwQ')) {
+            pageType = 'music'; // Canal oficial de YouTube Music
+        } else if (path.endsWith('/UCYfdidRxbB8Qhf0Nx7ioOYw')) {
+            pageType = 'news'; // Canal de Noticias
+        } else if (path.endsWith('/UCEgdi0XIXXZ-qJOFPf4JSKw')) {
+            pageType = 'sports'; // Canal de Deportes
+        } else if (path.endsWith('/UCtFRv9O2AHqOZjjynzrv-xg')) {
+            pageType = 'learning'; // Canal de Aprendizaje
+        }
+        // Feeds personales del usuario
+        else if (path.endsWith('/feed/you')) {
+            pageType = 'you';
+        } else if (path.endsWith('/feed/history')) {
+            pageType = 'history';
+        } else if (path.endsWith('/feed/subscriptions')) {
+            pageType = 'subscriptions';
+        }
         // Posibles rutas de canales de usuario
-        const channelPaths = [
-            '/@',        // Canal personalizado (nuevo formato: /@nombre)
-            '/channel',  // Canal por ID (formato: /channel/UCxxxx)
-            '/c',        // Canal personalizado (antiguo: /c/nombre)
-            '/user',     // Canal de usuario clásico (muy antiguo)
-            '/UC'        // Canal directo por ID (raro)
-        ];
+        // Canal personalizado (nuevo formato: /@nombre)
+        else if (path.startsWith('/@')) {
+            pageType = 'channel';
+        }
+        // Canal por ID (formato: /channel/UCxxxx)
+        else if (path.startsWith('/channel')) {
+            pageType = 'channel';
+        }
+        // Canal personalizado (antiguo: /c/nombre)
+        else if (path.startsWith('/c')) {
+            pageType = 'channel';
+        }
+        // Canal de usuario clásico (muy antiguo)
+        else if (path.startsWith('/user')) {
+            pageType = 'channel';
+        }
+        // Canal directo por ID (raro)
+        else if (path.startsWith('/UC')) {
+            pageType = 'channel';
+        }
 
-        // Si la ruta coincide con alguno de los prefijos de canal, se considera canal
-        if (channelPaths.some(prefix => path.startsWith(prefix))) return 'channel';
-
-        // Si no se reconoce la ruta, devolvemos "unknown"
-        return 'unknown';
+        // Guardar en caché
+        _lastPageTypeUrl = window.location.href;
+        _cachedPageType = pageType;
+        return pageType;
     }
 
     // ------------------------------------------
     // MARK: 📺 Get Video Element
     // ------------------------------------------
-    // Helper para encontrar el <video> actual
+    // Encuentra el elemento <video> actualmente reproducido o visible en la página.
+    // Estrategia de dos capas:
+    //   1. YouTube Helper API (YTHelper) - PREFERIDO cuando disponible, más rápido y confiable
+    //   2. Búsqueda DOM (Fallback) - Cuando YTHelper no está disponible o se necesita más control
+    //
+    // Características:
+    //   - Evita elementos de anuncios e inline previews no deseados
+    //   - Maneja casos especiales: miniplayer, Shorts, embeds, home-like pages
+    //   - Prioriza videos que estén reproduciéndose vs simplemente visibles
+    //   - Respeta configuración del usuario (saveShorts, saveRegularVideos, etc)
     async function getActiveVideoElement() {
-        // Prioridad: YouTube Helper API
-        if (YTHelper?.player?.videoElement) {
-            try {
-                const el = YTHelper.player.videoElement;
-                const pt = getYouTubePageType();
-                const container = el.closest('#movie_player, #shorts-player');
-                const isShortsContainer = container?.id === 'shorts-player';
-                // En home/watch/embed evita usar el shorts-player; en Shorts sí debe usarse
-                if ((pt === 'shorts' && isShortsContainer) || (pt !== 'shorts' && !isShortsContainer)) {
-                    // En Shorts con guardado de shorts desactivado, evitar retorno inmediato del helper de Shorts.
-                    // Además, si hay miniplayer visible/reproduciendo, preferir DOM para seleccionarlo.
-                    let blockShortsHelper = false;
+        // ======================================================================
+        // OPCIÓN 1: YOUTUBE HELPER API (Más confiable y rápido)
+        // ======================================================================
+        // YouTube Helper proporciona acceso directo al elemento <video> del player
+        // principal, evitando la necesidad de buscar en el DOM. Esto es:
+        //   - Más rápido (1 acceso vs múltiples querySelectorAll)
+        //   - Más confiable (YouTube lo actualiza en tiempo real)
+        //   - Menos propenso a conflictos con otras extensiones
+        try {
+            if (YTHelper?.player?.videoElement) {
+                const helperElement = YTHelper.player.videoElement;
+                const pageType = getYouTubePageType();
+
+                // Validar que el elemento esté en el contexto correcto (movie_player o shorts-player)
+                // Esto previene retornar elementos de tests o contextos inesperados
+                const container = helperElement.closest('#movie_player, #shorts-player');
+                const isShortsElement = container?.id === 'shorts-player';
+                const isWatchElement = container?.id === 'movie_player';
+
+                // === CASO: SHORTS ===
+                // En páginas de Shorts, YTHelper proporciona el video del shorts-player
+                // PERO: Si el usuario deshabilitó saveShorts y hay miniplayer reproduciéndose,
+                // preferir el miniplayer (video principal) del DOM para respetar la config del usuario
+                if (pageType === 'shorts' && isShortsElement) {
                     try {
-                        if (pt === 'shorts' && isShortsContainer) {
-                            const mpEl = document.querySelector('#movie_player video.html5-main-video, #miniplayer video.html5-main-video, ytd-miniplayer video');
-                            const mpPlaying = (() => { try { return !!mpEl && !mpEl.paused; } catch (_) { return false; } })();
-                            const shortsDisabled = (() => { try { return cachedSettings?.saveShorts === false; } catch (_) { return false; } })();
-                            blockShortsHelper = (!!mpEl && (shortsDisabled || mpPlaying));
+                        const miniplayerEl = document.querySelector('#movie_player video.html5-main-video');
+                        // Si miniplayer está reproduciendo Y saveShorts está deshabilitado,
+                        // forzar búsqueda en DOM para que rejección temprana de updateStatus() lo capture
+                        if (miniplayerEl && !miniplayerEl.paused && cachedSettings?.saveShorts === false) {
+                            log('getActiveVideoElement', '⏭ Miniplayer activo y saveShorts deshabilitado, buscando en DOM');
+                            throw new Error('Force DOM search');
                         }
                     } catch (_) { }
-                    if (blockShortsHelper) {
-                        log('getActiveVideoElement', '⏭ Evitando helper de Shorts (saveShorts=false o miniplayer activo); buscando en DOM para priorizar miniplayer');
-                    } else {
-                        // En páginas home-like, no devolvemos aún: buscamos DOM primero para privilegiar previews reales
-                        if (pt !== 'home' && pt !== 'search' && pt !== 'channel' && pt !== 'unknown') {
-                            log('getActiveVideoElement', '✅ Usando YTHelper.player.videoElement');
-                            return el;
-                        } else {
-                            log('getActiveVideoElement', 'ℹ️ En home-like no se retorna helper de inmediato; se buscará en DOM');
-                        }
-                    }
+
+                    log('getActiveVideoElement', '✅ YTHelper: Usando elemento de Shorts');
+                    return helperElement;
                 }
-                log('getActiveVideoElement', '⚠️ Ignorando YTHelper.videoElement por desajuste de contexto');
-            } catch (_) { }
+
+                // === CASO: WATCH / EMBED ===
+                // En página de reproducción normal o embeds, usar YTHelper directamente
+                if ((pageType === 'watch' || pageType === 'embed') && isWatchElement) {
+                    log('getActiveVideoElement', '✅ YTHelper: Usando elemento de Watch');
+                    return helperElement;
+                }
+
+                // === CASO: HOME-LIKE (Home, Search, Channel, etc) ===
+                // En páginas tipo home, el YTHelper puede existir pero apunta a un player
+                // invisible (background). Para inline previews, necesitamos la búsqueda DOM
+                // que detecta específicamente qué video está visible Y reproduciendo
+                if (['home', 'search', 'channel', 'unknown'].includes(pageType)) {
+                    log('getActiveVideoElement', 'ℹ️ YTHelper disponible pero en home-like; buscando en DOM para previews reales');
+                    throw new Error('Skip helper for home-like');
+                }
+            }
+        } catch (e) {
+            if (e.message !== 'Skip helper for home-like' && e.message !== 'Force DOM search') {
+                log('getActiveVideoElement', '⚠️ YTHelper falló o no disponible, usando búsqueda DOM');
+            }
         }
 
-        log('getActiveVideoElement', '⚠️ YouTube Helper API no disponible, usando búsqueda DOM');
+        // ======================================================================
+        // OPCIÓN 2: BÚSQUEDA DOM (Fallback)
+        // ======================================================================
+        // Cuando YTHelper no disponible o no apropiado (home, search, etc),
+        // buscamos el elemento <video> usando selectores DOM con prioridad:
+        //   1. SHORTS activos: Prioridad máxima en páginas de Shorts
+        //   2. Videos regulares: En páginas watch
+        //   3. Miniplayer: Para videos que continúan en background
+        //   4. Fallbacks genéricos: Como último recurso
+        //
+        // El orden importa: querySelectorAll sigue el orden de los selectores,
+        // así que colocamos primero los más específicos/confiables
+        log('getActiveVideoElement', '🔍 Buscando video en DOM...');
 
         const selectors = [
-            // === SHORTS (activo primero) ===
+            // === SHORTS (activo primero, máxima especificidad) ===
+            // ytd-reel-video-renderer[is-active]: Solo el reel ACTUALMENTE mostrado
+            // Necesita la estructura completa porque YouTube cambia esto según la vista
             'ytd-reel-video-renderer[is-active] #short-video-container ytd-player div.html5-video-container video',
             'ytd-reel-video-renderer[is-active] video.reel-video-player-element',
+
+            // Overlay de shorts (cuando aparece el selector de siguientes)
             'ytd-reel-player-overlay-renderer #shorts-player video',
             'ytd-reel-player-overlay-renderer video.html5-main-video',
+
+            // Fallbacks para Shorts (menos específicos pero útiles en algunos layouts)
             'ytd-reel-video-renderer #short-video-container ytd-player div.html5-video-container video',
             'ytd-reel-video-renderer video.reel-video-player-element',
             'ytd-shorts video.html5-main-video',
             '#shorts-player video',
 
-            // === VIDEOS REGULARES (en página de reproducción) ===
+            // === VIDEOS REGULARES (página de reproducción normal) ===
+            // Estos son para cuando el usuario está viendo un video completo en watch.youtube.com
             '#movie_player video.html5-main-video',
             '.html5-video-player video.html5-main-video',
 
-            // === MINIPLAYER FLOTANTE (Picture-in-Picture / Miniplayer) ===
-            // Este es el clave para cuando el usuario vuelve al homepage o cambia a shorts desde video regular reproduciendose
+            // === MINIPLAYER FLOTANTE (Picture-in-Picture / Floating Player) ===
+            // Muy importante: cuando el usuario navega a home o cambia a shorts,
+            // el video principal sigue reproduciéndose en miniplayer.
+            // Este es el caso donde necesitamos detectarlo para saveShorts=false
             '#movie_player',
             '.ytp-miniplayer-ui video.html5-main-video',
             '#miniplayer video.html5-main-video',
             'ytd-miniplayer video',
-            '.html5-video-container video', // más genérico, pero útil
+            '.html5-video-container video', // Más genérico, pero útil como fallback
 
-            // === FALLBACKS GENÉRICOS (evitando previews) ===
+            // === FALLBACKS GENÉRICOS (último recurso) ===
+            // Evitar [data-no-fullscreen] que indica previews inline que no queremos
             'video:not([data-no-fullscreen])',
             'video'
         ];
 
+        // ======================================================================
+        // PASO 1: Recopilar todos los candidatos posibles
+        // ======================================================================
+        // flatMap busca con CADA selector y devuelve todos los matches
+        // Esto puede retornar duplicados (el mismo video matched por múltiples selectores),
+        // pero eso está bien - los filtros posteriores los eliminarán
         const candidates = selectors.flatMap(selector => {
             const elements = Array.from(document.querySelectorAll(selector));
             info('getActiveVideoElement', `Selector "${selector}": ${elements.length} elementos`);
@@ -3643,78 +4615,143 @@ background: var(--ypp-danger);
         });
         log('getActiveVideoElement', `Total de candidatos: ${candidates.length}`);
 
-        // Excluir candidatos dentro de contextos de anuncios (in-feed o overlays del player)
+        // ======================================================================
+        // PASO 2: Filtrar candidatos (visibilidad, tipo de nodo, contexto)
+        // ======================================================================
+
+        // Función auxiliar: detectar si un elemento está dentro de un anuncio
+        // Esto es crucial porque YouTube inyecta <video> fake en anuncios que
+        // no queremos grabar (violación de Copyright y mala experiencia)
         const isAdContextNode = (node) => {
             try {
                 if (!node || !node.closest) return false;
-                const adNode = node.closest('.ytp-ad-module, .ytp-ad-player-overlay, .video-ads, ytd-in-feed-ad-layout-renderer, ytd-ad-slot-renderer, ytd-display-ad-renderer, ytd-promoted-sparkles-web-renderer, #player-ads');
+
+                // Buscar contenedores explícitos de anuncios
+                const adNode = node.closest(
+                    '.ytp-ad-module, .ytp-ad-player-overlay, .video-ads, ' +
+                    'ytd-in-feed-ad-layout-renderer, ytd-ad-slot-renderer, ' +
+                    'ytd-display-ad-renderer, ytd-promoted-sparkles-web-renderer, #player-ads'
+                );
                 if (adNode) return true;
-                // Si el contenedor del movie_player marca ad-showing, considerarlo anuncio
+
+                // También revisar si el player tiene la clase ad-showing
+                // (indica que está reproduciendo un anuncio actualmente)
                 try {
-                    const po = (node.closest('#movie_player, .html5-video-player'));
-                    if (po && (po.classList?.contains('ad-showing') || po.classList?.contains('ad-interrupting'))) return true;
+                    const playerContainer = node.closest('#movie_player, .html5-video-player');
+                    if (playerContainer && (
+                        playerContainer.classList?.contains('ad-showing') ||
+                        playerContainer.classList?.contains('ad-interrupting')
+                    )) {
+                        return true;
+                    }
                 } catch (_) { }
+
                 return false;
             } catch (_) { return false; }
         };
 
+        // Filtrar candidatos: quedarse solo con videos VISIBLES y REPRODUCIBLES
         const visibleVideos = candidates.filter(video => {
             if (!video) return false;
-            if (((video.tagName || '').toUpperCase()) !== 'VIDEO') return false;
-            if (isAdContextNode(video)) { info('getActiveVideoElement', 'Descartado por contexto de anuncio'); return false; }
 
+            // Sanity check: tiene que ser un <video> real
+            if (((video.tagName || '').toUpperCase()) !== 'VIDEO') return false;
+
+            // CRÍTICO: Excluir anuncios
+            if (isAdContextNode(video)) {
+                info('getActiveVideoElement', 'Descartado por contexto de anuncio');
+                return false;
+            }
+
+            // ================================================================
+            // Análisis de visibilidad: ¿puede el usuario ver este video?
+            // ================================================================
             const rect = video.getBoundingClientRect();
-            // Considerar contenedor de inline preview para la visibilidad
+
+            // Si está dentro de un inline preview (thumbnail con hover), considerar su contenedor
             let inlineContainerEl = null;
-            try { inlineContainerEl = video.closest('#inline-preview-player, .ytp-inline-preview-ui, ytd-thumbnail-overlay-inline-playback-renderer'); } catch (_) { inlineContainerEl = null; }
-            const contRect = (() => { try { return inlineContainerEl?.getBoundingClientRect?.(); } catch (_) { return null; } })();
-            const visByVideoRect = rect.width > 50 && rect.height > 50 && rect.bottom > 0 && rect.top < (window.innerHeight || 99999);
-            const visByContRect = !!(contRect && contRect.width > 50 && contRect.height > 50 && contRect.bottom > 0 && contRect.top < (window.innerHeight || 99999));
-            // Chequeo de estilo (display/visibility/opacity) del contenedor si existe, de lo contrario del video
+            try {
+                inlineContainerEl = video.closest(
+                    '#inline-preview-player, ' +
+                    '.ytp-inline-preview-ui, ' +
+                    'ytd-thumbnail-overlay-inline-playback-renderer'
+                );
+            } catch (_) { inlineContainerEl = null; }
+
+            const contRect = (() => {
+                try { return inlineContainerEl?.getBoundingClientRect?.(); }
+                catch (_) { return null; }
+            })();
+
+            // Visibilidad por tamaño: tiene que ser lo suficientemente grande para ver
+            const visByVideoRect = rect.width > 50 && rect.height > 50 &&
+                rect.bottom > 0 && rect.top < (window.innerHeight || 99999);
+            const visByContRect = !!(contRect && contRect.width > 50 && contRect.height > 50 &&
+                contRect.bottom > 0 && contRect.top < (window.innerHeight || 99999));
+
+            // Visibilidad por estilo CSS: el contenedor debe estar visible (no hidden/opacity 0)
             let visByStyle = true;
             try {
                 const styleNode = inlineContainerEl || video;
                 const cs = window.getComputedStyle(styleNode);
-                const op = parseFloat(cs.opacity || '1');
-                visByStyle = cs.display !== 'none' && cs.visibility !== 'hidden' && op > 0.05;
-            } catch (_) { visByStyle = true; }
+                const opacity = parseFloat(cs.opacity || '1');
+                visByStyle = cs.display !== 'none' && cs.visibility !== 'hidden' && opacity > 0.05;
+            } catch (_) {
+                visByStyle = true;
+            }
+
             const isVisible = (visByVideoRect || visByContRect) && visByStyle;
+
+            // ================================================================
+            // Análisis de reproducibilidad: ¿puede este video reproducirse?
+            // ================================================================
             const hasSource = !!(video.currentSrc || video.src || video.querySelector('source'));
             const isPlaying = (() => { try { return !video.paused; } catch (_) { return false; } })();
             const hasDuration = Number.isFinite(video.duration) && video.duration > 0;
-            const ready = (video.readyState || 0) >= 2; // HAVE_CURRENT_DATA
+            const ready = (video.readyState || 0) >= 2; // HAVE_CURRENT_DATA (puede empezar a reproducir)
             const progressed = (Number.isFinite(video.currentTime) && video.currentTime > 0);
             const playable = ready || progressed || hasDuration || isPlaying;
 
             log('getActiveVideoElement', `Video: ${video.currentSrc?.substring(0, 50)}... | Visible: ${isVisible} | Tamaño: ${rect.width}x${rect.height} | Reproduciendo: ${isPlaying}`);
 
+            // Aceptar por inline preview: casos especiales para home-like pages
             let acceptByInline = false;
             try {
                 const inlineEl = inlineContainerEl || video.closest('#inline-preview-player, .ytp-inline-preview-ui, ytd-thumbnail-overlay-inline-playback-renderer');
                 if (inlineEl) {
-                    const ptNow = getYouTubePageType();
-                    const isHomeLike = (ptNow === 'home' || ptNow === 'search' || ptNow === 'channel' || ptNow === 'unknown');
+                    const pageType = getYouTubePageType();
+                    const isHomeLike = (pageType === 'home' || pageType === 'search' || pageType === 'channel' || pageType === 'unknown');
                     const allowInline = !!(cachedSettings && cachedSettings.saveInlinePreviews === true);
+
                     // Permitir selección si:
                     // - El usuario habilitó guardar previews inline, o
-                    // - Ya está reproduciendo o avanzó (para detección no intrusiva incluso si guardar está deshabilitado)
+                    // - Ya está reproduciendo o avanzó (detección no intrusiva, incluso si guardado está deshabilitado)
                     acceptByInline = isHomeLike && (allowInline || isPlaying || progressed);
+
                     // Sticky: recordar último inline playing para tolerar reflows rápidos
+                    // Si el usuario scrollea rápido, queremos recordar qué estaba reproduciendo
                     try {
                         if (acceptByInline && (isPlaying || progressed) && isVisible) {
                             window.__ypp_lastInlinePreview__ = { el: video, ts: Date.now() };
                         }
                     } catch (_) { }
                 }
-            } catch (_) { acceptByInline = false; }
+            } catch (_) {
+                acceptByInline = false;
+            }
 
+            // Retornar true solo si: está visible Y (tiene contenido reproducible OR es inline preview aceptado)
             return isVisible && ((hasSource && playable) || acceptByInline);
         });
 
         log('getActiveVideoElement', `Videos visibles y reproducibles: ${visibleVideos.length}`);
 
+        // ======================================================================
+        // PASO 3: Si no hay videos visibles, intentar fallback sticky
+        // ======================================================================
+        // Si el usuario está scrolleando rápido o hay un reflow que ocultó momentáneamente
+        // el preview, recordamos el último que estaba reproduciendo (<1500ms)
         if (visibleVideos.length === 0) {
-            // Fallback: usar último inline preview detectado recientemente (< 1500ms)
             try {
                 const last = window.__ypp_lastInlinePreview__;
                 if (last && last.el && (Date.now() - (last.ts || 0) <= 1500) && document.contains(last.el) && !isAdContextNode(last.el)) {
@@ -3725,68 +4762,216 @@ background: var(--ypp-danger);
             return null;
         }
 
-        // Preferir el video que esté reproduciéndose actualmente
+        // ======================================================================
+        // PASO 4: Seleccionar entre videos visibles por PRIORIDAD
+        // ======================================================================
+        // Extraer solo los videos que ESTÁN REPRODUCIÉNDOSE en este momento
+        // (Estos tienen máxima prioridad porque indican intención del usuario)
         const playingVideos = visibleVideos.filter(v => {
             try { return !v.paused; } catch (_) { return false; }
         });
 
+        // Función helper: dentro de una lista de videos, seleccionar por prioridad
+        // LÓGICA: Miniplayer > Main Player (movie_player) > Shorts > Cualquiera
+        // POR QUÉ este orden:
+        //   - Miniplayer: Cuando el usuario lo hizo flotante, tiene intención clara
+        //   - Main Player: El video principal en la página (no flotante)
+        //   - Shorts: Video actual en el feed de Shorts
+        //   - Cualquiera: Fallback si nada de lo anterior
         const pickByPriority = (list) => {
-            const mp = list.find(v => v.closest('.ytp-miniplayer-ui') || v.closest('#miniplayer') || v.closest('ytd-miniplayer'));
+            // Prioridad 1: Miniplayer (usuario lo destacó flotante)
+            const mp = list.find(v =>
+                v.closest('.ytp-miniplayer-ui') ||
+                v.closest('#miniplayer') ||
+                v.closest('ytd-miniplayer')
+            );
             if (mp) return mp;
-            const main = list.find(v => v.closest('#movie_player') || v.closest('.html5-video-player'));
+
+            // Prioridad 2: Main player (movie_player en página watch)
+            const main = list.find(v =>
+                v.closest('#movie_player') ||
+                v.closest('.html5-video-player')
+            );
             if (main) return main;
-            const shorts = list.find(v => v.closest('ytd-reel-video-renderer') || v.closest('ytd-shorts') || v.closest('#shorts-player'));
+
+            // Prioridad 3: Shorts feed
+            const shorts = list.find(v =>
+                v.closest('ytd-reel-video-renderer') ||
+                v.closest('ytd-shorts') ||
+                v.closest('#shorts-player')
+            );
             if (shorts) return shorts;
+
+            // Fallback: El primero de la lista
             return list[0];
         };
 
-        // Si estamos en Shorts y el guardado de Shorts está deshabilitado,
-        // priorizar el miniplayer incluso cuando ambos están reproduciéndose.
+        // ======================================================================
+        // PASO 5: Preferencias especiales para Shorts
+        // ======================================================================
+        // Cuando el usuario DESHABILITA el guardado de Shorts (saveShorts=false)
+        // pero está navegando desde una página Shorts, y el video principal (miniplayer)
+        // sigue reproduciéndose, preferimos capturar el miniplayer en lugar del shorts.
+        //
+        // CASO COMÚN: Usuario está en Shorts, video principal se reproducía en fondo,
+        // luego vuelve a la página anterior. Queremos grabar el video principal, no el short.
         let preferMiniplayer = false;
-        try { preferMiniplayer = (getYouTubePageType() === 'shorts') && (cachedSettings?.saveShorts === false); } catch (_) { }
-        // Si estamos en Shorts y el guardado de Shorts está habilitado, preferir Shorts sobre miniplayer
-        let preferShorts = false;
-        try { preferShorts = (getYouTubePageType() === 'shorts') && (cachedSettings?.saveShorts !== false); } catch (_) { }
+        try {
+            preferMiniplayer = (getYouTubePageType() === 'shorts') && (cachedSettings?.saveShorts === false);
+        } catch (_) { }
 
+        // Opuesto: Si están HABILITADOS los Shorts, preferir Shorts sobre miniplayer
+        let preferShorts = false;
+        try {
+            preferShorts = (getYouTubePageType() === 'shorts') && (cachedSettings?.saveShorts !== false);
+        } catch (_) { }
+
+        // ======================================================================
+        // PASO 6: Seleccionar video final
+        // ======================================================================
+        // Primera opción: Si hay videos REPRODUCIÉNDOSE, ellos ganan
         if (playingVideos.length > 0) {
+            // Sub-opción A: preferimos miniplayer (saveShorts=false en Shorts)
             if (preferMiniplayer) {
-                const mpPlaying = playingVideos.find(v => v.closest('.ytp-miniplayer-ui') || v.closest('#miniplayer') || v.closest('ytd-miniplayer'));
+                const mpPlaying = playingVideos.find(v =>
+                    v.closest('.ytp-miniplayer-ui') ||
+                    v.closest('#miniplayer') ||
+                    v.closest('ytd-miniplayer')
+                );
                 if (mpPlaying) {
                     log('getActiveVideoElement', 'Seleccionado miniplayer (preferido) por reproducción activa en Shorts con guardado desactivado');
                     return mpPlaying;
                 }
             }
+
+            // Sub-opción B: preferimos Shorts (saveShorts=true en Shorts)
             if (preferShorts) {
-                const spPlaying = playingVideos.find(v => v.closest('ytd-reel-video-renderer') || v.closest('ytd-shorts') || v.closest('#shorts-player'));
+                const spPlaying = playingVideos.find(v =>
+                    v.closest('ytd-reel-video-renderer') ||
+                    v.closest('ytd-shorts') ||
+                    v.closest('#shorts-player')
+                );
                 if (spPlaying) {
                     log('getActiveVideoElement', 'Seleccionado Shorts (preferido) por reproducción activa en Shorts con guardado habilitado');
                     return spPlaying;
                 }
             }
+
+            // Default: usar la función de prioridad estándar
             const chosen = pickByPriority(playingVideos);
             log('getActiveVideoElement', 'Seleccionado por reproducción activa');
             return chosen;
         }
 
-        // Si no hay videos reproduciéndose, pero preferimos miniplayer, escogerlo si es visible
+        // Segunda opción: Si no hay reproducción activa, revisar por VISIBILIDAD
+        // pero respetando preferencias (miniplayer vs shorts)
         if (preferMiniplayer) {
-            const mpVisible = visibleVideos.find(v => v.closest('.ytp-miniplayer-ui') || v.closest('#miniplayer') || v.closest('ytd-miniplayer'));
+            const mpVisible = visibleVideos.find(v =>
+                v.closest('.ytp-miniplayer-ui') ||
+                v.closest('#miniplayer') ||
+                v.closest('ytd-miniplayer')
+            );
             if (mpVisible) {
                 log('getActiveVideoElement', 'Seleccionado miniplayer (preferido) por visibilidad en Shorts con guardado desactivado');
                 return mpVisible;
             }
         }
-        // Si no hay videos reproduciéndose, pero preferimos Shorts, escogerlo si es visible
+
+        // Similar para Shorts: si preferimos Shorts, escogerlo si es visible
         if (preferShorts) {
-            const spVisible = visibleVideos.find(v => v.closest('ytd-reel-video-renderer') || v.closest('ytd-shorts') || v.closest('#shorts-player'));
+            const spVisible = visibleVideos.find(v =>
+                v.closest('ytd-reel-video-renderer') ||
+                v.closest('ytd-shorts') ||
+                v.closest('#shorts-player')
+            );
             if (spVisible) {
                 log('getActiveVideoElement', 'Seleccionado Shorts (preferido) por visibilidad en Shorts con guardado habilitado');
                 return spVisible;
             }
         }
+
+        // Fallback final: usar la función de prioridad estándar
+        // (miniplayer > main > shorts > cualquiera)
         const chosen = pickByPriority(visibleVideos);
-        log('getActiveVideoElement', 'Seleccionado por prioridad de visibilidad');
+        log('getActiveVideoElement', `Seleccionado por prioridad de visibilidad`);
         return chosen;
+    }
+
+    // ------------------------------------------
+    // MARK: 📺 Determine Video Context
+    // ------------------------------------------
+
+    /**
+     * Determina el contexto/tipo de un elemento <video> basado en su ubicación en el DOM.
+     * Extrae la lógica de selección de miniplayer/shorts/watch para que processVideo()
+     * ya sepa qué tipo de contenido está procesando.
+     * 
+     * @param {HTMLVideoElement} videoElement - Elemento <video> a analizar
+     * @returns {Object} Objeto con propiedades:
+     *   - type: 'miniplayer' | 'shorts' | 'watch' | 'preview' | 'unknown'
+     *   - container: HTMLElement - Contenedor padre del video
+     *   - isInline: boolean - Si es un preview inline
+     *   - shouldProcess: boolean - Si debe procesarse según configuración
+     */
+    function determineVideoContext(videoElement) {
+        const result = {
+            type: 'unknown',
+            container: null,
+            isInline: false,
+            shouldProcess: true
+        };
+
+        if (!videoElement || videoElement.tagName !== 'VIDEO') {
+            return result;
+        }
+
+        try {
+            // Detectar miniplayer
+            const miniplayerContainer = videoElement.closest('.ytp-miniplayer-ui, #miniplayer, ytd-miniplayer');
+            if (miniplayerContainer) {
+                result.type = 'miniplayer';
+                result.container = miniplayerContainer;
+                return result;
+            }
+
+            // Detectar shorts
+            const shortsContainer = videoElement.closest('ytd-reel-video-renderer, ytd-shorts, #shorts-player, #short-video-container');
+            if (shortsContainer) {
+                result.type = 'shorts';
+                result.container = shortsContainer;
+                result.shouldProcess = cachedSettings?.saveShorts !== false;
+                return result;
+            }
+
+            // Detectar inline preview
+            const inlineContainer = videoElement.closest('#inline-preview-player, .ytp-inline-preview-ui, ytd-thumbnail-overlay-inline-playback-renderer');
+            if (inlineContainer) {
+                result.type = 'preview';
+                result.container = inlineContainer;
+                result.isInline = true;
+                result.shouldProcess = cachedSettings?.saveInlinePreviews === true;
+                return result;
+            }
+
+            // Detectar watch/main player
+            const watchContainer = videoElement.closest('#movie_player, .html5-video-player');
+            if (watchContainer) {
+                result.type = 'watch';
+                result.container = watchContainer;
+                result.shouldProcess = cachedSettings?.saveRegularVideos !== false;
+                return result;
+            }
+
+            // Fallback: intentar encontrar cualquier contenedor conocido
+            const anyContainer = videoElement.closest('[id*="player"], [class*="player"]');
+            if (anyContainer) {
+                result.type = 'unknown';
+                result.container = anyContainer;
+            }
+
+        } catch (_) { }
+
+        return result;
     }
 
     // ------------------------------------------
@@ -3942,6 +5127,250 @@ background: var(--ypp-danger);
     }
 
     // ------------------------------------------
+    // MARK: 📺 VideoInfoFacade - Unified Metadata Interface
+    // ------------------------------------------
+    /**
+     * Facade para extracción unificada de metadatos de video.
+     * Proporciona una interfaz única que delega a las funciones especializadas
+     * existentes mientras mantiene el aislamiento de contexto.
+     * 
+     * IMPORTANTE: Detecta automáticamente el contexto (shorts vs miniplayer vs watch)
+     * para evitar contaminación de datos entre players coexistentes.
+     * 
+     * @namespace VideoInfoFacade
+     */
+    const VideoInfoFacade = (() => {
+        /**
+         * Resultado estructurado de extracción de metadatos.
+         * @typedef {Object} VideoMetadata
+         * @property {string} title - Título del video
+         * @property {string} author - Nombre del canal/autor
+         * @property {string|null} authorId - ID del canal (si disponible)
+         * @property {string} thumbnail - URL de la miniatura
+         * @property {number} duration - Duración en segundos
+         * @property {string|null} views - Vistas formateadas (si disponible)
+         * @property {string|null} description - Descripción del video (si disponible)
+         * @property {number|null} published - Timestamp de publicación (si disponible)
+         * @property {boolean} isLive - Si es un livestream
+         * @property {string} context - Contexto de extracción ('shorts', 'watch', 'miniplayer', 'preview')
+         * @property {boolean} isComplete - Si se obtuvieron todos los campos básicos
+         */
+
+        /**
+         * Extrae metadatos de video con detección automática de contexto.
+         * Usa las funciones existentes pero centraliza la lógica de contexto.
+         * 
+         * @param {Object} options - Opciones de extracción
+         * @param {Object} [options.player] - Objeto player de YouTube
+         * @param {HTMLVideoElement} [options.videoElement] - Elemento <video>
+         * @param {string} [options.videoId] - ID conocido del video
+         * @param {string} [options.pageType] - Tipo de página (si se conoce)
+         * @returns {Promise<VideoMetadata>} Metadatos extraídos
+         */
+        const extract = async ({ player, videoElement, videoId, pageType } = {}) => {
+            // Determinar contexto actual
+            const context = resolveContext(videoElement, pageType);
+            log('VideoInfoFacade', `📊 Contexto resuelto: ${context.type}`);
+
+            // Obtener videoId si no se proporcionó
+            const resolvedVideoId = videoId || resolveVideoId(player, videoElement, context);
+            if (!resolvedVideoId) {
+                warn('VideoInfoFacade', '⚠️ No se pudo resolver videoId');
+                return createEmptyResult(context);
+            }
+
+            // Según el contexto, elegir estrategia de extracción
+            let metadata;
+            try {
+                if (context.type === 'shorts') {
+                    metadata = await extractForShorts(resolvedVideoId, videoElement);
+                } else if (context.type === 'miniplayer') {
+                    metadata = await extractForMiniplayer(resolvedVideoId, player);
+                } else {
+                    metadata = await extractForWatch(resolvedVideoId, player);
+                }
+            } catch (error) {
+                warn('VideoInfoFacade', `Error en extracción para ${context.type}:`, error);
+                metadata = createEmptyResult(context);
+            }
+
+            // Completar campos faltantes con fallbacks
+            return {
+                ...metadata,
+                videoId: resolvedVideoId,
+                context: context.type,
+                isComplete: !!(metadata.title && metadata.author)
+            };
+        };
+
+        /**
+         * Obtiene solo el ID del video del contexto actual.
+         * Útil para validaciones rápidas sin extraer toda la metadata.
+         * @param {Object} [options]
+         * @returns {string|null}
+         */
+        const getVideoId = ({ player, videoElement } = {}) => {
+            const context = resolveContext(videoElement);
+            return resolveVideoId(player, videoElement, context);
+        };
+
+        /**
+         * Resuelve el contexto actual basado en el elemento de video.
+         * @private
+         */
+        const resolveContext = (videoElement, pageType) => {
+            const pt = pageType || getYouTubePageType();
+            const containerId = videoElement?.closest?.('#movie_player, #shorts-player')?.id || null;
+
+            // Detectar miniplayer activo
+            const isMiniplayer = !!(
+                videoElement?.closest?.('#miniplayer') ||
+                videoElement?.closest?.('.ytp-miniplayer-ui') ||
+                videoElement?.closest?.('ytd-miniplayer')
+            );
+
+            // Detectar preview inline
+            const isInlinePreview = !!(
+                videoElement?.closest?.('#inline-preview-player') ||
+                videoElement?.closest?.('.ytp-inline-preview-ui')
+            );
+
+            if (isMiniplayer) {
+                return { type: 'miniplayer', containerId, pageType: pt };
+            }
+            if (containerId === 'shorts-player' || pt === 'shorts') {
+                return { type: 'shorts', containerId, pageType: pt };
+            }
+            if (isInlinePreview) {
+                return { type: 'preview', containerId, pageType: pt };
+            }
+            return { type: 'watch', containerId, pageType: pt };
+        };
+
+        /**
+         * Resuelve el videoId según el contexto.
+         * @private
+         */
+        const resolveVideoId = (player, videoElement, context) => {
+            // Priorizar según contexto
+            if (context.type === 'shorts') {
+                // En Shorts, priorizar URL para evitar contaminación
+                const urlData = extractOrNormalizeVideoId(location.href);
+                if (urlData?.id) return urlData.id;
+            }
+
+            // Intentar desde player
+            try {
+                const playerId = player?.getVideoData?.()?.video_id;
+                if (playerId) return playerId;
+            } catch (_) { }
+
+            // YTHelper
+            try {
+                if (YTHelper?.video?.id) return YTHelper.video.id;
+            } catch (_) { }
+
+            // URL como fallback
+            const urlData = extractOrNormalizeVideoId(location.href);
+            return urlData?.id || null;
+        };
+
+        /**
+         * Extracción específica para Shorts.
+         * Usa extractShortsMetadata para evitar contaminación del miniplayer.
+         * @private
+         */
+        const extractForShorts = async (videoId, videoElement) => {
+            // Usar función especializada que detecta el Short ACTIVO
+            const shortsMeta = extractShortsMetadata();
+            const duration = videoElement?.duration || 0;
+
+            return {
+                title: shortsMeta.title || t('unknown'),
+                author: shortsMeta.author || getVideoAuthor(null),
+                authorId: shortsMeta.channelId || null,
+                thumbnail: `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
+                duration,
+                views: shortsMeta.views || null,
+                description: null,
+                published: null,
+                isLive: false
+            };
+        };
+
+        /**
+         * Extracción para videos en miniplayer.
+         * Usa caché de watch metadata para evitar contaminación.
+         * @private
+         */
+        const extractForMiniplayer = async (videoId, player) => {
+            // Intentar obtener metadata desde caché primero
+            try {
+                const cachedMeta = await getWatchMetaCached(videoId);
+                if (cachedMeta) {
+                    return {
+                        title: cachedMeta.title || getVideoTittle(player),
+                        author: cachedMeta.author || getVideoAuthor(player),
+                        authorId: cachedMeta.authorId || null,
+                        thumbnail: `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`,
+                        duration: cachedMeta.duration || getVideoDuration(player),
+                        views: cachedMeta.viewCount || null,
+                        description: cachedMeta.description || null,
+                        published: cachedMeta.published || null,
+                        isLive: cachedMeta.isLive || false
+                    };
+                }
+            } catch (_) { }
+
+            // Fallback a extracción estándar
+            return extractForWatch(videoId, player);
+        };
+
+        /**
+         * Extracción estándar para watch page.
+         * @private
+         */
+        const extractForWatch = async (videoId, player) => {
+            return {
+                title: getVideoTittle(player),
+                author: getVideoAuthor(player),
+                authorId: YTHelper?.video?.channelId || null,
+                thumbnail: getVideoThumbnail(videoId),
+                duration: getVideoDuration(player) || 0,
+                views: YTHelper?.video?.viewCount ? Number(YTHelper.video.viewCount).toLocaleString() : null,
+                description: YTHelper?.video?.rawDescription?.trim() || null,
+                published: YTHelper?.video?.publishDate?.getTime() || null,
+                isLive: YTHelper?.video?.isCurrentlyLive || false
+            };
+        };
+
+        /**
+         * Crea un resultado vacío para casos de error.
+         * @private
+         */
+        const createEmptyResult = (context) => ({
+            title: t('unknown'),
+            author: t('unknown'),
+            authorId: null,
+            thumbnail: '',
+            duration: 0,
+            views: null,
+            description: null,
+            published: null,
+            isLive: false,
+            context: context?.type || 'unknown',
+            isComplete: false
+        });
+
+        // API pública
+        return Object.freeze({
+            extract,
+            getVideoId,
+            resolveContext
+        });
+    })();
+
+    // ------------------------------------------
     // MARK: 🎬 Get Video Tittle
     // ------------------------------------------
 
@@ -4018,269 +5447,359 @@ background: var(--ypp-danger);
         return isValid;
     }
 
+    // ------------------------------------------
+    // MARK: 📺 Get Video Title
+    // ------------------------------------------
+    // Obtiene el título del video con validación contra datos desactualizados.
+    // Usa patrón YTHelper-first con fallbacks en cascada.
+    //
+    // CRÍTICO: validateTitle() valida contra document.title para evitar 
+    // usar títulos de videos ANTERIORES cuando navegas rápido.
     function getVideoTittle(player) {
-        // Prioridad: YouTube Helper API (evitar en Shorts por posible miniplayer)
+        // ======================================================================
+        // OPCIÓN 1: YOUTUBE HELPER API (Preferida fuera de Shorts)
+        // ======================================================================
+        // YTHelper proporciona el título confiable del player principal.
+        // NO usarlo en Shorts porque puede estar mostrando el miniplayer.
         try {
-            const pt0 = getYouTubePageType();
-            if (pt0 !== 'shorts' && YTHelper?.video?.title) {
-                log('getVideoTittle', `Título encontrado en YTHelper: ${YTHelper.video.title}`);
+            const pageType = getYouTubePageType();
+            if (pageType !== 'shorts' && YTHelper?.video?.title) {
+                log('getVideoTittle', `Título YTHelper: ${YTHelper.video.title}`);
                 if (validateTitle(YTHelper.video.title)) {
                     return YTHelper.video.title;
                 }
-                warn('getVideoTittle', '⚠️ Título de YTHelper no validado, puede ser de video previo');
+                warn('getVideoTittle', '⚠️ Título YTHelper no validado (posible video previo)');
             }
         } catch (_) {
+            // Fallback silencioso si hay error
             if (YTHelper?.video?.title && validateTitle(YTHelper.video.title)) return YTHelper.video.title;
         }
 
+        // ======================================================================
+        // OPCIÓN 2: movie_player.getVideoData() (Player principal)
+        // ======================================================================
+        // En páginas no-Shorts, el movie_player contiene el video actual.
         try {
-            const pt = getYouTubePageType();
-            if (pt !== 'shorts') {
-                const mp = document.querySelector('#movie_player');
-                const mpTitle = mp?.getVideoData?.()?.title;
+            const pageType = getYouTubePageType();
+            if (pageType !== 'shorts') {
+                const mpTitle = document.querySelector('#movie_player')?.getVideoData?.()?.title;
                 if (mpTitle) {
-                    log('getVideoTittle', `Título encontrado en movie_player.getVideoData(): ${mpTitle}`);
+                    log('getVideoTittle', `Título movie_player: ${mpTitle}`);
                     if (validateTitle(mpTitle)) {
                         return mpTitle;
                     }
-                    warn('getVideoTittle', '⚠️ Título de movie_player no validado');
+                    warn('getVideoTittle', '⚠️ Título movie_player no validado');
                 }
             }
         } catch (_) { }
 
-        // Título en Shorts: preferir encabezado propio de Shorts. Evitar #anchored-panel (pertenece a watch/miniplayer)
+        // ======================================================================
+        // OPCIÓN 3: SHORTS - Usar solo encabezado del Short activo
+        // ======================================================================
+        // En Shorts, NUNCA usar datos de miniplayer (#anchored-panel).
+        // Confiar SOLO en extractShortsMetadata().title que detecta el Short ACTIVO.
         try {
-            const ptS = getYouTubePageType();
-            if (ptS === 'shorts') {
-                // Usar helper dedicado que prioriza ytd-reel-video-renderer[is-active] #metapanel #title
-                const shortsTitleDom = extractShortsTitle();
-                if (shortsTitleDom && typeof shortsTitleDom === 'string' && shortsTitleDom.trim().length > 0) {
-                    log('getVideoTittle', `Título encontrado en Shorts DOM (sin validar contra document.title): ${shortsTitleDom}`);
-                    return shortsTitleDom.trim();
+            const pageType = getYouTubePageType();
+            if (pageType === 'shorts') {
+                const shortsTitle = extractShortsMetadata().title;
+                if (shortsTitle && typeof shortsTitle === 'string' && shortsTitle.trim().length > 0) {
+                    log('getVideoTittle', `Título Shorts: ${shortsTitle}`);
+                    return shortsTitle.trim();
                 }
-                // En Shorts, si no se encontró un título válido en su propio DOM, no usar fallbacks de watch/miniplayer
+                // En Shorts, si no hay título propio, NO usar fallbacks (evitar contaminación miniplayer)
                 return t('unknown');
-            } else {
-                const anchorTitleShorts =
-                    document.querySelector('yt-formatted-string.ytd-video-description-header-renderer')?.textContent?.trim() ||
-                    document.querySelector('#anchored-panel yt-formatted-string.style-scope.ytd-video-description-header-renderer')?.textContent?.trim();
-                if (anchorTitleShorts) {
-                    log('getVideoTittle', `Título encontrado en #anchored-panel: ${anchorTitleShorts}`);
-                    if (validateTitle(anchorTitleShorts)) {
-                        return anchorTitleShorts;
-                    }
-                    warn('getVideoTittle', '⚠️ Título de Shorts anchor no validado');
-                }
             }
         } catch (_) { }
 
-        // Selectores meta tag y window.ytInitialPlayerResponse pueden tener/regresar datos de videos previos!
+        // ======================================================================
+        // OPCIÓN 4: Panel anclado - Encabezado de video en páginas watch
+        // ======================================================================
+        // En páginas normales (watch, embed), el #anchored-panel tiene el título oficial
+        try {
+            const anchorTitle =
+                document.querySelector('yt-formatted-string.ytd-video-description-header-renderer')?.textContent?.trim() ||
+                document.querySelector('#anchored-panel yt-formatted-string.style-scope.ytd-video-description-header-renderer')?.textContent?.trim();
 
-        // Si el título está en el meta tag, usarlo
-        const metaTitleTag = document.querySelector('meta[name="title"]');
-        const metaTitle = metaTitleTag ? metaTitleTag.getAttribute('content') : null;
-        if (metaTitle) {
-            log('getVideoTittle', `Título encontrado en meta tag: ${metaTitle}`);
-            if (validateTitle(metaTitle)) {
-                return metaTitle;
+            if (anchorTitle) {
+                log('getVideoTittle', `Título #anchored-panel: ${anchorTitle}`);
+                if (validateTitle(anchorTitle)) {
+                    return anchorTitle;
+                }
+                warn('getVideoTittle', '⚠️ Título anchored-panel no validado');
             }
-            warn('getVideoTittle', '⚠️ Título de meta tag no validado, puede ser de video previo');
+        } catch (_) { }
+
+        // ======================================================================
+        // OPCIÓN 5: Meta tags HTML (consolidados)
+        // ======================================================================
+        // Meta tags pueden tener datos DESACTUALIZADOS de videos previos.
+        // Probar en orden: name="title" → og:title → twitter:title
+        //
+        // IMPORTANTE: Cada uno DEBE VALIDARSE contra document.title
+        // porque YouTube preserva metas de videos anteriores en navegación rápida.
+        const metaTitleSources = [
+            { selector: 'meta[name="title"]', name: 'meta[name="title"]' },
+            { selector: 'meta[property="og:title"]', name: 'og:title' },
+            { selector: 'meta[name="twitter:title"]', name: 'twitter:title' }
+        ];
+
+        for (const source of metaTitleSources) {
+            const metaTitle = document.querySelector(source.selector)?.getAttribute('content');
+            if (metaTitle) {
+                log('getVideoTittle', `Título ${source.name}: ${metaTitle}`);
+                if (validateTitle(metaTitle)) {
+                    return metaTitle;
+                }
+                warn('getVideoTittle', `⚠️ Título ${source.name} no validado`);
+            }
         }
 
-        // Fallback si no está en meta[name=title]
-        const metaOgTitleTag = document.querySelector('meta[property="og:title"]');
-        const metaOgTitle = metaOgTitleTag ? metaOgTitleTag.getAttribute('content') : null;
-        if (metaOgTitle) {
-            log('getVideoTittle', `Título encontrado en meta og:title: ${metaOgTitle}`);
-            if (validateTitle(metaOgTitle)) {
-                return metaOgTitle;
+        // ======================================================================
+        // OPCIÓN 6: window.ytInitialPlayerResponse (JSON incrustado)
+        // ======================================================================
+        // RIESGO ALTO: Este JSON también puede ser de un video previo.
+        // Solo usar si pasó validación.
+        try {
+            const jsonTitle = window.ytInitialPlayerResponse?.videoDetails?.title;
+            if (jsonTitle) {
+                log('getVideoTittle', `Título JSON incrustado: ${jsonTitle}`);
+                if (validateTitle(jsonTitle)) {
+                    return jsonTitle;
+                }
+                warn('getVideoTittle', '⚠️ Título JSON no validado');
             }
-            warn('getVideoTittle', '⚠️ Título de og:title no validado, puede ser de video previo');
-        }
+        } catch (_) { }
 
-        // Fallback si no está en meta[property="og:title"]
-        const metaTwitterTitleTag = document.querySelector('meta[name="twitter:title"]');
-        const metaTwitterTitle = metaTwitterTitleTag ? metaTwitterTitleTag.getAttribute('content') : null;
-        if (metaTwitterTitle) {
-            log('getVideoTittle', `Título encontrado en meta twitter:title: ${metaTwitterTitle}`);
-            if (validateTitle(metaTwitterTitle)) {
-                return metaTwitterTitle;
+        // ======================================================================
+        // OPCIÓN 7: player.getVideoData() (Fallback si no es Shorts)
+        // ======================================================================
+        // Último intento con el player pasado como parámetro.
+        // Incluye estructura completa con metadata adicional.
+        try {
+            const videoData = player?.getVideoData?.();
+            if (videoData?.title) {
+                log('getVideoTittle', `Título player.getVideoData(): ${videoData.title}`);
+                if (validateTitle(videoData.title)) {
+                    return videoData.title;
+                }
+                warn('getVideoTittle', '⚠️ Título player.getVideoData() no validado');
             }
-            warn('getVideoTittle', '⚠️ Título de twitter:title no validado, puede ser de video previo');
-        }
+        } catch (_) { }
 
-        // Fallback a JSON incrustado (CUIDADO: puede tener datos de videos previos)
-        const title = window.ytInitialPlayerResponse?.videoDetails?.title;
-        if (title) {
-            log('getVideoTittle', `Título encontrado en JSON incrustado: ${title}`);
-            if (validateTitle(title)) {
-                return title;
-            }
-            warn('getVideoTittle', '⚠️ Título de JSON incrustado no validado, puede ser de video previo');
-        }
-
-        /*
-        player.getVideoData() = {
-                "video_id": "iy4mXZN1Zzk",
-                "author": "robbiewilliamsvevo",
-                "title": "Robbie Williams - Feel",
-                "isPlayable": true,
-                "errorCode": null,
-                "video_quality": "medium",
-                "video_quality_features": [],
-                "list": "RDiy4mXZN1Zzk",
-                "backgroundable": false,
-                "eventId": "Q-AHae30KbiZ4dUPnbDByQk",
-                "cpn": "m6WhMHqg6WQd25ET",
-                "isLive": false,
-                "isWindowedLive": false,
-                "isManifestless": false,
-                "allowLiveDvr": false,
-                "isListed": true,
-                "isMultiChannelAudio": false,
-                "hasProgressBarBoundaries": false,
-                "isPremiere": false,
-                "itct": "CAAQu2kiEwitooPuxtSQAxW4TLgEHR1YMJk=",
-                "playerResponseCpn": "",
-                "progressBarStartPositionUtcTimeMillis": null,
-                "progressBarEndPositionUtcTimeMillis": null,
-                "paidContentOverlayDurationMs": 0
-            }
-        */
-
-        const videoData = player?.getVideoData?.();
-        if (videoData != null) {
-            log('getVideoTittle', `Título encontrado en player.getVideoData(): ${videoData?.title}`);
-            if (validateTitle(videoData.title)) {
-                return videoData.title;
-            }
-            warn('getVideoTittle', '⚠️ Título de player.getVideoData() no validado, puede ser de video previo');
-        }
-
-        // Fallback al DOM
-        const DOMSelectors = [
+        // ======================================================================
+        // OPCIÓN 8: Búsqueda DOM de elementos h1/title
+        // ======================================================================
+        // Selectores específicos para encontrar el h1 del video en DOM.
+        // Estos PUEDEN tener datos viejos en navegación rápida, pero son
+        // lo único disponible en algunos contextos (home, search, etc).
+        const domSelectors = [
             'ytd-watch-metadata h1 yt-formatted-string',
             'h1.ytd-watch-metadata yt-formatted-string',
             '#title h1 yt-formatted-string',
             'h1 yt-formatted-string',
             '#title h1',
             'h1.title'
-            //'h2 span.yt-core-attributed-string' // entrega el nombre pero si existe traducción activa devuelve esa version, No original.
         ];
 
-        for (const sel of DOMSelectors) {
-            const el = document.querySelector(sel);
-            const t = el?.textContent.trim();
-            if (t) {
-                log('getVideoTittle', `Título encontrado en DOM: ${t}`);
-                if (validateTitle(t)) {
-                    return t;
+        for (const selector of domSelectors) {
+            const titleElement = document.querySelector(selector);
+            const title = titleElement?.textContent?.trim();
+
+            if (title) {
+                log('getVideoTittle', `Título DOM [${selector}]: ${title}`);
+                if (validateTitle(title)) {
+                    return title;
                 }
-                warn('getVideoTittle', '⚠️ Título de DOM no validado, puede ser de video previo');
+                warn('getVideoTittle', '⚠️ Título DOM no validado');
             }
         }
 
-        // Fallback al <title> del documento, limpiando "- YouTube"
+        // ======================================================================
+        // OPCIÓN 9: <title> del documento (Último recurso)
+        // ======================================================================
+        // El <title> de la página siempre tiene el formato "Video Title - YouTube"
+        // Es menos confiable en navegación rápida, pero casi siempre existe.
         const docTitle = document.title.replace(/ - YouTube$/, '');
-        log('getVideoTittle', `Título encontrado en <title>: ${docTitle}`);
-        if (validateTitle(docTitle)) {
-            return docTitle;
+        if (docTitle) {
+            log('getVideoTittle', `Título <title>: ${docTitle}`);
+            if (validateTitle(docTitle)) {
+                return docTitle;
+            }
+            warn('getVideoTittle', '⚠️ Título <title> no validado');
         }
-        warn('getVideoTittle', '⚠️ Título de <title> no validado, puede ser de video previo');
 
-        // Si llegamos aquí, no pudimos validar ningún título
-        // Retornar el primer título encontrado con advertencia
-        warn('getVideoTittle', '⚠️ No se pudo validar ningún título, usando primer título disponible');
+        // ======================================================================
+        // FALLBACK FINAL: Sin validación (última opción)
+        // ======================================================================
+        // Si llegamos aquí, NO PUDIMOS validar ningún título.
+        // Retornar sin validación con advertencia urgente.
+        warn('getVideoTittle', '🚨 No se pudo validar título, usando sin validación');
         return YTHelper?.video?.title ||
-            anchorTitleShorts ||
-            metaTitle ||
-            metaOgTitle ||
-            metaTwitterTitle ||
-            title ||
-            videoData?.title ||
+            document.querySelector('#anchored-panel yt-formatted-string')?.textContent?.trim() ||
+            document.querySelector('meta[property="og:title"]')?.getAttribute('content') ||
+            document.querySelector('meta[name="title"]')?.getAttribute('content') ||
             docTitle ||
             t('unknown');
     }
 
-    // Función para obtener el autor del video
+    // ------------------------------------------
+    // MARK: 📺 Get Video Author
+    // ------------------------------------------
+    // Obtiene el nombre del canal/autor del video.
+    // Estrategia YTHelper-first con fallbacks consolidados y
+    // manejo especial para Shorts (evitar contaminación de miniplayer).
     function getVideoAuthor(player) {
-        const pt = getYouTubePageType();
-        // 1) Preferir author del player (movie_player) en watch/embed/home
+        const pageType = getYouTubePageType();
+
+        // ======================================================================
+        // OPCIÓN 1: YOUTUBE HELPER API (Preferida fuera de Shorts)
+        // ======================================================================
+        // YTHelper.video.channel tiene el autor del player principal.
+        // EVITAR en Shorts porque puede ser del miniplayer en background.
         try {
-            if (pt !== 'shorts') {
-                // Forzar movie_player si existe
-                const mp = document.querySelector('#movie_player');
-                const mpAuthor = mp?.getVideoData?.()?.author;
+            if (pageType !== 'shorts' && YTHelper?.video?.channel) {
+                const author = ('' + YTHelper.video.channel).trim();
+                if (author && author.length > 0 && !isPlaceholder(author)) {
+                    log('getVideoAuthor', `Autor YTHelper: ${author}`);
+                    return author;
+                }
+            }
+        } catch (_) { }
+
+        // ======================================================================
+        // OPCIÓN 2: movie_player.getVideoData() (Player principal)
+        // ======================================================================
+        // En páginas watch/embed, el movie_player tiene el autor confiable.
+        try {
+            if (pageType !== 'shorts') {
+                const mpAuthor = document.querySelector('#movie_player')?.getVideoData?.()?.author;
                 if (mpAuthor && typeof mpAuthor === 'string' && mpAuthor.trim().length > 0) {
-                    log('getVideoAuthor', `Autor encontrado en movie_player: ${mpAuthor}`);
+                    log('getVideoAuthor', `Autor movie_player: ${mpAuthor}`);
                     return mpAuthor.trim();
                 }
             }
         } catch (_) { }
 
-        // 1b) videoDetails.author (suele estar disponible en watch y es confiable)
+        // ======================================================================
+        // OPCIÓN 3: videoDetails.author (JSON incrustado)
+        // ======================================================================
+        // window.ytInitialPlayerResponse es generalmente confiable en páginas watch.
         try {
-            if (pt !== 'shorts') {
+            if (pageType !== 'shorts') {
                 const vdAuthor = window.ytInitialPlayerResponse?.videoDetails?.author;
                 if (vdAuthor && typeof vdAuthor === 'string' && vdAuthor.trim().length > 0) {
-                    log('getVideoAuthor', `Autor encontrado en videoDetails: ${vdAuthor}`);
+                    log('getVideoAuthor', `Autor videoDetails: ${vdAuthor}`);
                     return vdAuthor.trim();
                 }
             }
         } catch (_) { }
 
-        // 2) Player pasado por parámetro (evitar placeholders y evitar Shorts)
+        // ======================================================================
+        // OPCIÓN 4: Player pasado como parámetro
+        // ======================================================================
+        // Fallback a player.getVideoData() con validación contra placeholders.
+        // Necesario cuando otros métodos fallan.
         try {
-            const rawPlayerAuthor = player?.getVideoData?.()?.author;
-            const playerAuthor = typeof rawPlayerAuthor === 'string' ? rawPlayerAuthor.trim() : '';
-            const isPlaceholderAuthor = !playerAuthor || playerAuthor.toLowerCase() === 'unknown';
-            if (pt !== 'shorts' && playerAuthor && !isPlaceholderAuthor) {
-                log('getVideoAuthor', `Autor encontrado en player: ${playerAuthor}`);
-                return playerAuthor;
+            const playerAuthor = player?.getVideoData?.()?.author;
+            if (playerAuthor && typeof playerAuthor === 'string') {
+                const author = playerAuthor.trim();
+                if (author && !isPlaceholder(author)) {
+                    log('getVideoAuthor', `Autor player param: ${author}`);
+                    return author;
+                }
             }
         } catch (_) { }
 
-        // 3) En Shorts, usar solo el encabezado del reproductor de Shorts; evitar YTHelper (puede ser del miniplayer)
-        if (pt === 'shorts') {
+        // ======================================================================
+        // OPCIÓN 5: SHORTS - Encabezado específico del Short activo
+        // ======================================================================
+        // En Shorts, NUNCA usar datos de miniplayer o watch.
+        // Buscar SOLO en el metapanel del Short ACTIVO.
+        if (pageType === 'shorts') {
             try {
-                const shortsAuthorText =
-                    // Preferir metapanel del Short ACTIVO
+                const shortsAuthor =
+                    // Metapanel del Short ACTIVO (máxima prioridad)
                     document.querySelector('ytd-reel-video-renderer[is-active] #metapanel #channel-name a')?.textContent?.trim() ||
-                    // Overlay del reproductor del Short activo
+                    // Overlay del reproductor
                     document.querySelector('ytd-reel-player-overlay-renderer #metapanel #channel-name a')?.textContent?.trim() ||
-                    // Otras ubicaciones válidas
+                    // Encabezado del reproductor
                     document.querySelector('#shorts-player ytd-reel-player-header-renderer #channel-name a')?.textContent?.trim() ||
                     document.querySelector('ytd-reel-player-header-renderer #channel-name a')?.textContent?.trim() ||
+                    // Links @username en Shorts
                     document.querySelector('ytd-reel-video-renderer[is-active] #metapanel a[href^="/@"]')?.textContent?.trim() ||
                     document.querySelector('#shorts-player a[href^="/@"]')?.textContent?.trim();
-                if (shortsAuthorText && shortsAuthorText.length > 0) {
-                    log('getVideoAuthor', `Autor encontrado en Shorts DOM: ${shortsAuthorText}`);
-                    return shortsAuthorText;
+
+                if (shortsAuthor && shortsAuthor.length > 0 && !isPlaceholder(shortsAuthor)) {
+                    log('getVideoAuthor', `Autor Shorts: ${shortsAuthor}`);
+                    return shortsAuthor;
                 }
             } catch (_) { }
-            // Si no se encuentra, retornar desconocido para evitar contaminación desde miniplayer
+
+            // En Shorts, si no encontramos autor, NO usar miniplayer (evitar contaminación)
+            log('getVideoAuthor', 'No se encontró autor en Shorts, retornando unknown');
             return t('unknown');
         }
 
-        // 4) DOM selectors (fallback)
-        const domAuthor =
-            document.querySelector('link[itemprop="name"]')?.getAttribute('content') ||
-            document.querySelector('yt-button-shape#subscribe-button-shape button.yt-spec-button-shape-next')?.getAttribute('aria-label')?.replace(/^Subscribe to /, '').replace(/\.$/, '').trim() ||
-            document.querySelector('ytd-subscription-notification-toggle-button-renderer-next button.yt-spec-button-shape-next')?.getAttribute('aria-label')?.match(/for (.+)$/)?.[1]?.trim();
+        // ======================================================================
+        // OPCIÓN 6: Meta tags HTML y link elements (consolidados)
+        // ======================================================================
+        // Selectores múltiples para encontrar el autor en el DOM.
+        // En páginas watch, el <link itemprop="name"> contiene el canal.
+        const domAuthorSources = [
+            {
+                selector: 'link[itemprop="name"]',
+                getAttribute: 'content',
+                name: 'link[itemprop="name"]'
+            },
+            {
+                selector: 'yt-button-shape#subscribe-button-shape button.yt-spec-button-shape-next',
+                getAttribute: 'aria-label',
+                name: 'subscribe-button aria-label',
+                parse: (text) => text?.replace(/^Subscribe to /, '').replace(/\.$/, '').trim()
+            },
+            {
+                selector: 'ytd-subscription-notification-toggle-button-renderer-next button.yt-spec-button-shape-next',
+                getAttribute: 'aria-label',
+                name: 'subscription-toggle aria-label',
+                parse: (text) => text?.match(/for (.+)$/)?.[1]?.trim()
+            }
+        ];
 
-        if (domAuthor) {
-            log('getVideoAuthor', `Autor encontrado en DOM: ${domAuthor}`);
-            return domAuthor;
+        for (const source of domAuthorSources) {
+            const element = document.querySelector(source.selector);
+            if (!element) continue;
+
+            let author = element.getAttribute(source.getAttribute);
+            if (source.parse) {
+                author = source.parse(author);
+            }
+
+            if (author && typeof author === 'string' && author.length > 0 && !isPlaceholder(author)) {
+                log('getVideoAuthor', `Autor ${source.name}: ${author}`);
+                return author;
+            }
         }
 
-        // 5) Último intento: YTHelper fuera de Shorts si no hay nada más
-        if (YTHelper?.video?.channel) {
-            log('getVideoAuthor', `Autor fallback YTHelper: ${YTHelper.video.channel}`);
-            return ('' + YTHelper.video.channel).trim();
+        // ======================================================================
+        // FALLBACK FINAL: YTHelper solo fuera de Shorts
+        // ======================================================================
+        // Último recurso: si nada funcionó, usar YTHelper sin validación.
+        // (Ya lo intentamos al inicio, pero repetimos aquí sin validar)
+        if (pageType !== 'shorts' && YTHelper?.video?.channel) {
+            const author = ('' + YTHelper.video.channel).trim();
+            log('getVideoAuthor', `Autor YTHelper (sin validar): ${author}`);
+            return author || t('unknown');
         }
 
-        log('getVideoAuthor', 'No se pudo obtener autor, usando fallback');
+        log('getVideoAuthor', 'No se encontró autor válido');
         return t('unknown');
+    }
+
+    // Helper: detectar valores "desconocido" o placeholders
+    function isPlaceholder(value) {
+        if (!value || typeof value !== 'string') return true;
+        const lower = value.toLowerCase();
+        return lower === 'unknown' || lower === 'loading' || lower === 'loading...' || value.length === 0;
     }
 
     // ------------------------------------------
@@ -4403,78 +5922,78 @@ background: var(--ypp-danger);
      * Obtiene las vistas desde la UI de Shorts.
      * @returns {string|null} Vistas formateadas o null si no se encuentran
      */
-    function extractShortsViews() {
-        const candidates = [
-            // Metadatos del Short ACTIVO en el feed (evita contaminación)
-            'ytd-reel-video-renderer[is-active] #metapanel [aria-label*="views" i]',
-            'ytd-reel-video-renderer[is-active] #metapanel [aria-label*="visualizaciones" i]',
-            // Overlay del reproductor de Shorts (UI visible del activo)
-            'ytd-reel-player-overlay-renderer #metapanel [aria-label*="views" i]',
-            'ytd-reel-player-overlay-renderer #metapanel [aria-label*="visualizaciones" i]',
-            // Otras ubicaciones válidas para el Short activo
-            '#shorts-player [aria-label*="views" i]',
-            '#shorts-player [aria-label*="view" i]',
-            '#shorts-player [aria-label*="visualizaciones" i]',
-            '#shorts-player [aria-label*="reproducciones" i]',
-            'ytd-reel-player-header-renderer [aria-label*="views" i]',
-            'ytd-reel-player-header-renderer [aria-label*="visualizaciones" i]',
-            '#metapanel [aria-label*="views" i]',
-            '#metapanel [aria-label*="visualizaciones" i]'
-        ];
-        for (const sel of candidates) {
-            const el = document.querySelector(sel);
-            const label = el?.getAttribute?.('aria-label') || el?.textContent || '';
-            const fv = formatViewsFromLabel(label);
-            if (fv) return fv;
-        }
-        return null;
-    }
-
     /**
-     * Obtiene el título desde la UI de Shorts.
-     * @returns {string|null} Título del Short o null si no se encuentra
+     * Extrae metadatos del Short ACTIVO desde el UI (metapanel/overlay).
+     * Consolida las búsquedas de title, views, y channelId en una sola función.
+     * 
+     * OPTIMIZACIÓN: En lugar de 3 funciones separadas que buscan selectores,
+     * esta función busca el elemento raíz del Short ACTIVO una sola vez y extrae
+     * toda la información del mismo elemento, evitando múltiples querySelector.
+     * 
+     * @returns {Object} { title: string|null, views: string|null, channelId: string|null }
      */
-    function extractShortsTitle() {
-        const sels = [
-            // Preferir el metapanel del Short ACTIVO
-            'ytd-reel-video-renderer[is-active] #metapanel #title',
-            // Overlay del reproductor (corresponde al activo)
-            'ytd-reel-player-overlay-renderer #metapanel #title',
-            'ytd-reel-player-header-renderer #title',
-            'ytd-reel-player-header-renderer h2',
-            'ytd-reel-player-header-renderer h2 span.yt-core-attributed-string',
-            'ytd-reel-video-renderer[is-active] #metapanel h2 span.yt-core-attributed-string',
-            '#shorts-player #title',
-            '#metapanel #title'
-        ];
-        for (const s of sels) {
-            const t = document.querySelector(s)?.textContent?.trim();
-            if (t && t.length > 1) return t;
-        }
-        return null;
-    }
+    function extractShortsMetadata() {
+        const result = { title: null, views: null, channelId: null };
 
-    /**
-     * Extrae el channelId del Short ACTIVO desde el metapanel/overlay.
-     * En caso de no encontrarlo, retornar null (fallbacks ocurren en el caller).
-     * @returns {string|null}
-     */
-    function extractShortsChannelId() {
         try {
-            const candidates = [
-                'ytd-reel-video-renderer[is-active] #metapanel a[href*="/channel/"]',
-                'ytd-reel-player-overlay-renderer #metapanel a[href*="/channel/"]',
-                '#shorts-player #metapanel a[href*="/channel/"]'
+            // PASO 1: Buscar el contenedor raíz del metapanel activo
+            // Estos selectores apuntan a los mismos elementos, pero buscamos uno a la vez
+            const metapanelSelectors = [
+                'ytd-reel-video-renderer[is-active] #metapanel',
+                'ytd-reel-player-overlay-renderer #metapanel',
+                '#shorts-player #metapanel',
+                '#metapanel'
             ];
-            for (const sel of candidates) {
-                const href = document.querySelector(sel)?.href || '';
-                if (href.includes('/channel/')) {
-                    const id = href.split('/channel/')[1]?.split(/[/?#]/)[0];
-                    if (id && id.length > 0) return id;
+
+            let metapanel = null;
+            for (const sel of metapanelSelectors) {
+                metapanel = document.querySelector(sel);
+                if (metapanel) break;
+            }
+
+            if (!metapanel) return result;
+
+            // PASO 2: Extraer TÍTULO desde el metapanel
+            // Búsqueda consolidada: probar selectores en orden de preferencia
+            const titleSelectors = [
+                { selector: metapanel.querySelector('#title'), name: '#title' },
+                { selector: metapanel.querySelector('h2 span.yt-core-attributed-string'), name: 'h2 span.yt-core-attributed-string' },
+                { selector: metapanel.querySelector('h2'), name: 'h2' }
+            ];
+
+            for (const source of titleSelectors) {
+                const text = source.selector?.textContent?.trim();
+                if (text && text.length > 1) {
+                    result.title = text;
+                    break;
+                }
+            }
+
+            // PASO 3: Extraer VISTAS desde el metapanel
+            // Buscar elementos con aria-label que mencionen "views" o "visualizaciones"
+            const viewElements = metapanel.querySelectorAll('[aria-label*="view" i], [aria-label*="visualizaciones" i], [aria-label*="reproducciones" i]');
+            for (const el of viewElements) {
+                const label = el?.getAttribute?.('aria-label') || el?.textContent || '';
+                const formattedViews = formatViewsFromLabel(label);
+                if (formattedViews) {
+                    result.views = formattedViews;
+                    break;
+                }
+            }
+
+            // PASO 4: Extraer CHANNEL ID desde enlaces
+            // Buscar enlaces que contengan "/channel/" en href
+            const channelLink = metapanel.querySelector('a[href*="/channel/"]');
+            if (channelLink) {
+                const href = channelLink.href || '';
+                const id = href.split('/channel/')[1]?.split(/[/?#]/)[0];
+                if (id && id.length > 0) {
+                    result.channelId = id;
                 }
             }
         } catch (_) { }
-        return null;
+
+        return result;
     }
 
     // ------------------------------------------
@@ -4633,6 +6152,132 @@ background: var(--ypp-danger);
 
 
 
+
+
+
+
+
+
+
+
+    // Helper: Obtener Channel ID consolidado
+    // Consolida la lógica repetida de búsqueda de authorId entre diferentes contextos
+    async function getVideoAuthorId(videoId, isMiniPlayer, pageType) {
+        // En miniplayer: usar movie_player + caché watch metadata
+        if (isMiniPlayer) {
+            let authorId =
+                document.querySelector('#movie_player a.ytp-ce-channel-title.ytp-ce-link[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
+                document.querySelector('#movie_player a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
+                '';
+
+            try {
+                const meta = await getWatchMetaCached(videoId);
+                if (meta?.authorId) return meta.authorId;
+            } catch (_) { }
+
+            return authorId || t('unknown');
+        }
+
+        // En Shorts (sin miniplayer): usar UI de Shorts
+        if (pageType === 'shorts') {
+            let authorId = extractShortsMetadata().channelId ||
+                document.querySelector('#shorts-player a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
+                document.querySelector('ytd-reel-player-header-renderer a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
+                document.querySelector('ytd-reel-video-renderer a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
+                document.querySelector('link[rel="canonical"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
+                null;
+
+            // Fallback: videoDetails.channelId si es del mismo video
+            if (!authorId) {
+                try {
+                    const vd = window.ytInitialPlayerResponse?.videoDetails;
+                    if (vd?.videoId === videoId && vd?.channelId) {
+                        return vd.channelId;
+                    }
+                } catch (_) { }
+            }
+
+            // Fallback: YTHelper si es del mismo video
+            if (!authorId) {
+                try {
+                    const vid = YTHelper?.video?.id || YTHelper?.video?.videoId;
+                    if (YTHelper?.video?.channelId && vid === videoId) {
+                        return YTHelper.video.channelId.trim();
+                    }
+                } catch (_) { }
+            }
+
+            return authorId || t('unknown');
+        }
+
+        // En otras páginas (watch, embed, home, etc.): usar YTHelper + DOM
+        return YTHelper?.video?.channelId ||
+            document.querySelector('a[href^="/channel/"]')?.getAttribute("href")?.split("/")?.[2] ||
+            document.querySelector('#items yt-button-shape a')?.href?.split('/channel/')[1]?.split('/')[0] ||
+            t('unknown');
+    }
+
+    // Helper: Obtener vistas consolidado
+    // Consolida la búsqueda de vistas entre diferentes contextos
+    function getVideoViews(videoId, pageType, isMiniPlayer) {
+        // En Shorts sin miniplayer: no retornar vistas automáticamente
+        // (se rellenan después con extractShortsMetadata().viewsNumber o caché)
+        if (pageType === 'shorts' && !isMiniPlayer) {
+            return null;
+        }
+
+        // YTHelper: siempre disponible y confiable
+        if (YTHelper?.video?.viewCount) {
+            return Number(YTHelper.video.viewCount).toLocaleString();
+        }
+
+        // JSON incrustado: confiable en páginas watch
+        if (window.ytInitialPlayerResponse?.videoDetails?.viewCount) {
+            return Number(window.ytInitialPlayerResponse.videoDetails.viewCount).toLocaleString();
+        }
+
+        // DOM: múltiples selectores consolidados
+        const viewSelectors = [
+            '.view-count',
+            'view-count-factoid-renderer .ytwFactoidRendererFactoid[role="text"]',
+            'ytd-watch-info-text div#tooltip.tp-yt-paper-tooltip',
+            'yt-formatted-string.view-count'
+        ];
+
+        for (const selector of viewSelectors) {
+            const views = document.querySelector(selector)?.textContent ||
+                document.querySelector(selector)?.getAttribute('aria-label');
+            if (views) {
+                const extracted = views.match(/[\d.,\s]+/)?.[0]?.trim();
+                if (extracted) return extracted;
+            }
+        }
+
+        return t('notAvailable');
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    // MARK: getVideoInfo
     async function getVideoInfo(player, videoId) {
         const now = Date.now();
 
@@ -4641,9 +6286,25 @@ background: var(--ypp-danger);
         // Contexto de la página
         const ptV = getYouTubePageType();
 
-        // Título y autor
-        let title = getVideoTittle(player);
-        let author = getVideoAuthor(player);
+        // Detectar si este video está en miniplayer para evitar contaminación de datos
+        const isVideoInMiniPlayer = PlayerStateManager.isVideoInMiniPlayer(videoId);
+
+        // Título y autor - usar datos específicos del miniplayer si corresponde
+        let title, author;
+        if (isVideoInMiniPlayer) {
+            // Para miniplayer, obtener datos desde caché de watch metadata para evitar contaminación
+            try {
+                const meta = await getWatchMetaCached(videoId);
+                title = meta?.title || getVideoTittle(player);
+                author = meta?.author || getVideoAuthor(player);
+            } catch (_) {
+                title = getVideoTittle(player);
+                author = getVideoAuthor(player);
+            }
+        } else {
+            title = getVideoTittle(player);
+            author = getVideoAuthor(player);
+        }
 
         // Thumbnail
         let thumb = getVideoThumbnail(videoId)
@@ -4651,51 +6312,71 @@ background: var(--ypp-danger);
 
         // Datos adicionales para compatibilidad con FreeTube
         let published =
-            YTHelper?.video?.publishDate?.getTime() ||
-            (YTHelper?.video?.rawPublishDate ? new Date(YTHelper.video.rawPublishDate).getTime() : null);
+            YTHelper?.video?.publishDate?.getTime()
+            || (YTHelper?.video?.rawPublishDate ? new Date(YTHelper.video.rawPublishDate).getTime() : null);
 
         let description =
-            YTHelper?.video?.rawDescription?.trim() ??
-            document.querySelector('#inline-expander div#snippet.ytd-text-inline-expander yt-attributed-string')?.textContent.trim() ??
-            '';
+            YTHelper?.video?.rawDescription?.trim()
+            || document.querySelector('#inline-expander div#snippet.ytd-text-inline-expander yt-attributed-string')?.textContent.trim()
+            || '';
 
         let isLive = YTHelper?.video?.isCurrentlyLive || false;
 
         // Views (evitar contaminación en Shorts cuando no es miniplayer)
         let viewsNumber;
         try {
+            // Usar PlayerStateCache para determinar si el video está en miniplayer
+            const isVideoInMiniPlayer = PlayerStateManager.isVideoInMiniPlayer(videoId);
 
+            log('viewsnumber ptV', ptV)
 
-            let isMiniOnShortsV = false;
-            if (ptV === 'shorts') {
-                try {
-                    const mp = document.querySelector('#movie_player');
-                    const mpVid = mp?.getVideoData?.()?.video_id;
-                    if (mpVid && mpVid === videoId) isMiniOnShortsV = true;
-                    warn('viewsnumber mpVid', mpVid)
-                } catch (_) { }
-            }
-            if (ptV === 'shorts' && !isMiniOnShortsV) {
+            log('viewsnumber isVideoInMiniPlayer', isVideoInMiniPlayer)
+            log('viewsnumber YTHelper.video', YTHelper.video.viewCount)
+            log('viewsnumber ytInitialData', ytDataCache)
+
+           /*  if (ptV === 'shorts' && !isVideoInMiniPlayer) {
                 viewsNumber = null;
-                warn('viewsnumber !isMiniOnShortsV', viewsNumber)
-            } else if (YTHelper?.video?.viewCount) {
-                warn('viewsnumber YTHelper', YTHelper.video.viewCount)
+                log('viewsnumber !isMiniOnShortsV', viewsNumber)
+            } else */ if (YTHelper?.video?.viewCount) {
+                // No se usa en Shorts cuando no es miniplayer, porque regresa 0 en shorts
+                log('viewsnumber YTHelper', YTHelper.video.viewCount)
                 viewsNumber = Number(YTHelper.video.viewCount).toLocaleString();
             } else if (window.ytInitialPlayerResponse?.videoDetails?.viewCount != null) {
-                warn('viewsnumber ytInitialPlayerRespons', Number(window.ytInitialPlayerResponse.videoDetails.viewCount).toLocaleString())
+                log('viewsnumber ytInitialPlayerRespons', Number(window.ytInitialPlayerResponse.videoDetails.viewCount).toLocaleString())
                 viewsNumber = Number(window.ytInitialPlayerResponse.videoDetails.viewCount).toLocaleString();
             } else {
                 viewsNumber =
                     document.querySelector('.view-count')?.textContent?.match(/[\d.,\s]+/)?.[0].trim() ||
+                    // funciona en shorts
                     document.querySelector('view-count-factoid-renderer .ytwFactoidRendererFactoid[role="text"]')?.getAttribute('aria-label')?.match(/[\d.,\s]+/)?.[0].trim() ||
                     document.querySelector('ytd-watch-info-text div#tooltip.tp-yt-paper-tooltip')?.textContent?.match(/[\d.,\s]+/)?.[0].trim() ||
                     document.querySelector('yt-formatted-string.view-count')?.textContent?.match(/[\d.,\s]+/)?.[0].trim() ||
                     t('notAvailable');
-                warn('viewsnumber ultimo', viewsNumber)
+
+
+                log('viewsnumber .view-count', document.querySelector('.view-count')?.textContent?.match(/[\d.,\s]+/)?.[0].trim())
+                log('viewsnumber view-count-factoid-renderer', document.querySelector('view-count-factoid-renderer .ytwFactoidRendererFactoid[role="text"]')?.getAttribute('aria-label')?.match(/[\d.,\s]+/)?.[0].trim())
+                log('viewsnumber ytd-watch-info-text', document.querySelector('ytd-watch-info-text div#tooltip.tp-yt-paper-tooltip')?.textContent?.match(/[\d.,\s]+/)?.[0].trim())
+                log('viewsnumber yt-formatted-string', document.querySelector('yt-formatted-string.view-count')?.textContent?.match(/[\d.,\s]+/)?.[0].trim())
+
+
+                log('viewsnumber ultimo', viewsNumber)
             }
         } catch (_) {
             viewsNumber = t('notAvailable');
         }
+
+
+
+
+
+
+
+
+
+
+
+
 
         let videoEl = null;
         try {
@@ -4717,19 +6398,29 @@ background: var(--ypp-danger);
 
 
         let authorId;
-        let isMiniOnShorts = false;
-        try {
-            if (ptV === 'shorts') {
-                const mpChk = document.querySelector('#movie_player');
-                const mpVid = mpChk?.getVideoData?.()?.video_id;
+        // Reutilizar la detección de miniplayer ya hecha al inicio
+        const isMiniOnShorts = isVideoInMiniPlayer;
 
-                if (mpVid && mpVid === videoId) isMiniOnShorts = true;
-            }
-        } catch (_) { }
-
-        if (ptV === 'shorts' && !isMiniOnShorts) {
+        // Lógica unificada: si es miniplayer, usar datos del miniplayer independientemente de la página
+        if (isMiniOnShorts) {
+            // Miniplayer: usar datos específicos del miniplayer para evitar contaminación
+            authorId =
+                document.querySelector('#movie_player a.ytp-ce-channel-title.ytp-ce-link[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
+                document.querySelector('#movie_player a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
+                '';
+            // Fusionar con metadata de la página watch del miniplayer para asegurar datos correctos
+            try {
+                const meta = await getWatchMetaCached(videoId);
+                if (meta && meta.authorId) authorId = meta.authorId;
+                if (meta && meta.author) author = meta.author;
+                if (meta && meta.viewsNumber) viewsNumber = meta.viewsNumber;
+                if (meta && meta.title) title = meta.title;
+                if (meta && meta.description) description = meta.description;
+            } catch (_) { }
+            if (!authorId) authorId = t('unknown');
+        } else if (ptV === 'shorts') {
             // Shorts normales (sin miniplayer): primero metapanel/overlay del Short ACTIVO
-            authorId = extractShortsChannelId() ||
+            authorId = extractShortsMetadata().channelId ||
                 document.querySelector('#shorts-player a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
                 document.querySelector('ytd-reel-player-header-renderer a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
                 document.querySelector('ytd-reel-video-renderer a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
@@ -4737,8 +6428,6 @@ background: var(--ypp-danger);
                 document.querySelector('meta[property="og:url"]')?.content?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
                 document.querySelector('link[itemprop="url"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
                 null;
-
-            warn('authorId 11111', YTHelper?.video.id)
 
             // Fallback seguro: usar videoDetails.channelId si pertenece al mismo Short
             if (!authorId) {
@@ -4774,12 +6463,12 @@ background: var(--ypp-danger);
 
             // En Shorts, intentar forzar título y vistas desde su propia UI (evitar contaminación del miniplayer)
             try {
-                const sTitle = extractShortsTitle();
+                const sTitle = extractShortsMetadata().title;
                 if (sTitle && typeof sTitle === 'string' && sTitle.trim().length > 1) title = sTitle.trim();
             } catch (_) { }
             try {
                 if (!viewsNumber || viewsNumber === t('notAvailable')) {
-                    const sViews = extractShortsViews();
+                    const sViews = extractShortsMetadata().viewsNumber;
                     if (sViews) viewsNumber = sViews;
                 }
             } catch (_) { }
@@ -4790,30 +6479,13 @@ background: var(--ypp-danger);
                     if (metaForShort && metaForShort.viewsNumber) viewsNumber = metaForShort.viewsNumber;
                 }
             } catch (_) { }
-        } else if (ptV === 'shorts' && isMiniOnShorts) {
-            // Shorts + miniplayer: NO usar window.ytInitialPlayerResponse (pertenece al Short)
-            // 1) Intentar enlaces dentro de #movie_player
-            authorId =
-                document.querySelector('#movie_player a.ytp-ce-channel-title.ytp-ce-link[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
-                document.querySelector('#movie_player a[href*="/channel/"]')?.href?.split('/channel/')[1]?.split(/[/?#]/)[0] ||
-                '';
-            // 2) Siempre fusionar con metadata de la página watch del miniplayer para asegurar author/authorId correctos
-            try {
-                const meta = await getWatchMetaCached(videoId);
-                if (meta && meta.authorId) authorId = meta.authorId;
-                if (meta && meta.author) author = meta.author;
-                if (meta && meta.viewsNumber) viewsNumber = meta.viewsNumber;
-                if (meta && meta.title) title = meta.title;
-                if (meta && meta.description) description = meta.description;
-            } catch (_) { }
-            if (!authorId) authorId = t('unknown');
         } else {
-            // Páginas normales (watch, embed, home, etc.)
+            // Páginas normales (watch, embed, home, etc.) sin miniplayer
             authorId =
                 YTHelper?.video?.channelId ||
                 document.querySelector('a[href^="/channel/"]')
                     .getAttribute("href") // "/channel/UCYfdidRxbB8Qhf0Nx7ioOYw/videos"
-                    .split("/")[2] || // "UCYfdidRxbB8Qhf0Nx7ioOYw" 
+                    .split("/")[2] || // "UCYfdidRxbB8Qhf0Nx7ioOYw"
 
                 //window.ytInitialPlayerResponse?.videoDetails?.channelId ||
                 //document.querySelector('#upload-info a.yt-simple-endpoint')?.href?.split('/channel/')[1] ||
@@ -4861,7 +6533,7 @@ background: var(--ypp-danger);
             if (ptV === 'shorts' && !isMiniOnShorts) {
                 if (!title || title === t('unknown')) {
                     try {
-                        const sTitle2 = extractShortsTitle();
+                        const sTitle2 = extractShortsMetadata().title;
                         if (sTitle2 && typeof sTitle2 === 'string' && sTitle2.trim().length > 1) {
                             title = sTitle2.trim();
                         }
@@ -4974,124 +6646,199 @@ background: var(--ypp-danger);
 
 
 
-    // ------------------------------------------
-    // MARK: 📺 get Video Duration
-    // ------------------------------------------
 
+
+
+    // ------------------------------------------
+    // MARK: 📺 Get Video Duration
+    // ------------------------------------------
+    // Obtiene la duración del video en segundos con decimales cuando es posible.
+    // Usa patrón YTHelper-first y consolida búsquedas repetidas.
+    //
+    // IMPORTANTE: Algunos métodos (meta tags, time display) NO dan decimales (275 vs 275.421).
+    // El objetivo es conseguir decimales cuando sea posible para precisión.
     function getVideoDuration(player, videoEl) {
         const nowTs = Date.now();
-        const canLogDur = nowTs - lastDurationLog > 2000;
-        if (canLogDur) lastDurationLog = nowTs;
-        let duration;
+        const canLog = nowTs - lastDurationLog > 2000;
+        if (canLog) lastDurationLog = nowTs;
 
-        // Player directo
-        // 275.421
-        duration = player?.getDuration?.();
-        if (canLogDur) log('getVideoDuration', 'duración player.getDuration', duration)
-        if (duration && duration > 0 && !isNaN(duration)) return duration;
-
-        // movie_player global
-        // 275.421
-        // Evitar este fallback si estamos en Shorts o si el elemento pertenece a shorts-player
-        let ptNow = null; let contId = null;
+        // Detectar contexto: Shorts o Watch/Embed (evitar mezclar datos)
+        let pageType = null;
+        let containerType = null;
         try {
-            ptNow = getYouTubePageType();
-            contId = videoEl?.closest?.('#movie_player, #shorts-player')?.id || null;
-            if (ptNow !== 'shorts' && contId !== 'shorts-player') {
-                duration = document.querySelector('#movie_player')?.getDuration?.();
-                if (canLogDur) log('getVideoDuration', 'duración movie_player.getDuration', duration)
-                if (duration && duration > 0 && !isNaN(duration)) return duration;
-            } else if (canLogDur) {
-                log('getVideoDuration', '⛔ Omitiendo movie_player.getDuration por contexto Shorts');
+            pageType = getYouTubePageType();
+            containerType = videoEl?.closest?.('#movie_player, #shorts-player')?.id || null;
+            const isShortsContext = pageType === 'shorts' || containerType === 'shorts-player';
+            if (canLog && isShortsContext) {
+                log('getVideoDuration', '⏭ Contexto Shorts detectado, evitando YTHelper/meta tags');
             }
         } catch (_) { }
 
-        // PlayerObject
-        // 275.421
-        duration = player?.playerObject?.getDuration?.();
-        if (canLogDur) log('getVideoDuration', 'duración playerObject.getDuration', duration)
-        if (duration && duration > 0 && !isNaN(duration)) return duration;
+        // Helper: validar que duración es válida
+        const isValid = (dur) => dur && dur > 0 && !isNaN(dur);
 
-        // Elemento video
-        // 275.421
-        duration = videoEl?.duration;
-        if (canLogDur) log('getVideoDuration', 'duración videoEl.duration', duration)
-        if (duration && duration > 0 && !isNaN(duration)) return duration;
+        // ======================================================================
+        // OPCIÓN 1: player.getDuration() (Player principal)
+        // ======================================================================
+        // El player pasado como parámetro suele ser el del player principal.
+        // Retorna decimales: 275.421
+        try {
+            const dur = player?.getDuration?.();
+            if (canLog) log('getVideoDuration', `[1] player.getDuration: ${dur}`);
+            if (isValid(dur)) return dur;
+        } catch (_) { }
 
-        // YouTube Helper API (evitar en Shorts para no contaminar con miniplayer)
-        if (ptNow !== 'shorts' && contId !== 'shorts-player') {
-            // YouTube Helper API API Proxy
-            // 275.421
-            duration = YTHelper.apiProxy.getDuration?.()
-            if (canLogDur) log('getVideoDuration', 'duración YTHelper.apiProxy.getDuration', duration)
-            if (duration && duration > 0 && !isNaN(duration)) return duration;
-
-            // YouTube Helper API (no da decimales)
-            // 275 no da decimales!
-            duration = YTHelper?.video?.lengthSeconds;
-            if (canLogDur) log('getVideoDuration', 'duración YTHelper.video.lengthSeconds', duration)
-            if (duration && duration > 0 && !isNaN(duration)) return duration;
-        } else if (canLogDur) {
-            log('getVideoDuration', '⛔ Omitiendo YTHelper.getDuration por contexto Shorts');
+        // ======================================================================
+        // OPCIÓN 2: movie_player global (Evitar en Shorts)
+        // ======================================================================
+        // En páginas watch, #movie_player.getDuration() es confiable.
+        // EN SHORTS: NUNCA usar porque puede ser del miniplayer en background.
+        if (pageType !== 'shorts' && containerType !== 'shorts-player') {
+            try {
+                const dur = document.querySelector('#movie_player')?.getDuration?.();
+                if (canLog) log('getVideoDuration', `[2] movie_player.getDuration: ${dur}`);
+                if (isValid(dur)) return dur;
+            } catch (_) { }
         }
 
-        // ytp-time-duration (no usar en Shorts y no da decimales)
-        // "4:35" -> parseTimeToSeconds -> 275 no da decimales!
-        if (ptNow !== 'shorts' && contId !== 'shorts-player') {
-            duration = document.querySelector('.ytp-time-duration')?.textContent;
-            if (canLogDur) log('getVideoDuration', 'duración document.querySelector(.ytp-time-duration).textContent', duration)
-            if (duration) {
-                const parsedDuration = parseTimeToSeconds(duration.trim());
-                if (canLogDur) log('getVideoDuration', 'duración document.querySelector(.ytp-time-duration).textContent', parsedDuration)
-                if (parsedDuration && parsedDuration > 0 && !isNaN(parsedDuration)) return parsedDuration;
+        // ======================================================================
+        // OPCIÓN 3: player.playerObject.getDuration()
+        // ======================================================================
+        // Acceso alternativo al object interno del player.
+        // Retorna decimales: 275.421
+        try {
+            const dur = player?.playerObject?.getDuration?.();
+            if (canLog) log('getVideoDuration', `[3] playerObject.getDuration: ${dur}`);
+            if (isValid(dur)) return dur;
+        } catch (_) { }
+
+        // ======================================================================
+        // OPCIÓN 4: Elemento <video> (Directo)
+        // ======================================================================
+        // Si tenemos el elemento video, su propiedad duration es lo más fiable.
+        // Retorna decimales: 275.421
+        if (videoEl) {
+            try {
+                const dur = videoEl.duration;
+                if (canLog) log('getVideoDuration', `[4] videoEl.duration: ${dur}`);
+                if (isValid(dur)) return dur;
+            } catch (_) { }
+        }
+
+        // ======================================================================
+        // OPCIÓN 5: YOUTUBE HELPER API (Evitar en Shorts)
+        // ======================================================================
+        // YTHelper proporciona acceso al player interno de YouTube.
+        // EN SHORTS: NUNCA usar porque apunta al miniplayer.
+        if (pageType !== 'shorts' && containerType !== 'shorts-player') {
+            try {
+                // Subopción 5a: YTHelper API Proxy (puede dar decimales)
+                const dur = YTHelper?.apiProxy?.getDuration?.();
+                if (canLog) log('getVideoDuration', `[5a] YTHelper.apiProxy.getDuration: ${dur}`);
+                if (isValid(dur)) return dur;
+            } catch (_) { }
+
+            try {
+                // Subopción 5b: YTHelper video.lengthSeconds (NO da decimales: 275)
+                const dur = YTHelper?.video?.lengthSeconds;
+                if (canLog) log('getVideoDuration', `[5b] YTHelper.video.lengthSeconds: ${dur}`);
+                if (isValid(dur)) return dur;
+            } catch (_) { }
+        }
+
+        // ======================================================================
+        // OPCIÓN 6: Meta tags HTML (Consolidados, Evitar en Shorts)
+        // ======================================================================
+        // Meta tags contienen duración formateada, requieren parseo.
+        // NO dan decimales después del parseo (PT4M35S = 275, no 275.421).
+        // EN SHORTS: NO usar.
+        if (pageType !== 'shorts' && containerType !== 'shorts-player') {
+            const metaSources = [
+                {
+                    selector: '.ytp-time-duration',
+                    getAttribute: 'textContent',
+                    parse: parseTimeToSeconds,
+                    name: '.ytp-time-duration (time display)'
+                },
+                {
+                    selector: 'meta[itemprop="duration"]',
+                    getAttribute: 'content',
+                    parse: parseISODuration,
+                    name: 'meta[itemprop="duration"] (ISO format)'
+                }
+            ];
+
+            for (const source of metaSources) {
+                try {
+                    let rawValue;
+                    if (source.getAttribute === 'textContent') {
+                        rawValue = document.querySelector(source.selector)?.textContent;
+                    } else {
+                        rawValue = document.querySelector(source.selector)?.getAttribute(source.getAttribute);
+                    }
+
+                    if (rawValue) {
+                        const dur = source.parse(rawValue.trim());
+                        if (canLog) log('getVideoDuration', `[6] ${source.name}: ${dur}`);
+                        if (isValid(dur)) return dur;
+                    }
+                } catch (_) { }
             }
         }
 
-        // meta[itemprop="duration"] (evitar en Shorts y no da decimales)
-        // "PT4M35S" -> parseISODuration -> 275  no da decimales!
-        if (ptNow !== 'shorts' && contId !== 'shorts-player') {
-            duration = document.querySelector('meta[itemprop="duration"]')?.content;
-            if (canLogDur) log('getVideoDuration', 'duración document.querySelector(meta[itemprop="duration"]).content', duration)
-            if (duration) {
-                const parsedDuration = parseISODuration(duration);
-                if (parsedDuration && parsedDuration > 0 && !isNaN(parsedDuration)) return parsedDuration;
-            }
-        }
+        // ======================================================================
+        // OPCIÓN 7: Elemento <video> con espera de metadatos
+        // ======================================================================
+        // Si el <video> aún no ha cargado metadatos (duration=0),
+        // esperar a que cargue usando el evento 'loadedmetadata'.
+        // Esto es async y retorna una Promise.
+        if (videoEl) {
+            try {
+                const dur = videoEl.duration;
 
-        // Si todavía no se obtuvo, probar con el <video> real
-        // 275.421
-        if (!duration || isNaN(duration) || duration === 0) {
-            if (videoEl) {
-                // Esperar a que el <video> cargue los metadatos si aún no lo ha hecho
-                if (isNaN(videoEl.duration) || videoEl.duration === 0) {
-                    // Retornar una promesa que esperará los metadatos
+                // Si ya tiene duración, retornarla
+                if (isValid(dur)) {
+                    if (canLog) log('getVideoDuration', `[7a] videoEl.duration (cached): ${dur}`);
+                    return dur;
+                }
+
+                // Si duration es 0/NaN, esperar a metadatos
+                if (isNaN(dur) || dur === 0) {
+                    if (canLog) log('getVideoDuration', '[7b] Esperando a que videoEl cargue metadatos...');
+
                     return new Promise(resolve => {
-                        const checkDuration = () => {
-                            if (!isNaN(videoEl.duration) && videoEl.duration > 0) {
-                                if (canLogDur) log('getVideoDuration', 'duración videoEl.duration (después de esperar metadatos)', videoEl.duration);
-                                resolve(videoEl.duration);
-                            } else {
-                                videoEl.addEventListener('loadedmetadata', () => {
-                                    if (canLogDur) log('getVideoDuration', 'duración videoEl.duration (después de loadedmetadata)', videoEl.duration);
-                                    resolve(videoEl.duration);
-                                }, { once: true });
-                                // Timeout por si nunca se cargan los metadatos
-                                setTimeout(() => {
-                                    if (canLogDur) log('getVideoDuration', 'timeout esperando metadatos, usando 0');
-                                    resolve(0);
-                                }, 3000);
+                        const checkAndResolve = () => {
+                            const currentDur = videoEl.duration;
+                            if (isValid(currentDur)) {
+                                if (canLog) log('getVideoDuration', `[7b] videoEl.duration (después de espera): ${currentDur}`);
+                                resolve(currentDur);
                             }
                         };
-                        checkDuration();
+
+                        // Opción 1: Ya está listo
+                        checkAndResolve();
+
+                        // Opción 2: Esperar evento
+                        if (!isValid(videoEl.duration)) {
+                            videoEl.addEventListener('loadedmetadata', checkAndResolve, { once: true });
+
+                            // Timeout: si pasan 3s sin metadatos, renunciar
+                            setTimeout(() => {
+                                if (!isValid(videoEl.duration)) {
+                                    if (canLog) log('getVideoDuration', '[7b] Timeout esperando metadatos (3s), resolviendo con 0');
+                                    resolve(0);
+                                }
+                            }, 3000);
+                        }
                     });
-                } else {
-                    duration = videoEl.duration;
-                    if (canLogDur) log('getVideoDuration', 'duración videoEl.duration (directo)', duration);
-                    return duration;
                 }
-            }
+            } catch (_) { }
         }
 
+        // ======================================================================
+        // FALLBACK FINAL: 0 (No se pudo obtener duración)
+        // ======================================================================
+        if (canLog) log('getVideoDuration', '[FALLBACK] No se pudo obtener duración válida, retornando 0');
         return 0;
     }
 
@@ -5335,12 +7082,12 @@ background: var(--ypp-danger);
             }
 
             // Verificar si hay tiempo fijo desde el URL
-            const hasFixedTime = window.location.href.includes('&t=') || window.location.href.includes('#t=');
-            log('isLiveVideo', `Tiempo fijo en URL: ${hasFixedTime}`);
-            if (hasFixedTime) {
-                log('isLiveVideo', '❌ Video tiene tiempo fijo configurado - NO es live');
-                return false;
-            }
+            /*  const hasFixedTime = window.location.href.includes('&t=') || window.location.href.includes('#t=');
+             log('isLiveVideo', `Tiempo fijo en URL: ${hasFixedTime}`);
+             if (hasFixedTime) {
+                 log('isLiveVideo', '❌ Video tiene tiempo fijo configurado - NO es live');
+                 return false;
+             } */
 
             log('isLiveVideo', '❌ NO detectado como live');
             return false;
@@ -5558,6 +7305,37 @@ background: var(--ypp-danger);
         return info;
     }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    // MARK: Update Status
+
     /**
      * Guarda el progreso del video actual
      * @param {object} player - Player de YouTube
@@ -5567,30 +7345,87 @@ background: var(--ypp-danger);
      * @returns {Promise<object>} - Resultado del guardado
      */
     const updateStatus = async (player, videoEl, type, plId, expectedVideoId) => {
+
+        const pageTypeNow = getYouTubePageType();
         // Obtener el ID desde URL
         const homeVideoCheck = await getActiveVideoElement();
         let url;
-        if (getYouTubePageType() === 'home' && homeVideoCheck) {
+
+
+
+
+        if (pageTypeNow === 'home' && homeVideoCheck) {
             let containerId = null;
             try { containerId = homeVideoCheck.closest('#movie_player, #shorts-player')?.id || null; } catch (_) { }
-            // Usar lastVideoUrl solo si el activo está en el miniplayer
-            url = (containerId === 'movie_player') ? lastVideoUrl : location.href;
+
+            if (containerId === 'movie_player') {
+                // Para miniplayer, obtener URL correcta verificando que pertenezca al video actual
+                const playerState = PlayerStateCache.getCurrentState();
+                if (playerState.hasMiniPlayer) {
+                    // Buscar URL específica del video actual en miniplayer
+                    const miniPlayerUrlSelectors = [
+                        '.ytp-miniplayer-ui a[href*="watch?v=' + expectedVideoId + '"]',
+                        '#miniplayer a[href*="watch?v=' + expectedVideoId + '"]',
+                        'ytd-miniplayer a[href*="watch?v=' + expectedVideoId + '"]',
+                        '#movie_player a[href*="watch?v=' + expectedVideoId + '"]',
+                        'a[href*="watch?v=' + expectedVideoId + '"][href*="list="]'
+                    ];
+
+                    for (const selector of miniPlayerUrlSelectors) {
+                        const anchor = document.querySelector(selector);
+                        if (anchor) {
+                            const fullUrl = anchor.href;
+                            const urlVideoId = extractOrNormalizeVideoId(fullUrl)?.id;
+                            if (urlVideoId === expectedVideoId) {
+                                url = fullUrl;
+                                log('updateStatus', `📌 URL verificada del miniplayer usada: ${url}`);
+                                break;
+                            }
+                        }
+                    }
+
+                    // Fallback a lastVideoUrl solo si pertenece al video actual
+                    if (!url && lastVideoUrl) {
+                        const lastUrlVideoId = extractOrNormalizeVideoId(lastVideoUrl)?.id;
+                        if (lastUrlVideoId === expectedVideoId) {
+                            url = lastVideoUrl;
+                            log('updateStatus', `📌 lastVideoUrl verificada usada: ${url}`);
+                        } else {
+                            // No usar URL que no pertenece al video actual
+                            url = `https://www.youtube.com/watch?v=${expectedVideoId}`;
+                            log('updateStatus', `📌 URL básica usada (lastVideoUrl no coincide): ${url}`);
+                        }
+                    }
+                } else {
+                    url = location.href;
+                }
+            } else {
+                url = location.href;
+            }
         } else {
             url = location.href;
         }
 
-        const pageTypeNow = getYouTubePageType();
+
         const urlDataNow = extractOrNormalizeVideoId(url);
         const urlIdNow = urlDataNow?.id || null;
+
+        // Para miniplayer con URL verificada, usar directamente el playlist ID de la URL
+        const playerState = PlayerStateCache.getCurrentState();
+        if (playerState.hasMiniPlayer && urlDataNow?.list) {
+            plId = urlDataNow.list;
+            log('updateStatus', `📌 Usando playlist ID de URL verificada para miniplayer: ${plId}`);
+        }
         // Fuente del playlist en este ciclo (solo se usa para Shorts)
         let playlistSource = null; // 'url' | 'anchor' | 'fallback' | null
+        let contId = null; // Identificador del contenedor (movie_player | shorts-player | null)
+        try { contId = videoEl?.closest?.('#movie_player, #shorts-player')?.id || null; } catch (_) { }
+
         try {
             if (pageTypeNow === 'shorts') {
                 // Shorts: distinguir entre contenedor de Shorts y Miniplayer
                 let p = urlDataNow?.list || null;
                 let pSource = p ? 'url' : null; // url | anchor | fallback | null
-                let contId = null;
-                try { contId = videoEl?.closest?.('#movie_player, #shorts-player')?.id || null; } catch (_) { }
 
                 if (contId === 'movie_player') {
                     // Miniplayer visible estando en página Shorts: permitir anchors del miniplayer y fallback a lastPlaylistId
@@ -5638,6 +7473,8 @@ background: var(--ypp-danger);
                 try { if ((pSource === 'url' || pSource === 'anchor') && plId) { lastPlaylistId = plId; } } catch (_) { }
                 playlistSource = pSource;
             } else {
+                // Si plId ya viene como parámetro (desde processVideo), usarlo
+                // Solo resolver si no se proporcionó plId
                 if (!plId) {
                     let p = urlDataNow?.list || null;
                     if (!p) {
@@ -5657,8 +7494,16 @@ background: var(--ypp-danger);
                     }
                     if (p) plId = p;
                     try { if (plId) lastPlaylistId = plId; } catch (_) { }
+                } else {
+                    // plId ya viene del parámetro, solo actualizar lastPlaylistId si es estable
+                    const isStableContext = (pageTypeNow === 'watch' || pageTypeNow === 'embed');
+                    if (isStableContext) {
+                        try { lastPlaylistId = plId; } catch (_) { }
+                    }
                 }
                 const isHomeishNow = pageTypeNow === 'home' || pageTypeNow === 'search' || pageTypeNow === 'channel';
+                // Solo sobrescribir plId si el actual NO es un Mix automático (RD)
+                // Los Mixes automáticos (RD) deben ser respetados y guardados como playlists válidas
                 if (isHomeishNow && lastPlaylistId && /^RD/.test(lastPlaylistId) && plId && !/^RD/.test(plId)) {
                     plId = lastPlaylistId;
                 }
@@ -5666,24 +7511,24 @@ background: var(--ypp-danger);
         } catch (_) { }
         let video_id;
         try {
-            if (pageTypeNow === 'watch' || pageTypeNow === 'embed' || pageTypeNow === 'playlist') {
-                video_id = urlIdNow || expectedVideoId || YTHelper?.video?.id || player?.getVideoData?.()?.video_id || null;
-            } else if (pageTypeNow === 'shorts') {
-                const cont = videoEl?.closest?.('#movie_player, #shorts-player');
-                if (cont?.id === 'movie_player') {
-                    const mp = document.querySelector('#movie_player');
-                    const mpId = mp?.getVideoData?.()?.video_id;
-                    // En Shorts pero con miniplayer visible: permitir expected/mpId primero
-                    video_id = expectedVideoId || mpId || player?.getVideoData?.()?.video_id || urlIdNow || YTHelper?.video?.id || null;
-                } else {
-                    // En Shorts dentro de #shorts-player: priorizar SIEMPRE el ID de la URL; no usar expectedVideoId salvo como último recurso
-                    video_id = urlIdNow || player?.getVideoData?.()?.video_id || YTHelper?.video?.id || expectedVideoId || null;
-                }
-            } else if (pageTypeNow === 'home') {
-                video_id = expectedVideoId || urlIdNow || YTHelper?.video?.id || player?.getVideoData?.()?.video_id || null;
+            // Usar PlayerStateCache para determinar el player primario y obtener video_id consistente
+            const playerInfo = PlayerStateCache.getPrimaryPlayer(expectedVideoId || urlIdNow);
+
+            if (playerInfo.playerType === 'miniplayer') {
+                // Miniplayer activo - usar el ID del miniplayer
+                const mp = document.querySelector('#movie_player');
+                video_id = mp?.getVideoData?.()?.video_id || expectedVideoId || urlIdNow || YTHelper?.video?.id || player?.getVideoData?.()?.video_id || null;
+            } else if (playerInfo.playerType === 'shorts') {
+                // Shorts player - priorizar URL para evitar contaminación del miniplayer
+                video_id = urlIdNow || player?.getVideoData?.()?.video_id || YTHelper?.video?.id || expectedVideoId || null;
             } else {
+                // Watch player o casos genéricos
                 video_id = expectedVideoId || urlIdNow || YTHelper?.video?.id || player?.getVideoData?.()?.video_id || null;
             }
+
+            // Logging mejorado con información de coexistencia
+            const coexistenceInfo = PlayerStateManager.getCoexistenceInfo();
+            log('updateStatus', `Player detectado: ${playerInfo.playerType} | Coexistencia: ${coexistenceInfo} | Video ID: ${video_id}`);
         } catch (_) {
             video_id = urlIdNow || YTHelper?.video?.id || player?.getVideoData?.()?.video_id || expectedVideoId || null;
         }
@@ -5698,60 +7543,53 @@ background: var(--ypp-danger);
         if (!videoEl || !document.contains(videoEl)) {
             try { const hv = YTHelper?.player?.videoElement; if (hv) videoEl = hv; } catch (_) { }
         }
-        // Re-enlazar al contenedor correcto para evitar contaminación entre Shorts y Miniplayer
+        // Re-enlazar al contenedor correcto usando PlayerStateCache para evitar contaminación
         try {
-            const mp = document.querySelector('#movie_player');
-            const sp = document.querySelector('#shorts-player');
-            const mpIdNow = mp?.getVideoData?.()?.video_id || null;
-            // Determinar el contenedor objetivo según el propio videoEl (no forzar movie_player en Home)
-            let targetContainerId = null;
-            try { targetContainerId = videoEl?.closest?.('#movie_player, #shorts-player')?.id || null; } catch (_) { }
-            // Si estamos en Shorts y el tipo solicitado es shorts pero el elemento proviene del miniplayer,
-            // forzar rebind al contenedor de Shorts o abortar si no está disponible.
-            // Importante: no rebindear contextos "watch" (miniplayer) solo porque la página sea Shorts;
-            // esto provocaría que el miniplayer dejara de guardar al entrar a Shorts.
-            if (type === 'shorts' && targetContainerId === 'movie_player') {
-                try {
-                    const spElTry = document.querySelector('#shorts-player video') || document.querySelector('ytd-shorts video.html5-main-video');
-                    if (spElTry) {
-                        targetContainerId = 'shorts-player';
-                        videoEl = spElTry;
-                        // En Shorts, el ID confiable es el de la URL
-                        if (urlIdNow) video_id = urlIdNow;
-                        log('updateStatus', '⤴️ Re-binding a shorts-player para evitar contaminación del miniplayer en Shorts');
-                    } else if (type === 'shorts') {
-                        log('updateStatus', '⛔ No se encontró contenedor de Shorts en contexto Shorts; no se guardará para evitar cruce');
-                        return { success: false, reason: 'shorts_container_mismatch' };
-                    }
-                } catch (_) { }
+            const playerInfo = PlayerStateCache.getPrimaryPlayer(video_id);
+
+            // Obtener el contexto correcto del player
+            const context = PlayerContexts.getContextForVideo(video_id);
+            if (context) {
+                PlayerContexts.updateLogicalType(context.containerId);
             }
-            if (!targetContainerId) {
-                if (type === 'shorts' || pageTypeNow === 'shorts') targetContainerId = 'shorts-player';
-            }
-            // No cambiar a movie_player en páginas Shorts según coincidencia de IDs; se maneja por pollers separados
-            if (targetContainerId === 'movie_player' && mp) {
-                player = mp;
+
+            // Configurar player y videoEl según el tipo detectado
+            if (playerInfo.playerType === 'miniplayer') {
+                const mp = document.querySelector('#movie_player');
+                if (mp) player = mp;
                 const veMp = document.querySelector('#movie_player video.html5-main-video');
                 if (veMp) videoEl = veMp;
-            } else if (targetContainerId === 'shorts-player') {
+            } else if (playerInfo.playerType === 'shorts') {
                 const veSp = document.querySelector('#shorts-player video') || document.querySelector('ytd-shorts video.html5-main-video');
                 if (veSp) videoEl = veSp;
-                // Siempre usar un player stub para Shorts para evitar tomar metadatos del miniplayer
+                // Usar player stub para Shorts para evitar contaminación del miniplayer
                 player = {
                     getVideoData: () => ({ video_id: urlIdNow, title: getVideoTittle(null) || null, author: getVideoAuthor(null) || null }),
                     getCurrentTime: () => { try { return videoEl?.currentTime || 0; } catch (_) { return 0; } },
                     getDuration: () => { try { return videoEl?.duration || 0; } catch (_) { return 0; } }
                 };
+            } else {
+                // Mantener configuración existente para watch player
+                const veMp = document.querySelector('#movie_player video.html5-main-video');
+                if (veMp) videoEl = veMp;
             }
-        } catch (_) { }
+
+            log('updateStatus', `Re-binding completado: ${playerInfo.playerType} | Container: ${playerInfo.containerId}`);
+        } catch (_) {
+            log('updateStatus', 'Error en re-binding, usando configuración original');
+        }
         // Obtener currentTime evitando contaminación entre Shorts y Miniplayer
         let currentTime = 0;
-        let contId = null;
-        try { contId = videoEl?.closest?.('#movie_player, #shorts-player')?.id || null; } catch (_) { }
-        // Bloqueo de contexto cruzado: en página Shorts, si el tipo pasado es 'watch' pero el contenedor es Shorts, no guardar
-        if (pageTypeNow === 'shorts' && type === 'watch' && contId === 'shorts-player') {
-            log('updateStatus', '⛔ Contexto Shorts con tipo watch y contenedor shorts-player; evitando guardado cruzado');
-            return { success: false, reason: 'context_mismatch_watch_in_shorts' };
+
+        // Validar consistencia de contexto usando PlayerStateCache
+        const playerInfo = PlayerStateCache.getPrimaryPlayer(video_id);
+        if (playerInfo.isCoexisting) {
+            // En coexistencia, verificar que el tipo solicitado coincida con el player primario
+            const expectedType = playerInfo.playerType;
+            if (type !== expectedType && type !== 'unknown') {
+                log('updateStatus', `⛔ Tipo solicitado '${type}' no coincide con player primario '${expectedType}' en coexistencia`);
+                return { success: false, reason: 'context_mismatch_coexistence' };
+            }
         }
         // Evitar guardar si es una previsualización inline y el usuario no lo habilitó
         try {
@@ -5787,6 +7625,42 @@ background: var(--ypp-danger);
             } catch (_) { }
         }
         const now = Date.now();
+
+        // VALIDACIÓN TEMPRANA: Rechazar si el tipo de contenido está deshabilitado ANTES de obtener metadata
+        log('updateStatus', `🔍 Iniciando validación temprana: type='${type}', cachedSettings=${!!cachedSettings}`);
+        try {
+
+            log('updateStatus', `📄 pageType detectado: ${pageTypeNow}`);
+            let tentativeType = type;
+
+            // Determinar tipo tentativo basado en la página y el tipo declarado
+            if (type === 'shorts' || (type === 'unknown' && pageTypeNow === 'shorts')) {
+                tentativeType = 'shorts';
+            } else if (type === 'live') {
+                tentativeType = 'live';
+            } else if (type === 'unknown' || !type.startsWith('preview_')) {
+                tentativeType = 'watch';
+            }
+            log('updateStatus', `🎯 tentativeType determinado: ${tentativeType} (basado en type='${type}')`);
+            log('updateStatus', `⚙️ cachedSettings.saveShorts=${cachedSettings?.saveShorts}, saveRegularVideos=${cachedSettings?.saveRegularVideos}, saveLiveStreams=${cachedSettings?.saveLiveStreams}`);
+
+            // Validación de configuración temprana - RECHAZA TEMPRANO si está deshabilitado
+            if (tentativeType === 'shorts' && cachedSettings?.saveShorts === false) {
+                log('updateStatus', '🛑 EARLY REJECTION: Shorts deshabilitado, omitiendo obtención de metadata');
+                return { success: false, reason: 'shorts_disabled_by_settings' };
+            }
+            if (tentativeType === 'watch' && !type.startsWith('preview_') && cachedSettings?.saveRegularVideos === false) {
+                log('updateStatus', '🛑 EARLY REJECTION: Videos regulares deshabilitados, omitiendo obtención de metadata');
+                return { success: false, reason: 'regular_videos_disabled_by_settings' };
+            }
+            if (tentativeType === 'live' && cachedSettings?.saveLiveStreams === false) {
+                log('updateStatus', '🛑 EARLY REJECTION: Livestreams deshabilitados, omitiendo obtención de metadata');
+                return { success: false, reason: 'livestreams_disabled_by_settings' };
+            }
+            log('updateStatus', '✅ Validación temprana pasada, procediendo a obtener metadata');
+        } catch (e) {
+            log('updateStatus', '⚠️ Error en validación temprana:', e);
+        }
 
         return getCachedVideoInfo(player, video_id).then(async ({ duration, ...videoInfo }) => {
             log('updateStatus', `then duration: ${duration} = ${formatTime(duration)} | current time: ${currentTime} | video_id: ${video_id}`);
@@ -5893,9 +7767,8 @@ background: var(--ypp-danger);
             }
 
             // Ajustar metadata con fuentes confiables en watch/home
-            const pageType = getYouTubePageType();
             let baseVideoInfo = { ...videoInfo };
-            if (pageType !== 'shorts') {
+            if (pageTypeNow !== 'shorts') {
                 try {
                     const mp = document.querySelector('#movie_player');
                     const mpData = mp?.getVideoData?.();
@@ -5904,7 +7777,7 @@ background: var(--ypp-danger);
                     if (mpIdNow2 && mpIdNow2 === video_id && mpAuthor) baseVideoInfo.author = mpAuthor;
                 } catch (_) { }
                 try {
-                    if (pageType === 'watch' || pageType === 'embed') {
+                    if (pageTypeNow === 'watch' || pageTypeNow === 'embed') {
                         const vdAuthor = window.ytInitialPlayerResponse?.videoDetails?.author;
                         if (vdAuthor) baseVideoInfo.author = vdAuthor;
                         const chId = window.ytInitialPlayerResponse?.videoDetails?.channelId;
@@ -5915,7 +7788,7 @@ background: var(--ypp-danger);
 
             // En páginas que no son watch (home, etc.), evitar sobreescribir metadata sensible
             const safeVideoInfo = { ...baseVideoInfo };
-            if (pageType !== 'watch' && sourceData) {
+            if (pageTypeNow !== 'watch' && sourceData) {
                 if (!safeVideoInfo.title && sourceData.title) safeVideoInfo.title = sourceData.title;
                 if ((!safeVideoInfo.author || safeVideoInfo.author === t('unknown')) && sourceData.author) safeVideoInfo.author = sourceData.author;
                 if ((!safeVideoInfo.authorId || safeVideoInfo.authorId === t('unknown')) && sourceData.authorId) safeVideoInfo.authorId = sourceData.authorId;
@@ -5941,16 +7814,22 @@ background: var(--ypp-danger);
                 }
             } catch (_) { }
 
-            // Forzar tipo "watch" si el contenedor es miniplayer/desktop player, pero nunca sobreescribir "live"
+            // Para miniplayer, si ya es preview, mantener el tipo preview, sino usar "watch"
             try {
                 if (!isLiveType && contId === 'movie_player') {
-                    finalType = 'watch';
+                    if (!(typeof finalType === 'string' && finalType.startsWith('preview_'))) {
+                        finalType = 'watch';
+                    }
+                    // Si es miniplayer Y preview, cambiar a preview_watch para mantener consistencia
+                    if (playerInfo.playerType === 'miniplayer' && finalType === 'watch') {
+                        finalType = 'preview_watch';
+                    }
                 }
             } catch (_) { }
 
             // Forzar tipo Shorts solo cuando el contenedor real es Shorts
             try {
-                if (pageType === 'shorts' && contId === 'shorts-player') {
+                if (pageTypeNow === 'shorts' && contId === 'shorts-player') {
                     finalType = 'shorts';
                 }
             } catch (_) { }
@@ -5962,8 +7841,8 @@ background: var(--ypp-danger);
             // Protección adicional: en páginas home-like, si el enlace al video_id vive dentro de contenedores de anuncio
             // o ni siquiera existe un enlace directo al watch para ese ID, no guardar (previene anuncios autoplay en Home).
             try {
-                const ptNow2 = getYouTubePageType();
-                const isHomeLike2 = (ptNow2 === 'home' || ptNow2 === 'search' || ptNow2 === 'channel' || ptNow2 === 'unknown');
+
+                const isHomeLike2 = (pageTypeNow === 'home' || pageTypeNow === 'search' || pageTypeNow === 'channel' || pageTypeNow === 'unknown');
                 const isPreviewType2 = typeof type === 'string' && type.startsWith('preview');
                 if (isHomeLike2 && isPreviewType2 && video_id) {
                     const anchors = Array.from(document.querySelectorAll(`a[href*="/watch?v=${video_id}"]`));
@@ -5986,57 +7865,39 @@ background: var(--ypp-danger);
                 }
             } catch (_) { }
 
-            // Guardar progreso en formato FreeTube (video independiente con metadata de playlist)
+            // Guardar progreso usando el sistema especializado por tipo de contenido
             const normalizedDuration = isLiveType ? ((isFinite(duration) && duration > 0) ? duration : 0) : duration;
 
-            // Preservar asociación de playlist previa cuando corresponda
+            // Determinar playlist a persistir
+            let playlistToPersist = null;
             let prevSaved = null;
             try { prevSaved = Storage.get(video_id) || null; } catch (_) { prevSaved = null; }
 
-            let playlistToPersist = null;
             if (finalType === 'shorts') {
-                // Para Shorts, solo persistir playlist si proviene explícitamente de la URL o de un anchor del propio Short
                 playlistToPersist = (plId && (playlistSource === 'url' || playlistSource === 'anchor')) ? plId : null;
             } else if (plId) {
-                // Si hay un plId en la URL, usarlo
                 playlistToPersist = plId;
             } else if (prevSaved?.lastViewedPlaylistId) {
-                // Mantener la asociación con cualquier tipo de lista de reproducción previa
                 playlistToPersist = prevSaved.lastViewedPlaylistId;
                 log('updateStatus', `Manteniendo asociación con lista de reproducción: ${playlistToPersist}`);
             }
 
-            const videoData = {
-                videoId: video_id,
-                timestamp: currentTime,
-                lastUpdated: now,
-                videoType: finalType,
-                isCompleted: isFinished,
-                duration: normalizedDuration,
-                ...safeVideoInfo,
-                // Metadatos de playlist (estilo FreeTube)
-                lastViewedPlaylistId: playlistToPersist,
-                lastViewedPlaylistType: playlistToPersist ? ((type === 'shorts') ? '' : (prevSaved?.lastViewedPlaylistType || 'channel')) : '', // 'channel', 'user', o vacío
-                lastViewedPlaylistItemId: null // YouTube no proporciona itemId, FreeTube lo usa internamente
-            };
-            videoData.thumb = `https://i.ytimg.com/vi/${video_id}/maxresdefault.jpg`;
+            // LLAMADA AL NUEVO SISTEMA: Detección de tipo + guardado especializado
+            const saveResult = saveVideoDataByType(
+                video_id,
+                currentTime,
+                normalizedDuration,
+                safeVideoInfo,
+                pageTypeNow,
+                contId,
+                videoEl,
+                isLiveType,
+                finalType,
+                playlistToPersist
+            );
 
-            try {
-                const channelUrl = videoData.authorId !== `${t('unknow')}` ? `https://www.youtube.com/channel/${videoData.authorId}` : '';
-                log('updateStatus', 'Canal final para guardar', {
-                    author: videoData.author,
-                    authorId: videoData.authorId,
-                    channelUrl: channelUrl
-                });
-            } catch (_) { }
-
-            // Siempre guardar con video_id como clave
-            Storage.set(video_id, videoData);
-            log('updateStatus', `Datos guardados para video ${video_id}${plId ? ` (playlist: ${plId})` : ''}:`, videoData);
-
-            // Si hay playlist, obtener su nombre de manera asíncrona y guardarlo en metadata de playlist
-            if (playlistToPersist) {
-                // Guardar metadata de la playlist por separado (para referencia)
+            // Procesar resultado y metadatos de playlist
+            if (saveResult.success && playlistToPersist) {
                 const playlistMetaKey = `playlist_meta_${playlistToPersist}`;
                 let playlistMeta = Storage.get(playlistMetaKey) || {
                     playlistId: playlistToPersist,
@@ -6060,10 +7921,10 @@ background: var(--ypp-danger);
                     });
                 }
 
-                return { success: true, video_id, timestamp: videoData.timestamp, playlistId: playlistToPersist };
-            } else {
-                return { success: true, video_id, timestamp: videoData.timestamp };
+                return { ...saveResult, playlistId: playlistToPersist };
             }
+
+            return saveResult;
 
         }).catch(error => {
             conError('updateStatus', 'Error en getVideoInfo:', error);
@@ -6071,6 +7932,31 @@ background: var(--ypp-danger);
         });
     };
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    // MARK: Resume playback
     const resumePlayback = async (player, vid, videoEl, savedData, type) => {
         log('resumePlayback', 'Llamado con:', { player, vid, videoEl, savedData, type });
         if (!savedData || !vid) {
@@ -6216,34 +8102,34 @@ background: var(--ypp-danger);
             const videoType = type === 'short' ? 'shorts' : 'watch';
             updateProgressBarGradient(timeToSeek, d, videoType);
         } catch (_) { }
-
-        try {
-            const saveResult = await updateStatus(player, videoEl, type, savedData?.lastViewedPlaylistId || null, vid);
-            if (saveResult?.success) {
-                log('resumePlayback', `💾 Progreso guardado post-resume para ${vid}`);
-                lastSaveTime = Date.now();
-            } else {
-                log('resumePlayback', `⚠️ No se guardó post-resume para ${vid}:`, saveResult?.reason);
-            }
-        } catch (e) {
-            conError('resumePlayback', 'Error guardando post-resume:', e);
-        }
+        /* 
+                try {
+                    const saveResult = await updateStatus(player, videoEl, type, savedData?.lastViewedPlaylistId || null, vid);
+                    if (saveResult?.success) {
+                        log('resumePlayback', `💾 Progreso guardado post-resume para ${vid}`);
+                        lastSaveTime = Date.now();
+                    } else {
+                        log('resumePlayback', `⚠️ No se guardó post-resume para ${vid}:`, saveResult?.reason);
+                    }
+                } catch (e) {
+                    conError('resumePlayback', 'Error guardando post-resume:', e);
+                } */
 
         // Asegurar re-enlace del handler de timeupdate al <video> actual tras el seek
-        try {
-            setTimeout(async () => {
-                try {
-                    warn('helper.player', YTHelper.player.playerObject)
-                    warn('helper.apiProxy', YTHelper.apiProxy.getPlayerResponse())
-                    warn('player', player)
-                    const freshPlayer = YTHelper?.player?.playerObject || player;
-                    const freshEl = await getActiveVideoElement();
-                    if (freshPlayer && (freshEl || videoEl)) {
-                        try { processVideo(freshPlayer, freshEl || videoEl); } catch (_) { }
-                    }
-                } catch (_) { }
-            }, 500);
-        } catch (_) { }
+        /*  try {
+             setTimeout(async () => {
+                 try {
+                     warn('helper.player', YTHelper.player.playerObject)
+                     warn('helper.apiProxy', YTHelper.apiProxy.getPlayerResponse())
+                     warn('player', player)
+                     const freshPlayer = YTHelper?.player?.playerObject || player;
+                     const freshEl = await getActiveVideoElement();
+                     if (freshPlayer && (freshEl || videoEl)) {
+                         try { processVideo(freshPlayer, freshEl || videoEl); } catch (_) { }
+                     }
+                 } catch (_) { }
+             }, 500);
+         } catch (_) { } */
     };
 
     let timeDisplay;
@@ -6261,6 +8147,19 @@ background: var(--ypp-danger);
     let progressPollIntervalId = null;
     let secondaryProgressPollIntervalId = null;
     let lastTimeUpdateTick = 0;
+
+    /**
+     * Obtiene el contexto actual según el video activo (fallback a movie_player).
+     * @returns {ReturnType<typeof PlayerContexts.forElement>}
+     */
+    const getActivePlayerContext = () => {
+        try {
+            const el = currentVideoEl || YTHelper?.player?.videoElement || null;
+            return PlayerContexts.forElement(el);
+        } catch (_) {
+            return PlayerContexts.get('movie_player');
+        }
+    };
 
     // Inicializa la visualización de tiempo en la barra de reproducción
     function initTimeDisplay() {
@@ -7014,19 +8913,26 @@ background: var(--ypp-danger);
             log('notifySeekOrProgress', '✅ Progreso guardado confirmado, procediendo con notificación');
         }
 
-        if (!cachedSettings) {
+        /* if (!cachedSettings) {
             try {
                 cachedSettings = await Settings.get();
             } catch (error) {
                 conError('notifySeekOrProgress', 'Error al cargar configuración para notificaciones (usaran defaults):', error);
                 cachedSettings = CONFIG.defaultSettings;
             }
-        }
+        } */
 
+        // Redundante podria ser solo alertStyle y borrar "showNotification" de todo el script
         if (cachedSettings.showNotifications === false || cachedSettings.alertStyle === 'hidden') {
-            log('notifySeekOrProgress', 'Notificaciones deshabilitadas o estilo oculto, no se muestra mensaje');
+            log('notifySeekOrProgress', 'Notificaciones deshabilitadas o estilo oculto, no se muestra mensaje durante guardado');
             return;
         }
+
+
+
+
+
+
 
         // Bloquear notificación de progreso si hay tiempo fijo o si hay un mensaje seek activo y video está pausado
         if (context === 'progress') {
@@ -7329,7 +9235,7 @@ background: var(--ypp-danger);
     }
 
     // ------------------------------------------
-    // MARK: 📺 Modal Videos
+    // MARK: processVideo
     // ------------------------------------------
     let currentVideoEl = null;
     let lastPlaylistId = null;
@@ -7353,6 +9259,8 @@ background: var(--ypp-danger);
             log('processVideo', '⏸️  ABORTANDO processVideo - Script pausado');
             return;
         }
+
+
         try {
             const pt0 = getYouTubePageType();
             if (pt0 !== 'shorts' && isAdBlockedFor('watch')) {
@@ -7362,26 +9270,26 @@ background: var(--ypp-danger);
         } catch (_) { }
 
         // Asegurar que cachedSettings esté cargado
-        if (!cachedSettings) {
-            try {
-                cachedSettings = await Settings.get();
-            } catch (error) {
-                conError('processVideo', 'Error al cargar configuración, usando defaults:', error);
-                cachedSettings = CONFIG.defaultSettings;
-            }
-        }
-        log('processVideo', `✅ cachedSettings cargado:`, cachedSettings);
+        /*   if (!cachedSettings) {
+              try {
+                  cachedSettings = await Settings.get();
+              } catch (error) {
+                  conError('processVideo', 'Error al cargar configuración, usando defaults:', error);
+                  cachedSettings = CONFIG.defaultSettings;
+              }
+          }
+          log('processVideo', `✅ cachedSettings cargado:`, cachedSettings); */
 
-        // Resetear isResuming si está stuck por mucho tiempo
-        if (isResuming) {
-            log('processVideo', '⚠️ isResuming estaba en true, reseteando por seguridad');
-            isResuming = false;
-        }
+        // Resetear isResuming si está trabado por mucho tiempo
+        /*  if (isResuming) {
+             log('processVideo', '⚠️ isResuming estaba en true, reseteando por seguridad');
+             isResuming = false;
+         } */
 
-        const activeVideoCheck = await getActiveVideoElement();
-        if (isNavigating && !activeVideoCheck) {
+        const activeVideoEl = await getActiveVideoElement();
+        if (isNavigating && !activeVideoEl) {
             log('processVideo', `isNavigating: ${isNavigating}`);
-            log('processVideo', `getActiveVideoElement(): ${activeVideoCheck}`);
+            log('processVideo', `getActiveVideoElement(): ${activeVideoEl}`);
             log('processVideo', 'Navegación en curso y no se encontró elemento de video, omitiendo procesamiento de video.');
             return;
         }
@@ -7420,68 +9328,52 @@ background: var(--ypp-danger);
             } catch (_) { }
         }
 
+        // Determinar contexto del video (miniplayer, shorts, watch, preview, etc.)
+        const videoContext = determineVideoContext(videoEl);
+        log('processVideo', `📍 Contexto del video: type=${videoContext.type}, container=${videoContext.container?.tagName || 'N/A'}, shouldProcess=${videoContext.shouldProcess}`);
+
+        // Validar si el video debe procesarse según su contexto
+        if (!videoContext.shouldProcess) {
+            log('processVideo', `⏭️  Video tipo '${videoContext.type}' no debe procesarse según configuración`);
+            return;
+        }
+
         let urlForVideoId = window.location.href;
         const pageType = getYouTubePageType();
         let videoIdDetected = null;
 
         let urlData = extractOrNormalizeVideoId(urlForVideoId);
 
-        if (pageType === 'watch' || pageType === 'embed' || pageType === 'playlist') {
-            videoIdDetected = urlData?.id || YTHelper?.video?.id || player?.getVideoData?.()?.video_id || null;
-        } else if (pageType === 'shorts') {
-            try {
-                const cont = activeVideoCheck?.closest?.('#movie_player, #shorts-player');
-                if (cont?.id === 'movie_player') {
-                    try {
-                        const mp = document.querySelector('#movie_player');
-                        const mpId = mp?.getVideoData?.()?.video_id;
-                        if (mpId) videoIdDetected = mpId;
-                    } catch (_) { }
-                }
-            } catch (_) { }
-            // Si shorts está deshabilitado, intentar forzar el ID del miniplayer si existe
-            if (!videoIdDetected) {
-                try {
-                    const shortsDisabled = cachedSettings?.saveShorts === false;
-                    if (shortsDisabled) {
-                        const mp2 = document.querySelector('#movie_player');
-                        const mp2Id = mp2?.getVideoData?.()?.video_id || null;
-                        if (mp2Id) videoIdDetected = mp2Id;
-                    }
-                } catch (_) { }
-            }
-            if (!videoIdDetected) {
-                videoIdDetected = urlData?.id || YTHelper?.video?.id || player?.getVideoData?.()?.video_id || null;
-            }
-        } else if (pageType === 'home') {
-            // Priorizar ID desde el movie_player (miniplayer en Home) para evitar tomar Shorts antiguos
-            try {
-                const mp = document.querySelector('#movie_player');
-                const mpId = mp?.getVideoData?.()?.video_id;
-                if (mpId) videoIdDetected = mpId;
-            } catch (_) { }
-            if (!videoIdDetected) {
-                try { videoIdDetected = player?.getVideoData?.()?.video_id || YTHelper?.video?.id || null; } catch (_) { }
-            }
-            if (!videoIdDetected && lastVideoUrl && activeVideoCheck) {
-                urlForVideoId = lastVideoUrl;
-                urlData = extractOrNormalizeVideoId(urlForVideoId);
-                log('processVideo', `📍 Usando lastVideoUrl para miniplayer: ${lastVideoUrl}`);
-            }
-            if (!videoIdDetected) videoIdDetected = urlData?.id;
-        } else if (pageType === 'search' || pageType === 'channel') {
-            // En búsqueda/canal, preferir movie_player (miniplayer) si existe
-            try {
-                const mp = document.querySelector('#movie_player');
-                const mpId = mp?.getVideoData?.()?.video_id;
-                if (mpId) videoIdDetected = mpId;
-            } catch (_) { }
-            if (!videoIdDetected) {
-                try { videoIdDetected = player?.getVideoData?.()?.video_id || YTHelper?.video?.id || null; } catch (_) { }
-            }
-            if (!videoIdDetected) videoIdDetected = urlData?.id;
+        // Usar PlayerStateCache para detectar el video ID correcto según el contexto
+        const playerState = PlayerStateCache.getCurrentState();
+        const primaryPlayer = PlayerStateCache.getPrimaryPlayer(urlData?.id);
+
+        if (primaryPlayer.playerType === 'miniplayer' && playerState.miniPlayerVideoId) {
+            videoIdDetected = playerState.miniPlayerVideoId;
+        } else if (primaryPlayer.playerType === 'shorts' && playerState.activeShortsVideoId) {
+            videoIdDetected = playerState.activeShortsVideoId;
+        } else if (primaryPlayer.playerType === 'watch' && playerState.activeWatchVideoId) {
+            videoIdDetected = playerState.activeWatchVideoId;
         } else {
+            // Fallback genérico
             videoIdDetected = urlData?.id || YTHelper?.video?.id || player?.getVideoData?.()?.video_id || null;
+        }
+
+        // Lógica especial para casos específicos
+        if (pageType === 'shorts' && !videoIdDetected && cachedSettings?.saveShorts === false && playerState.miniPlayerVideoId) {
+            // Si shorts está deshabilitado, intentar forzar el ID del miniplayer si existe
+            videoIdDetected = playerState.miniPlayerVideoId;
+        } else if ((pageType === 'search' || pageType === 'channel') && !videoIdDetected && playerState.miniPlayerVideoId) {
+            // En búsqueda/canal, preferir movie_player (miniplayer) si existe
+            videoIdDetected = playerState.miniPlayerVideoId;
+        }
+
+        // Último fallback usando lastVideoUrl si es necesario
+        if (!videoIdDetected && lastVideoUrl && activeVideoEl) {
+            urlForVideoId = lastVideoUrl;
+            urlData = extractOrNormalizeVideoId(urlForVideoId);
+            videoIdDetected = urlData?.id;
+            log('processVideo', `📍 Usando lastVideoUrl para miniplayer: ${lastVideoUrl}`);
         }
 
         if (!videoIdDetected) {
@@ -7509,7 +9401,75 @@ background: var(--ypp-danger);
 
             let candidate = pickListParam(urlForVideoId);
             const isHomeish = pageType === 'home' || pageType === 'search' || pageType === 'channel';
-            const contextElement = currentVideoEl || videoEl || activeVideoCheck;
+            const contextElement = currentVideoEl || videoEl || activeVideoEl;
+
+            // Para miniplayer, buscar playlist ID directamente desde la URL del miniplayer
+            const miniPlayerState = PlayerStateCache.getCurrentState();
+            if (miniPlayerState.hasMiniPlayer) {
+                try {
+                    // Intentar obtener la URL completa del miniplayer desde elementos que la contengan
+                    const miniPlayerUrlSelectors = [
+                        '.ytp-miniplayer-ui a[href*="watch?v=' + videoIdDetected + '"]',
+                        '#miniplayer a[href*="watch?v=' + videoIdDetected + '"]',
+                        'ytd-miniplayer a[href*="watch?v=' + videoIdDetected + '"]',
+                        '#movie_player a[href*="watch?v=' + videoIdDetected + '"]',
+                        // También buscar cualquier enlace que contenga el video ID actual
+                        'a[href*="watch?v=' + videoIdDetected + '"][href*="list="]'
+                    ];
+
+                    for (const selector of miniPlayerUrlSelectors) {
+                        const anchor = document.querySelector(selector);
+                        if (anchor) {
+                            const fullUrl = anchor.href;
+                            const listParam = pickListParam(fullUrl);
+                            if (listParam) {
+                                // Verificar que el video ID en la URL coincida con el video actual
+                                const urlVideoId = extractOrNormalizeVideoId(fullUrl)?.id;
+                                if (urlVideoId === videoIdDetected) {
+                                    candidate = listParam;
+                                    log('processVideo', `📌 plId confirmado desde URL completa del miniplayer (${selector}): ${candidate}`);
+                                    // Actualizar urlForVideoId con la URL completa si encontramos una
+                                    if (!urlForVideoId.includes('list=') && fullUrl.includes('list=')) {
+                                        urlForVideoId = fullUrl;
+                                        log('processVideo', `🔄 URL actualizada para miniplayer: ${urlForVideoId}`);
+                                    }
+                                    break;
+                                } else {
+                                    log('processVideo', `⚠️ URL del miniplayer no coincide con video actual (${urlVideoId} ≠ ${videoIdDetected}), ignorando playlist ID`);
+                                }
+                            }
+                        }
+                    }
+
+                    // Si no encontramos en enlaces específicos, buscar cualquier enlace del miniplayer con list
+                    if (!candidate) {
+                        const miniPlayerSelectors = [
+                            '.ytp-miniplayer-ui a[href*="list="]',
+                            '#miniplayer a[href*="list="]',
+                            'ytd-miniplayer a[href*="list="]',
+                            '#movie_player a[href*="list="]'
+                        ];
+
+                        for (const selector of miniPlayerSelectors) {
+                            const anchor = document.querySelector(selector);
+                            if (anchor) {
+                                const u = new URL(anchor.href, location.origin);
+                                const l = u.searchParams.get('list');
+                                const urlVideoId = u.searchParams.get('v');
+                                if (l && urlVideoId === videoIdDetected) {
+                                    candidate = l;
+                                    log('processVideo', `📌 plId confirmado desde miniplayer genérico (${selector}): ${candidate}`);
+                                    break;
+                                } else if (l && urlVideoId !== videoIdDetected) {
+                                    log('processVideo', `⚠️ Enlace genérico no coincide con video actual (${urlVideoId} ≠ ${videoIdDetected}), ignorando`);
+                                }
+                            }
+                        }
+                    }
+                } catch (error) {
+                    log('processVideo', `⚠️ Error buscando playlist ID en miniplayer: ${error.message}`);
+                }
+            }
 
             if (!candidate && isHomeish) {
                 try {
@@ -7557,7 +9517,10 @@ background: var(--ypp-danger);
                 } catch (_) { }
             }
 
-            if (!candidate && isHomeish && lastPlaylistId) {
+            // Solo usar lastPlaylistId si no hay información específica del miniplayer
+            // y si estamos seguros de que el video pertenece a esa playlist
+            if (!candidate && isHomeish && lastPlaylistId && !miniPlayerState.hasMiniPlayer) {
+                log('processVideo', `🔄 Usando lastPlaylistId como fallback (no miniplayer): ${lastPlaylistId}`);
                 candidate = lastPlaylistId;
             }
 
@@ -7569,13 +9532,7 @@ background: var(--ypp-danger);
                 } catch (_) { }
             }
 
-            if (isHomeish && lastPlaylistId && /^RD/.test(lastPlaylistId)) {
-                if (candidate && !/^RD/.test(candidate)) {
-                    candidate = lastPlaylistId;
-                } else if (!candidate) {
-                    candidate = lastPlaylistId;
-                }
-            }
+            // No forzar playlists de recomendaciones automáticamente para todos los videos
 
             try {
                 if (candidate) {
@@ -7592,12 +9549,33 @@ background: var(--ypp-danger);
                 } catch (_) { }
             }
 
+            // Para miniplayer, usar la URL completa que obtuvimos del miniplayer
+            if (miniPlayerState.hasMiniPlayer && videoIdDetected) {
+                try {
+                    // Si ya tenemos una URL completa del miniplayer verificada, usarla
+                    if (urlForVideoId && urlForVideoId.includes('watch?v=') && urlForVideoId.includes('list=') &&
+                        extractOrNormalizeVideoId(urlForVideoId)?.id === videoIdDetected) {
+                        lastVideoUrl = urlForVideoId;
+                        log('processVideo', `📌 URL completa verificada del miniplayer usada: ${lastVideoUrl}`);
+                    } else {
+                        // Fallback: construir URL sin playlist ID si no está confirmado
+                        lastVideoUrl = `https://www.youtube.com/watch?v=${videoIdDetected}`;
+                        log('processVideo', `📌 URL básica para miniplayer (sin playlist confirmado): ${lastVideoUrl}`);
+                    }
+                } catch (error) {
+                    log('processVideo', `⚠️ Error seteando URL para miniplayer: ${error.message}`);
+                }
+            }
+
             return candidate;
         };
 
         let plId = resolvePlaylistIdForProcess();
 
-        log('processVideo', `URL del reproductor: ${window.location.href} | Video ID del reproductor: ${videoIdDetected}`);
+        // Para miniplayer, usar la URL específica del miniplayer si está disponible
+        const miniPlayerUrlState = PlayerStateCache.getCurrentState();
+        const playerUrl = miniPlayerUrlState.hasMiniPlayer && urlForVideoId ? urlForVideoId : window.location.href;
+        log('processVideo', `URL del reproductor: ${playerUrl} | Video ID del reproductor: ${videoIdDetected}`);
 
         // Conjunto para rastrear videos que están siendo procesados actualmente
         const currentlyProcessingVideos = new Set();
@@ -7621,11 +9599,12 @@ background: var(--ypp-danger);
                 log('processVideo', `🔄 Tipo cambiado a 'live' porque se detectó video en vivo`);
             }
             try {
-                const cont2 = activeVideoCheck?.closest?.('#movie_player, #shorts-player');
+                const cont2 = activeVideoEl?.closest?.('#movie_player, #shorts-player');
                 const shortsDisabled = (() => { try { return cachedSettings?.saveShorts === false; } catch (_) { return false; } })();
                 const mpPresent = (() => { try { return !!(document.querySelector('#movie_player')); } catch (_) { return false; } })();
-                if (cont2?.id === 'movie_player' || (type === 'shorts' && shortsDisabled && mpPresent)) {
-                    // Si el video está en el miniplayer/movie_player, tratar shorts/home como watch para el guardado
+                // Si el video está en el miniplayer/movie_player, tratar shorts/home como watch para el guardado
+                // SOLO cambiar si está REALMENTE en movie_player (cont2?.id === 'movie_player'), no solo porque existe
+                if (cont2?.id === 'movie_player') {
                     if (type === 'shorts' || type === 'home') type = 'watch';
                 }
             } catch (_) { }
@@ -7635,7 +9614,7 @@ background: var(--ypp-danger);
             // Determinar tipo lógico para guardado (distinguir previews)
             let logicalType = type;
             try {
-                const el = (currentVideoEl || videoEl || activeVideoCheck);
+                const el = (currentVideoEl || videoEl || activeVideoEl);
                 const cont = el?.closest?.('#movie_player, #shorts-player');
                 const isHomeish = (type !== 'watch' && type !== 'shorts' && type !== 'embed' && type !== 'live');
                 if (isHomeish && (cont?.id !== 'movie_player')) {
@@ -7668,14 +9647,14 @@ background: var(--ypp-danger);
             let allowByMiniplayer = false;
             try {
                 // Permitir procesamiento si hay un miniplayer presente aun estando en Shorts
-                const cont = activeVideoCheck?.closest?.('#movie_player, #shorts-player');
+                const cont = activeVideoEl?.closest?.('#movie_player, #shorts-player');
                 const mp = document.querySelector('#movie_player');
                 allowByMiniplayer = (!!cont && (cont.id === 'movie_player')) || !!mp;
             } catch (_) { }
-            if (!cachedSettings[typeToSetting[type]] && !(((getYouTubePageType() === 'home') || allowByMiniplayer) && activeVideoCheck)) {
+            if (!cachedSettings[typeToSetting[type]] && !(((getYouTubePageType() === 'home') || allowByMiniplayer) && activeVideoEl)) {
                 // Loguea un mensaje indicando que este tipo de video no se debe procesar
                 log('processVideo', `🛑 Tipo "${type}" no está habilitado para guardado, omitiendo.`);
-                log('processVideo', `Es home con un video activo? ${!(getYouTubePageType() === 'home' && activeVideoCheck)}`);
+                log('processVideo', `Es home con un video activo? ${!(getYouTubePageType() === 'home' && activeVideoEl)}`);
 
                 // NO detenemos el monitor - debe seguir activo para detectar ads en próximos videos
                 // El monitor se gestiona en handleNavigation y debe permanecer activo
@@ -7687,6 +9666,12 @@ background: var(--ypp-danger);
                 return;
             }
 
+            // Resetear lastResumeId si cambió el video ID (para permitir reanudación de videos en playlist)
+            if (lastResumeId && lastResumeId !== videoIdDetected) {
+                log('processVideo', `🔄 Reset lastResumeId (${lastResumeId} → ${videoIdDetected}) por cambio de video en playlist`);
+                lastResumeId = null;
+            }
+
             // Buscar progreso previo
             let savedData = getSavedVideoData(videoIdDetected, plId);
             log('processVideo', `Verificando reanudación: savedData=${!!savedData}, videoIdDetected=${videoIdDetected}, lastResumeId=${lastResumeId}, videoIdDetected === lastResumeId=${videoIdDetected === lastResumeId}`);
@@ -7695,7 +9680,7 @@ background: var(--ypp-danger);
             // Opción B: desactivar reanudación para previews inline en páginas no watch/shorts/embed (conservar miniplayer)
             let disableResumeInInlinePreview = false;
             try {
-                const cont3 = (currentVideoEl || videoEl || activeVideoCheck)?.closest?.('#movie_player, #shorts-player');
+                const cont3 = (currentVideoEl || videoEl || activeVideoEl)?.closest?.('#movie_player, #shorts-player');
                 disableResumeInInlinePreview = (type !== 'watch' && type !== 'shorts' && type !== 'embed' && cont3?.id !== 'movie_player');
             } catch (_) { }
 
@@ -7757,6 +9742,17 @@ background: var(--ypp-danger);
             const boundType = logicalType;
             const boundPlId = plId;
 
+            // Contexto por contenedor (movie_player vs shorts-player) para evitar contaminación entre players
+            const boundContainerId = getPlayerContainerId(videoEl) || getPlayerContainerId(activeVideoEl) || 'movie_player';
+            const ctx = PlayerContexts.get(boundContainerId);
+            try {
+                ctx.player = player;
+                ctx.videoEl = videoEl;
+                ctx.videoId = boundVideoId;
+                ctx.logicalType = boundType;
+                ctx.playlistId = boundPlId;
+            } catch (_) { }
+
             // Handler para guardar progreso
             let lastAdBlockedHandlerLogTs = 0; // throttle para logs repetitivos del handler
             const handler = () => {
@@ -7806,7 +9802,9 @@ background: var(--ypp-danger);
                         }
                     }
 
-                    lastTimeUpdateTick = Date.now();
+                    const nowTick = Date.now();
+                    lastTimeUpdateTick = nowTick;
+                    try { ctx.lastTimeUpdateTick = nowTick; } catch (_) { }
 
                     // Validar que aún exista un video válido
                     if (!videoIdDetected) {
@@ -7830,9 +9828,18 @@ background: var(--ypp-danger);
                     // Usar currentPageType ya definido arriba
                     const urlIdNow = extractOrNormalizeVideoId(window.location.href)?.id || null;
                     let currentId = null;
-                    try { currentId = YTHelper?.video?.id || player?.getVideoData?.()?.video_id || null; } catch (_) { }
+                    try {
+                        // Priorizar obtener del player actual primero (más confiable)
+                        currentId = player?.getVideoData?.()?.video_id || YTHelper?.video?.id || null;
+                    } catch (_) { }
                     let mpId = null;
                     try { const mp = document.querySelector('#movie_player'); mpId = mp?.getVideoData?.()?.video_id || null; } catch (_) { }
+
+                    // DEBUG: Loguear valores para identificar problema
+                    if (!currentId && !mpId && Date.now() - lastTimeUpdateTick > 3000) {
+                        log('handler', `⚠️ DEBUG: No se obtuvo video ID - urlIdNow: ${urlIdNow}, boundVideoId: ${boundVideoId}, videoIdDetected: ${videoIdDetected}`);
+                    }
+
                     let effectiveIdNow = null;
                     try {
                         const cont = (currentVideoEl || videoEl)?.closest?.('#movie_player, #shorts-player');
@@ -7847,8 +9854,27 @@ background: var(--ypp-danger);
                         effectiveIdNow = currentId || mpId || urlIdNow || videoIdDetected;
                     }
 
-                    if (effectiveIdNow && effectiveIdNow !== boundVideoId) {
-                        log('handler', `El ID del video cambió (${boundVideoId} -> ${effectiveIdNow}). Re-enlazando handler.`);
+                    // CRÍTICO: Detectar cambio de video con mejor lógica
+                    // Se dispara si:
+                    // 1. La URL cambió Y el nuevo ID es válido Y diferente
+                    // 2. O el player reporta un video_id diferente al boundVideoId
+                    const videoIdFromPlayer = currentId || mpId;
+                    const videoIdFromUrl = urlIdNow;
+
+                    // Validar que el nuevo ID es legítimo (no es el mismo y cumple validaciones)
+                    const isValidNewId = (newId) => newId && /^[a-zA-Z0-9_-]{11}$/.test(newId);
+
+                    const playerReportsChange = (videoIdFromPlayer && isValidNewId(videoIdFromPlayer) && videoIdFromPlayer !== boundVideoId);
+                    const urlReportsChange = (videoIdFromUrl && isValidNewId(videoIdFromUrl) && videoIdFromUrl !== boundVideoId);
+
+                    if (playerReportsChange || urlReportsChange) {
+                        const newVideoId = playerReportsChange ? videoIdFromPlayer : videoIdFromUrl;
+                        log('handler', `🔄 CAMBIO DE VIDEO DETECTADO: anterior=${boundVideoId}, nuevo=${newVideoId}, playerReport=${playerReportsChange}, urlReport=${urlReportsChange}`);
+
+                        // Limpiar el período de gracia post-anuncio cuando se detecta un cambio de video
+                        // Esto asegura que el nuevo video no herede el período de gracia del anterior
+                        lastAdEndTime = 0;
+
                         try {
                             videoEl.removeEventListener('timeupdate', currentTimeUpdateHandler || handler);
                         } finally {
@@ -7856,14 +9882,17 @@ background: var(--ypp-danger);
                             setTimeout(() => {
                                 currentlyProcessingVideos.delete(videoIdDetected);
                             }, 1000);
-                        } try { clearVideoInfoCache(boundVideoId); } catch (_) { }
-                        try { clearVideoInfoCache(effectiveIdNow); } catch (_) { }
+                        }
+                        try { clearVideoInfoCache(boundVideoId); } catch (_) { }
+                        try { clearVideoInfoCache(newVideoId); } catch (_) { }
+
                         if (currentPageType === 'home' || currentPageType === 'search' || currentPageType === 'channel') {
-                            lastVideoUrl = `https://www.youtube.com/watch?v=${effectiveIdNow}${boundPlId ? `&list=${boundPlId}` : ''}`;
+                            lastVideoUrl = `https://www.youtube.com/watch?v=${newVideoId}${boundPlId ? `&list=${boundPlId}` : ''}`;
                             try { if (boundPlId) lastPlaylistId = boundPlId; } catch (_) { }
                         } else if (currentPageType === 'watch' || currentPageType === 'embed') {
                             lastVideoUrl = window.location.href;
                         }
+                        log('handler', `📍 Re-procesando video... videoId=${newVideoId}, lastVideoUrl=${lastVideoUrl}`);
                         setTimeout(() => {
                             try { processVideo(player, videoEl); } catch (_) { }
                         }, 0);
@@ -7891,7 +9920,7 @@ background: var(--ypp-danger);
                     // Lógica de guardado de progreso
                     const now = Date.now();
                     const minInterval = (cachedSettings?.minSecondsBetweenSaves || CONFIG.defaultSettings.minSecondsBetweenSaves) * 1000;
-                    const lastSavedForVideo = lastSaveTimesByVideoId[boundVideoId] || 0;
+                    const lastSavedForVideo = (ctx?.lastSaveTimesByVideoId?.[boundVideoId] ?? lastSaveTimesByVideoId[boundVideoId] ?? 0);
 
                     // Para previews, usar un intervalo más corto para mejor respuesta
                     const effectiveMinInterval = isPreviewOnHomeLike ?
@@ -7905,40 +9934,45 @@ background: var(--ypp-danger);
 
                     if (now - lastSavedForVideo >= minInterval) {
                         // Llamar a updateStatus y esperar el resultado
-                        updateStatus(player, (currentVideoEl || videoEl), boundType, ((boundType === 'shorts' || currentPageType === 'shorts') ? null : boundPlId), boundVideoId).then(saveResult => {
-                            if (saveResult?.success) {
-                                log('processVideo', `✅ Progreso guardado exitosamente para ${videoIdDetected}`);
+                        updateStatus(player, (currentVideoEl || videoEl), boundType, ((boundType === 'shorts' || currentPageType === 'shorts') ? null : boundPlId), boundVideoId)
+                            .then(saveResult => {
+                                if (saveResult?.success) {
+                                    log('processVideo', `✅ Progreso guardado exitosamente para ${videoIdDetected}`);
 
-                                // Notificar solo si realmente se guardó
-                                const currentTime = player.getCurrentTime ? player.getCurrentTime() : ((currentVideoEl || videoEl)?.currentTime || 0);
-                                notifySeekOrProgress(saveResult?.timestamp ?? currentTime, 'progress', { saveResult, videoType: boundType });
-                                try { lastSaveTimesByVideoId[boundVideoId] = Date.now(); } catch (_) { }
-                            } else {
-                                log('processVideo', `⚠️ No se guardó progreso para ${videoIdDetected}:`, saveResult?.reason);
-                                // Throttle de reintentos cuando es preview inline con datos inválidos
-                                try {
-                                    if (saveResult?.reason === 'invalid_data') {
-                                        const contNow2 = (currentVideoEl || videoEl)?.closest?.('#movie_player, #shorts-player');
-                                        let pageTypeNow2 = getYouTubePageType();
-                                        const isPreviewOnHomeLike2 = (pageTypeNow2 === 'home' || pageTypeNow2 === 'search' || pageTypeNow2 === 'channel') && contNow2?.id !== 'movie_player';
-                                        if (isPreviewOnHomeLike2) {
-                                            lastSaveTimesByVideoId[boundVideoId] = Date.now();
+                                    // Notificar solo si realmente se guardó
+                                    const currentTime = player.getCurrentTime ? player.getCurrentTime() : ((currentVideoEl || videoEl)?.currentTime || 0);
+                                    notifySeekOrProgress(saveResult?.timestamp ?? currentTime, 'progress', { saveResult, videoType: boundType });
+                                    const savedTs = Date.now();
+                                    try { lastSaveTimesByVideoId[boundVideoId] = savedTs; } catch (_) { }
+                                    try { if (ctx?.lastSaveTimesByVideoId) ctx.lastSaveTimesByVideoId[boundVideoId] = savedTs; } catch (_) { }
+                                } else {
+                                    log('processVideo', `⚠️ No se guardó progreso para ${videoIdDetected}:`, saveResult?.reason);
+                                    // Throttle de reintentos cuando es preview inline con datos inválidos
+                                    try {
+                                        if (saveResult?.reason === 'invalid_data') {
+                                            const contNow2 = (currentVideoEl || videoEl)?.closest?.('#movie_player, #shorts-player');
+                                            let pageTypeNow2 = getYouTubePageType();
+                                            const isPreviewOnHomeLike2 = (pageTypeNow2 === 'home' || pageTypeNow2 === 'search' || pageTypeNow2 === 'channel') && contNow2?.id !== 'movie_player';
+                                            if (isPreviewOnHomeLike2) {
+                                                const failTs = Date.now();
+                                                lastSaveTimesByVideoId[boundVideoId] = failTs;
+                                                try { if (ctx?.lastSaveTimesByVideoId) ctx.lastSaveTimesByVideoId[boundVideoId] = failTs; } catch (_) { }
+                                            }
                                         }
-                                    }
-                                } catch (_) { }
-                            }
+                                    } catch (_) { }
+                                }
 
-                            // Actualizar barra de progreso con colores (independientemente del guardado)
-                            try {
-                                const currentTime = player.getCurrentTime ? player.getCurrentTime() : ((currentVideoEl || videoEl)?.currentTime || 0);
-                                const duration = getVideoDuration(player, (currentVideoEl || videoEl));
-                                updateProgressBarGradient(currentTime, duration, boundType);
-                            } catch (error) {
-                                // Silenciar errores para no afectar el funcionamiento principal
-                            }
-                        }).catch(error => {
-                            conError('processVideo', 'Error al guardar progreso:', error);
-                        });
+                                // Actualizar barra de progreso con colores (independientemente del guardado)
+                                try {
+                                    const currentTime = player.getCurrentTime ? player.getCurrentTime() : ((currentVideoEl || videoEl)?.currentTime || 0);
+                                    const duration = getVideoDuration(player, (currentVideoEl || videoEl));
+                                    updateProgressBarGradient(currentTime, duration, boundType);
+                                } catch (error) {
+                                    // Silenciar errores para no afectar el funcionamiento principal
+                                }
+                            }).catch(error => {
+                                conError('processVideo', 'Error al guardar progreso:', error);
+                            });
 
                         // No mover lastSaveTime aquí; se actualiza solo en éxito para permitir reintentos tempranos
                     }
@@ -7958,28 +9992,51 @@ background: var(--ypp-danger);
             } catch (_) { }
 
             // Antes de agregar el nuevo handler, elimina el anterior si existía
-            if (currentVideoEl && currentTimeUpdateHandler) {
+            const prevVideoEl = ctx?.videoEl || currentVideoEl;
+            const prevHandler = ctx?.timeupdateHandler || currentTimeUpdateHandler;
+            if (prevVideoEl && prevHandler) {
                 try {
-                    currentVideoEl.removeEventListener('timeupdate', currentTimeUpdateHandler);
+                    prevVideoEl.removeEventListener('timeupdate', prevHandler);
                     log('processVideo', '🧹 Handler anterior removido correctamente.');
                 } catch (err) {
                     warn('processVideo', `No se pudo remover el handler anterior: ${err.message}`);
                 }
             }
             // Adjuntar el nuevo handler
+            try { ctx.timeupdateHandler = handler; } catch (_) { }
+            try { ctx.videoEl = videoEl; } catch (_) { }
             currentTimeUpdateHandler = handler;
             currentVideoEl = videoEl;
             videoEl.addEventListener('timeupdate', handler);
 
-            if (timeupdateRebindIntervalId) {
+            if (ctx?.timeupdateRebindIntervalId) {
+                try { clearInterval(ctx.timeupdateRebindIntervalId); } catch (_) { }
+            } else if (timeupdateRebindIntervalId) {
                 try { clearInterval(timeupdateRebindIntervalId); } catch (_) { }
             }
             const observedHandler = handler;
             const observedVideoId = boundVideoId;
-            timeupdateRebindIntervalId = setInterval(async () => {
+            const observedUrl = window.location.href;
+            const rebindInterval = setInterval(async () => {
                 try {
+                    // NUEVO: Detectar cambio de URL/video que no dispara yt-navigate-finish
+                    const currentUrlNow = window.location.href;
+                    const currentVideoIdFromUrl = extractOrNormalizeVideoId(currentUrlNow)?.id;
+                    if (currentVideoIdFromUrl && currentVideoIdFromUrl !== observedVideoId && !isNavigating) {
+                        log('rebindInterval', `🔄 CAMBIO DE VIDEO DETECTADO POR POLLING: ${observedVideoId} -> ${currentVideoIdFromUrl}`);
+                        try { activeEl?.removeEventListener?.('timeupdate', observedHandler); } catch (_) { }
+                        setTimeout(() => {
+                            try {
+                                cleanupAll();
+                                handleNavigation();
+                            } catch (_) { }
+                        }, 0);
+                        return; // Salir del interval, se recibirá un nuevo boundVideoId
+                    }
+
                     let activeEl = null;
                     const pt = getYouTubePageType();
+
                     if (pt === 'watch' || pt === 'embed') {
                         try { activeEl = document.querySelector('#movie_player video.html5-main-video') || YTHelper?.player?.videoElement || await getActiveVideoElement(); } catch (_) { }
                     } else if (pt === 'shorts') {
@@ -7990,7 +10047,7 @@ background: var(--ypp-danger);
                             if (preferMp) {
                                 activeEl = document.querySelector('#movie_player video.html5-main-video');
                             } else if (preferSp) {
-                                activeEl = document.querySelector('#shorts-player video') || document.querySelector('ytd-shorts video.html5-main-video');
+                                activeEl = document.querySelector('#shorts-player video');
                             }
                             if (!activeEl) {
                                 // Fallbacks en orden: Shorts explícito -> helper -> cualquier activo
@@ -8000,34 +10057,31 @@ background: var(--ypp-danger);
                     } else {
                         try { activeEl = await getActiveVideoElement(); if (!activeEl) { activeEl = YTHelper?.player?.videoElement; } } catch (_) { }
                     }
-                    if (!activeEl) return;
-                    let idOk = true;
-                    try {
-                        const container = activeEl.closest('#movie_player, #shorts-player');
-                        if (container?.id === 'shorts-player') {
-                            const urlShortId = extractOrNormalizeVideoId(window.location.href)?.id || null;
-                            if (urlShortId && observedVideoId) idOk = (urlShortId === observedVideoId);
-                        } else {
-                            const vid = container?.getVideoData?.()?.video_id;
-                            if (vid && observedVideoId) idOk = (vid === observedVideoId);
-                        }
-                    } catch (_) { }
-                    if ((activeEl !== currentVideoEl || !document.contains(currentVideoEl)) && idOk) {
-                        try { currentVideoEl?.removeEventListener('timeupdate', currentTimeUpdateHandler || observedHandler); } catch (_) { }
+                    const ctxEl = ctx?.videoEl || currentVideoEl;
+                    if ((activeEl !== ctxEl || !document.contains(ctxEl)) && observedVideoId) {
+                        try { ctxEl?.removeEventListener('timeupdate', (ctx?.timeupdateHandler || currentTimeUpdateHandler || observedHandler)); } catch (_) { }
+                        try { if (ctx) ctx.videoEl = activeEl; } catch (_) { }
+                        try { if (ctx) ctx.timeupdateHandler = observedHandler; } catch (_) { }
+                        // Back-compat con globals
                         currentVideoEl = activeEl;
                         currentTimeUpdateHandler = observedHandler;
                         try { activeEl.addEventListener('timeupdate', observedHandler); } catch (_) { }
                     }
                 } catch (_) { }
             }, 1000);
+            try { ctx.timeupdateRebindIntervalId = rebindInterval; } catch (_) { }
+            timeupdateRebindIntervalId = rebindInterval;
 
-            if (progressPollIntervalId) {
+            if (ctx?.progressPollIntervalId) {
+                try { clearInterval(ctx.progressPollIntervalId); } catch (_) { }
+            } else if (progressPollIntervalId) {
                 try { clearInterval(progressPollIntervalId); } catch (_) { }
             }
-            progressPollIntervalId = setInterval(async () => {
+            const pollInterval = setInterval(async () => {
                 try {
                     const nowTs = Date.now();
-                    if (nowTs - lastTimeUpdateTick <= 2500) return; // timeupdate activo, no hace falta fallback
+                    const lastTick = (ctx?.lastTimeUpdateTick ?? lastTimeUpdateTick);
+                    if (nowTs - lastTick <= 2500) return; // timeupdate activo, no hace falta fallback
                     if (isNavigating || isAdBlockedFor(boundType)) return;
 
                     let activeEl = null;
@@ -8051,7 +10105,8 @@ background: var(--ypp-danger);
                     if (effectiveIdNow && effectiveIdNow !== boundVideoId) return;
 
                     const minInterval = (cachedSettings?.minSecondsBetweenSaves || CONFIG.defaultSettings.minSecondsBetweenSaves) * 1000;
-                    if (nowTs - lastSaveTime < minInterval) return;
+                    const ctxLastSave = (ctx?.lastSaveTime ?? lastSaveTime);
+                    if (nowTs - ctxLastSave < minInterval) return;
 
                     updateStatus(effPlayer, activeEl, boundType, ((boundType === 'shorts' || pageTypeNow === 'shorts') ? null : boundPlId), boundVideoId).then(saveResult => {
                         if (saveResult?.success) {
@@ -8061,27 +10116,27 @@ background: var(--ypp-danger);
                         } else {
                             log('processVideo', `⚠️ No se guardó progreso para ${boundVideoId}:`, saveResult?.reason);
                         }
-                        try {
-                            const currentTime = effPlayer.getCurrentTime ? effPlayer.getCurrentTime() : (activeEl?.currentTime || 0);
-                            const duration = getVideoDuration(effPlayer, activeEl);
-                            updateProgressBarGradient(currentTime, duration, boundType);
-                        } catch (_) { }
+                        try { ctx.lastSaveTime = nowTs; } catch (_) { }
+                        lastSaveTime = nowTs;
                     }).catch(err => {
                         conError('processVideo', 'Error al guardar progreso (poller):', err);
                     });
-
-                    lastSaveTime = nowTs;
                 } catch (_) { }
             }, 1000);
+            try { ctx.progressPollIntervalId = pollInterval; } catch (_) { }
+            progressPollIntervalId = pollInterval;
 
-            if (secondaryProgressPollIntervalId) {
+            if (ctx?.secondaryProgressPollIntervalId) {
+                try { clearInterval(ctx.secondaryProgressPollIntervalId); } catch (_) { }
+            } else if (secondaryProgressPollIntervalId) {
                 try { clearInterval(secondaryProgressPollIntervalId); } catch (_) { }
             }
-            secondaryProgressPollIntervalId = setInterval(async () => {
+            const secondaryInterval = setInterval(async () => {
                 try {
                     if (isNavigating) return;
                     const pageTypeNow2 = getYouTubePageType();
                     if (pageTypeNow2 !== 'shorts') return;
+
                     const mpC = document.querySelector('#movie_player');
                     const spC = document.querySelector('#shorts-player');
                     if (!mpC && !spC) return;
@@ -8093,10 +10148,11 @@ background: var(--ypp-danger);
                     try { mpId3 = mpC?.getVideoData?.()?.video_id || null; } catch (_) { }
                     const urlIdNow2 = extractOrNormalizeVideoId(window.location.href)?.id || null;
                     if (mpEl2 && !mpEl2.paused && mpId3 && mpId3 !== boundVideoId && !isAdBlockedFor('watch')) {
-                        const lastSavedMp = lastSaveTimesByVideoId[mpId3] || 0;
+                        const lastSavedMp = (ctx?.lastSaveTimesByVideoId?.[mpId3] ?? lastSaveTimesByVideoId[mpId3] ?? 0);
                         if (nowTs2 - lastSavedMp >= minInterval2) {
                             const mpPlayer2 = mpC && typeof mpC.getDuration === 'function' ? mpC : player;
                             try { clearVideoInfoCache(mpId3); } catch (_) { }
+
                             // Derivar playlistId del miniplayer desde lastVideoUrl o anclado
                             let mpPlId2 = boundPlId;
                             if (!mpPlId2) {
@@ -8119,14 +10175,19 @@ background: var(--ypp-danger);
                                 } */
                             }
                             updateStatus(mpPlayer2, mpEl2, 'watch', mpPlId2, mpId3).then(r => {
-                                if (r && r.success) { try { lastSaveTimesByVideoId[mpId3] = Date.now(); } catch (_) { } }
+                                if (r && r.success) {
+                                    const tsOk = Date.now();
+                                    try { lastSaveTimesByVideoId[mpId3] = tsOk; } catch (_) { }
+                                    try { if (ctx?.lastSaveTimesByVideoId) ctx.lastSaveTimesByVideoId[mpId3] = tsOk; } catch (_) { }
+                                }
                             }).catch(() => { });
                         }
                     }
+
                     if (spEl2 && !spEl2.paused && urlIdNow2 && urlIdNow2 !== boundVideoId && !isAdBlockedFor('shorts')) {
                         // Respetar configuración: no guardar shorts si está deshabilitado
                         try { if (cachedSettings?.saveShorts === false) return; } catch (_) { }
-                        const lastSavedSp = lastSaveTimesByVideoId[urlIdNow2] || 0;
+                        const lastSavedSp = (ctx?.lastSaveTimesByVideoId?.[urlIdNow2] ?? lastSaveTimesByVideoId[urlIdNow2] ?? 0);
                         if (nowTs2 - lastSavedSp >= minInterval2) {
                             const spPlayer2 = {
                                 getVideoData: () => ({ video_id: urlIdNow2, title: getVideoTittle(null) || null, author: getVideoAuthor(null) || null }),
@@ -8136,7 +10197,9 @@ background: var(--ypp-danger);
                             try { clearVideoInfoCache(urlIdNow2); } catch (_) { }
                             updateStatus(spPlayer2, spEl2, 'shorts', null, urlIdNow2).then(r => {
                                 if (r && r.success) {
-                                    try { lastSaveTimesByVideoId[urlIdNow2] = Date.now(); } catch (_) { }
+                                    const tsOk2 = Date.now();
+                                    try { lastSaveTimesByVideoId[urlIdNow2] = tsOk2; } catch (_) { }
+                                    try { if (ctx?.lastSaveTimesByVideoId) ctx.lastSaveTimesByVideoId[urlIdNow2] = tsOk2; } catch (_) { }
                                     try {
                                         const currentTime2 = spPlayer2.getCurrentTime ? spPlayer2.getCurrentTime() : (spEl2?.currentTime || 0);
                                         notifySeekOrProgress(r.timestamp ?? currentTime2, 'progress', { saveResult: r, videoType: 'shorts' });
@@ -8147,10 +10210,12 @@ background: var(--ypp-danger);
                     }
                 } catch (_) { }
             }, 1000);
+            try { ctx.secondaryProgressPollIntervalId = secondaryInterval; } catch (_) { }
+            secondaryProgressPollIntervalId = secondaryInterval;
 
             try {
                 const ptEnd = getYouTubePageType();
-                const elEnd = currentVideoEl || videoEl || activeVideoCheck;
+                const elEnd = currentVideoEl || videoEl || activeVideoEl;
                 const contEnd = elEnd?.closest?.('#movie_player');
                 const isStableEnd = (ptEnd === 'watch' || ptEnd === 'embed') || !!contEnd;
                 if (plId && isStableEnd && ptEnd !== 'shorts') lastPlaylistId = plId;
@@ -8161,6 +10226,77 @@ background: var(--ypp-danger);
             setTimeout(() => (currentlyProcessingVideoId = null), 100);
         }
     };
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     // ------------------------------------------
     // MARK: ⏯ Seek
@@ -9556,7 +11692,8 @@ background: var(--ypp-danger);
         const resumeScript = () => {
             if (isScriptPaused) {
                 isScriptPaused = false;
-                // lastAdEndTime = Date.now(); // Marcar cuándo terminó el anuncio
+                // Marcar cuándo terminó el anuncio para evitar falsos positivos
+                lastAdEndTime = Date.now();
                 log('createAdStateMonitor', '▶️  SCRIPT REANUDADO - Anuncio finalizado');
                 // Reanudar procesos principales del script
                 // El evento scriptPauseStateChanged disparará handleNavigation en el listener global
@@ -9568,6 +11705,15 @@ background: var(--ypp-danger);
             const nowTs = Date.now();
             const canLog = nowTs - lastAdCheckLog > 1000;
             if (canLog) lastAdCheckLog = nowTs;
+
+            // PERÍODO DE GRACIA: Si el anuncio acaba de terminar, dar tiempo para que el DOM se limpie
+            // Esto evita detectar falsos positivos causados por elementos 'fantasma' del anuncio
+            const AD_END_GRACE_PERIOD = 500; // 500ms de gracia después de que termina el anuncio
+            if (lastAdEndTime > 0 && nowTs - lastAdEndTime < AD_END_GRACE_PERIOD) {
+                if (canLog) log('checkAdState', `⏳ PERÍODO DE GRACIA post-anuncio (${nowTs - lastAdEndTime}ms/${AD_END_GRACE_PERIOD}ms) - ignorando detecciones`);
+                return false; // No reportar anuncios durante el período de gracia
+            }
+
             // Evitar trabajo cuando no hay anuncio y el video está pausado/no visible,
             // pero antes hacer una verificación ligera de señales fuertes (clases/overlay/API)
             try {
@@ -9914,6 +12060,9 @@ background: var(--ypp-danger);
     let currentHandlingUrl = null; // URL que se está procesando actualmente
 
     const handleNavigation = () => {
+        // Invalidar caché de estado de players al cambiar de página
+        invalidatePlayerStateCache();
+
         if (isAdWatchPlaying) {
             // Si ya hay un listener esperando, no agregar otro
             if (waitingForAdEnd) {
@@ -9949,6 +12098,11 @@ background: var(--ypp-danger);
 
         isHandlingNavigation = true;
         currentHandlingUrl = currentUrl;
+
+        // Limpiar el período de gracia post-anuncio al navegar a una nueva página
+        // Esto evita que el período de gracia interfiera con el procesamiento del nuevo video
+        lastAdEndTime = 0;
+        log('handleNavigation', '🧹 Período de gracia post-anuncio limpiado para nueva navegación');
 
         // Limpiar caché de video info para asegurar datos frescos
         clearVideoInfoCache();
@@ -10368,6 +12522,76 @@ background: var(--ypp-danger);
     }
 
     // ------------------------------------------
+    // MARK: 🛠️ Helper Functions
+    // ------------------------------------------
+
+    /**
+     * Función helper para compatibilidad con código legacy.
+     * Verifica si un video específico está siendo reproducido por el miniplayer.
+     * @param {string} videoId - ID del video a verificar
+     * @returns {boolean} true si el miniplayer está reproduciendo este video
+     * @deprecated Usar PlayerStateManager.isVideoInMiniPlayer() en su lugar
+     */
+    const checkMiniPlayerActive = (videoId) => {
+        return PlayerStateManager.isVideoInMiniPlayer(videoId);
+    };
+
+    /**
+     * Invalida el caché de estado de players cuando cambie la navegación
+     */
+    const invalidatePlayerStateCache = () => {
+        PlayerStateCache.invalidate();
+        log('PlayerStateCache', '🔄 Caché invalidado por cambio de navegación');
+    };
+
+    /**
+     * Función de diagnóstico para verificar el estado actual de players
+     * @returns {Object} Información completa del diagnóstico
+     */
+    const diagnosePlayerState = () => {
+        const state = PlayerStateCache.getCurrentState();
+        const pageType = getYouTubePageType();
+        const coexistenceInfo = PlayerStateManager.getCoexistenceInfo();
+
+        return {
+            pageType,
+            playerState: state,
+            coexistenceInfo,
+            coexistence: PlayerStateCache.getPrimaryPlayer('test').isCoexisting,
+            timestamp: Date.now()
+        };
+    };
+
+    /**
+     * Función de diagnóstico para verificar tipos de video guardados
+     * @returns {Object} Estadísticas de tipos de video
+     */
+    const diagnoseVideoTypes = () => {
+        const storage = Settings._getStorage();
+        const videos = storage?.videos || {};
+        const stats = {
+            total: 0,
+            byType: {},
+            previews: [],
+            regular: []
+        };
+
+        for (const [videoId, data] of Object.entries(videos)) {
+            stats.total++;
+            const type = data.videoType || 'unknown';
+
+            stats.byType[type] = (stats.byType[type] || 0) + 1;
+
+            if (type.startsWith('preview')) {
+                stats.previews.push({ videoId, type, author: data.author, title: data.title });
+            } else {
+                stats.regular.push({ videoId, type, author: data.author, title: data.title });
+            }
+        }
+
+        return stats;
+    };
+
     // MARK: 🚀 Init
     // ------------------------------------------
 
@@ -10526,8 +12750,12 @@ background: var(--ypp-danger);
                     info('initializeGlobal', '⏸️  Script pausado por detección de anuncio - Módulos deben detenerse');
                 } else {
                     info('initializeGlobal', '▶️  Script reanudado - Anuncio finalizado');
-                    // Llamar directamente a handleNavigation cuando se reanuda el script
-                    handleNavigation();
+                    // Esperar a que el DOM se limpie después del anuncio antes de procesar el video
+                    // Esto evita detectar elementos 'fantasma' del anuncio que aún están presentes en el DOM
+                    setTimeout(() => {
+                        info('initializeGlobal', '⏳ Esperando limpieza del DOM post-anuncio...');
+                        handleNavigation();
+                    }, 300); // Esperar 300ms para que el DOM se estabilice
                 }
             });
 


### PR DESCRIPTION
### Fixed

- Fixed inline preview (sticky reflow) saves being misclassified as `video` instead of `preview_*`, which caused the Saved Videos modal `preview` filter to show no results for those entries.
- Fixed `preview_*` saves downgrading already-classified entries: if a video was already saved as `video`/`shorts`/`live`, hovering it again in homepage inline preview no longer changes its `videoType` back to `preview_*`.
- Fixed stale `preview_*` type leaking into dedicated pages: navigating from homepage preview to `/watch` or `/shorts` no longer keeps saving as `preview_*` due to a sticky `currentType`.
- Fixed FreeTube export short detection/counting to use internal types (`shorts`, `preview_shorts`) instead of the non-existent legacy `short` type.

- **Live Badge Hidding Button**: #12
  - Fixed YouTube "En vivo" (Live) badge being forced visible on non-live videos in the Delhi UI by restricting layout rules to the real livehead badge (`.ytp-live-badge-is-livehead`).
  - Fixed script time button styling/regression in Delhi UI (pill shape + overflow) by preventing flex stretching and enforcing consistent pill dimensions.
  - Fixed live/DVR mode detection for UI adjustments by using script-side detection (adds `ypp-is-livestream` when `.ytp-live-badge-is-livehead` is present), avoiding unreliable `.ytp-live`.

- **Fixed & Improved Data Migration System**:
  - Validated and normalized `videoType` during migration: Legacy types ('watch', 'regular', 'normal') are now correctly converted to 'video' or 'shorts'.
  - Fixed issue where data migrated from older versions would default to 'regular' type (invalid), making them invisible in filters.
  - Optimized migration performance by removing redundant `localStorage` reads when data is already in IndexedDB.
  - Implemented prefix stripping for migrated keys to ensure consistency with the new Storage system (keys no longer have double prefixes).
  - Added a "rescue" phase to `migrateToFreeTubeFormat` to recover any legacy data that might have been missed by the initial `StorageAsync` migration.
  - Updated `fromFreeTubeFormat` to correctly normalize imported video types.

- **Fixed Shorts author displaying as "Desconocido" (Unknown) in saved videos modal**:
  - `getVideoAuthor` now uses `extractShortsMetadata().author` as primary source for Shorts (consolidated metapanel search)
  - Added new DOM selectors for YouTube's updated Shorts channel name layout (`ytd-channel-name`, `yt-formatted-string`)
  - `getVideoInfo` now enriches author/authorId from `fetchWatchMeta` when DOM selectors fail for Shorts
  - Expanded Shorts authorId block to also fetch author and authorId from watch page JSON, not just views

- **Fixed infinite loading state in Saved Videos modal on Chrome/Edge**:
  - Solved cross-browser issue with `IDBRequest.result` access timing in `IndexedDBAdapter`.
  - Fixed `StorageAsync.get()` cache-miss fallback using incorrect property path (`entry?.value`).
  - Added missing `await` for `GM_listValues`/`GM_getValue` in migration logic for Tampermonkey.
  - Fixed `ReferenceError: modalVideoTitleById is not defined` preventing video list rendering.
  - Fixed data migration issue where legacy keys retained `YT_PLAYBACK_PLOX_` prefix, causing imported data to be invisible to the new version. Existing corrupted migrations will be auto-corrected.

- **Fixed legacy playlist metadata keys (`YT_PLAYBACK_PLOX_playlist_meta_*`) not being migrated/cleaned up**:
  - Legacy playlist metadata is now merged into new `playlist_meta_*` entries when present.
  - Old `localStorage`/GM keys are removed after migration to prevent leftovers.

- Fixed legacy key cleanup in Violentmonkey leaving `null` entries by using `GM_deleteValue` when available instead of `GM_setValue(key, null)`.
- Fixed Saved Videos modal crash when corrupted storage entries (non-object values) existed by hardening `fixThumbnailsInStorage()`.
- Fixed thumbnail normalization mistakenly treating `ypp_*` migration/meta keys as corrupt entries (they may be numeric) by excluding them from `fixThumbnailsInStorage()`.
- Fixed `ypp_*` migration/meta keys appearing as fake "Unknown" videos in the Saved Videos modal by excluding them from Storage key enumeration.
- Fixed settings not loading correctly in some userscript managers where `GM_getValue` may return an object (not a JSON string), which caused toggles like inline previews to appear unchecked.
- Fixed browser language auto-detection (option B): it now applies only when the user never explicitly set a language, instead of being blocked by merged defaults.
- Fixed `[object Object]` notification during data migration by correcting `showFloatingToast` calls and updating translation helper `t()` to support default fallback text.
- Fixed language selection inconsistency where the modal showed English as selected despite the interface being in Spanish. The issue occurred when `hadLanguageInStorage` was true but the stored language didn't match the browser's detected language. Now `cachedSettings.language` is always updated with the detected language and saved when different.
- Fixed miniplayer/home playlist association by validating playlist anchors against the current video ID before persisting a playlist.
- Fixed Mix (RD...) playlist headers in the saved videos modal to display `Mix - {video title}` when the title is missing.
- Fixed Mix (RD...) playlist headers/titles in the saved videos modal to remain stable by using the Mix seed video (RD{videoId}) title when available.
- Throttled playlist title HTTP fetches when titles are generic to reduce repeated network requests and improve load performance.

- **QuotaExceededError prevention**: 
  - No more automatic data deletions
  - IndexedDB provides orders of magnitude more storage than localStorage
  - Existing user data is preserved during migration
  - Eliminates storage-full errors that caused data loss

- Fixed missing brace in `getProgressColor` that caused a syntax error and prevented the script from loading
- Fixed `TypeError: allKeys is not iterable` during StorageAsync initialization by properly awaiting `Storage.keys()` and `Storage.get()` calls
- Fixed `TypeError: (intermediate value).filter is not a function` in `fixThumbnailsInStorage` by making it async and awaiting Storage operations
- Fixed infinite recursion during StorageAsync initialization by using direct GM_listValues/localStorage access during migration instead of the Storage API
- Fixed `TypeError: can't access property Symbol.iterator, allKeys is undefined` by ensuring allKeys defaults to an empty array when GM_listValues/localStorage are not available

- Fixed all remaining synchronous calls to async Storage API methods:
  - Made `getSavedVideoData`, `updateVideoList`, and `createVideoEntry` functions async
  - Added `await` to all `Storage.get()`, `Storage.set()`, `Storage.keys()`, and `Storage.del()` calls
  - Updated all callers of async functions to properly await them

- Improved miniplayer/shorts coexistence handling
  - Context validation ensures correct type assignment
  - Prevents saving shorts data with miniplayer context and vice versa

- Fixed duplicate `processVideo` calls when changing videos
  - Moved `currentlyProcessingVideos` Set to module level (was being recreated on each call)
  - Added `isProcessingVideoChange` flag to prevent multiple handler triggers
  - Added cleanup of processing state in `finally` block to allow Shorts navigation
  - Progress saving now correctly resumes after video navigation

- Fixed FreeTube export format #15
  - Now uses `type: "video"` for ALL formats (Videos & Shorts), matching standard FreeTube database format 

- Added storage error handling for quota exceeded errors:
  - Storage.set() now returns success/failure status
  - All save functions check for storage errors and propagate them
  - User sees "Storage full" notification when save fails due to quota
  - Prevents false "Progress saved" notifications when storage is full

- Improved Shorts/Preview detection at start
  - Lowered minimum save time from 1s to 0.1s for Shorts/Previews to prevent "invalid_data" errors on load
  - Adjusted handler threshold for previews to 0.5s (was 1s)
  - Fixed 5s delay on initial Short load by optimizing navigation handler
  - Resolved race condition where settings weren't loaded before processing initial video
  - Reduced console log verbosity and removed debugging artifacts
  - Fixed issue where some Watch videos were incorrectly saved as "preview" (missing view counts) due to aggressive inline detection
  - Fixed "N/A" view counts by preventing stale inline preview handlers from persisting on Watch pages

- Fixed critical video detection bug where playing videos were misclassified as previews
  - Reordered detection priorities in `detectContentType()`: miniplayer and watch page now have higher priority than preview detection
  - Added strict validation for preview classification: requires actual preview DOM context, not just `currentType` metadata
  - Videos in watch page or miniplayer are now correctly identified as regular videos and save properly
  - Prevents "preview_disabled_by_settings" error for actively playing videos

- Fixed erroneous playlist assignment by strictly requiring that detected video links originate from within a valid player container (e.g., `#movie_player`), effectively ignoring all external links such as sidebar recommendations.
- Fixed issue where playlists linked in the video description or info panels (#anchored-panel) were incorrectly assigned to the video, specifically blocking this aggressive scraping on standard Watch pages.
- Fixed "zombie" playlist persistence: The script now actively clears old playlist associations from storage if the current video is opened in a clean Watch page (no playlist in URL), preventing the recurrence of incorrect playlist assignments from past sessions.
- Implemented strict "First Level Validation": The script now strictly bypasses all playlist detection logic if the current page is a standard Watch page (`/watch`) and the URL lacks a playlist parameter. This effectively eliminates incorrectly assigned playlists from miniplayers or sidebars.
- Fixed erroneous playlist assignment by enforcing strict player container validation in all detection routines (init & save), completely blocking sidebar Mix recommendations.
- Fixed "Videos" filter missing items captured from Home/Search/Channel contexts.
- Fixed the "Videos" and "Previews" filters in the saved videos list not showing all relevant entries. Improved filtering logic to correctly handle legacy data (missing video type) and variations like embedded videos.
- Fixed critical bug where the script would erroneous assign random playlists found in the DOM (e.g. from side panels or previous sessions) to the current video. Now strictly validates that any scraped playlist link matches the current video ID.
- Fixed issue where new videos opened from Home would incorrectly inherit the playlist ID of the previous video or miniplayer session.
- Fixed issue where Shorts and videos would sometimes not save progress because the `isResuming` flag got stuck in a `true` state during rapid transitions or miniplayer usage.
- Fixed a potential deadlock in video processing by ensuring `currentlyProcessingVideos` set is properly cleaned up when handlers are removed.
- Fixed Shorts and videos not saving due to processing deadlock
  - Added cleanup of `currentlyProcessingVideos` Set in all early return paths in `processVideo()`
  - Prevents videos from being permanently blocked when they return early (disabled types, live streams, previews)
  - Videos can now be reprocessed after configuration changes or page navigation

- Fixed a concurrency issue where a video handler could try to re-process a video that was already being processed by a new navigation event
  - Prevents "video already being processed" deadlock loops in logs
  - Improves stability when switching videos rapidly in playlists or homescreen

- Fixed playlist ID not saving for regular videos (non-Mix playlists) by correctly tracking playlist source in `updateStatus`.
  - Ensured playlist detection from URL and page anchors is correctly prioritized and persisted. #11
- Fixed a critical bug where user-created playlists were displaying IDs instead of Titles in the saved videos modal.
  - Added missing `await` in `updateStatus` ensure playlist metadata is updated during video saves.
  - Removed "Mix-only" restriction when fetching playlist names; now all playlist types are processed.
  - Added request deduplication in `getPlaylistName` to prevent redundant network calls.
  - Implemented a proactive metadata refresher in the modal that fetches missing titles for previously saved videos.
  - Further refined `getPlaylistName` with more robust DOM selectors and better YouTube JSON structure parsing.

### Added

- Added storage usage indicator to the Saved Videos modal using `navigator.storage.estimate()` to show current usage vs quota (includes IndexedDB). #16

- **Miniplayer saving toggle**: New setting to control saving when videos are in miniplayer
  - Default enabled to preserve existing behavior
  - Miniplayer saves are now treated as regular watch videos when enabled

- **Virtual DOM Scrolling for Saved Videos Modal**: Major performance optimization for users with thousands of saved videos
  - New `VirtualScroller` class that renders only visible items (~20-30) instead of all items at once
  - Batch loading of storage data in parallel chunks (50 items per batch) to prevent UI freezing
  - Dynamic stats bar showing total videos count and currently rendered items
  - Loading indicator during initial data fetch
  - Proper cleanup of virtual scroller resources when modal closes
  - Buffer system renders extra items above/below viewport for smooth scrolling
  - CSS updates for fixed-height video items (120px) to enable precise positioning

- **IndexedDB Storage Backend**: New storage layer to eliminate quota errors #16
  - Primary backend: IndexedDB with significantly larger storage capacity
  - In-memory cache for synchronous access and performance
  - Automatic migration from localStorage/GM on first run (preserves existing data)
  - Fallback support for environments without IndexedDB
  - Migration flag (`idb_migrated`) prevents repeated migrations
  - Diagnostic API (`Storage.getBackendInfo()`) for troubleshooting

- **VideoTypeHandler module**: Strategy pattern for video type handling
  - Centralizes configuration validation (saveShorts, saveRegularVideos, etc.)
  - Provides context validation to prevent miniplayer/shorts data contamination
  - Supports VIDEO, SHORTS, PREVIEW, and LIVE content types
  
- **VideoInfoFacade module**: Unified interface for video metadata extraction
  - Automatic context detection (shorts, miniplayer, watch, preview)
  - Context-aware extraction strategies to prevent data contamination
  - Consistent return structure with title, author, duration, thumbnail, etc.

- Added option to remove playlist association from a saved video in the list view #13
  - Allows decoupling a video from a playlist while keeping individual progress
  - New button with folder/unlink icon in the video entry card

- New translations to all language sections in translations.json

### Changed

- **Storage API**: Now fully asynchronous to support IndexedDB
  - `Storage.set/get/del/keys()` now return Promises
  - Legacy synchronous calls updated throughout the codebase
  - Internal caching maintains responsiveness for frequent reads
  - Import/export and progress saving now use IndexedDB

- Refactored `saveVideoDataByType()` to delegate to VideoTypeHandler
  - Eliminated duplicated validation logic

- Updated `isAdBlockedFor` calls to use 'video' instead of 'watch' for better semantic consistency.
- Youtube Helper API to version 0.9.4